### PR TITLE
Bootstrap SpriteKit project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+DerivedData/
+TiltArena.xcodeproj/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Tilt Arena
+
+Tilt Arena is an iPhone-only SpriteKit arcade survival game.
+
+## Project Generation
+
+This repository uses XcodeGen to generate the Xcode project from `project.yml`.
+
+```sh
+xcodegen generate
+```
+
+## Build
+
+```sh
+xcodebuild -project TiltArena.xcodeproj \
+  -scheme TiltArena \
+  -configuration Debug \
+  -sdk iphonesimulator \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath build/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```

--- a/TiltArena/App/AppDelegate.swift
+++ b/TiltArena/App/AppDelegate.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = GameViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+        return true
+    }
+}

--- a/TiltArena/App/GameViewController.swift
+++ b/TiltArena/App/GameViewController.swift
@@ -1,0 +1,59 @@
+import SpriteKit
+import UIKit
+
+final class GameViewController: UIViewController {
+    private var hasPresentedScene = false
+
+    override func loadView() {
+        view = SKView(frame: .zero)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureSpriteView()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        guard let spriteView = view as? SKView else {
+            return
+        }
+
+        if hasPresentedScene {
+            spriteView.scene?.size = spriteView.bounds.size
+        } else {
+            let scene = ArenaScene(size: spriteView.bounds.size)
+            scene.scaleMode = .resizeFill
+            spriteView.presentScene(scene)
+            hasPresentedScene = true
+        }
+    }
+
+    override var prefersStatusBarHidden: Bool {
+        true
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .portrait
+    }
+
+    override var prefersHomeIndicatorAutoHidden: Bool {
+        true
+    }
+
+    private func configureSpriteView() {
+        guard let spriteView = view as? SKView else {
+            return
+        }
+
+        spriteView.ignoresSiblingOrder = true
+        spriteView.shouldCullNonVisibleNodes = true
+        spriteView.preferredFramesPerSecond = 120
+
+        #if DEBUG
+        spriteView.showsFPS = true
+        spriteView.showsNodeCount = true
+        #endif
+    }
+}

--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -1,0 +1,30 @@
+import SpriteKit
+
+final class ArenaScene: SKScene {
+    private let theme = ArenaTheme.darkTacticalRadar
+    private var arenaRoot = SKNode()
+
+    override init(size: CGSize) {
+        super.init(size: size)
+        anchorPoint = .zero
+        backgroundColor = theme.backgroundColor
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("ArenaScene does not support storyboard initialization.")
+    }
+
+    override func didMove(to view: SKView) {
+        rebuildArena()
+    }
+
+    override func didChangeSize(_ oldSize: CGSize) {
+        rebuildArena()
+    }
+
+    private func rebuildArena() {
+        arenaRoot.removeFromParent()
+        arenaRoot = ArenaThemeRenderer(theme: theme).makeArenaBackground(size: size)
+        addChild(arenaRoot)
+    }
+}

--- a/TiltArena/Game/Theme/ArenaTheme.swift
+++ b/TiltArena/Game/Theme/ArenaTheme.swift
@@ -1,0 +1,37 @@
+import SpriteKit
+
+struct ArenaTheme {
+    let backgroundColor: SKColor
+    let gridColor: SKColor
+    let borderColor: SKColor
+    let playerColor: SKColor
+    let playerAccentColor: SKColor
+    let enemyColor: SKColor
+    let pickupAmber: SKColor
+    let pickupBlue: SKColor
+    let pickupViolet: SKColor
+
+    static let darkTacticalRadar = ArenaTheme(
+        backgroundColor: SKColor(red: 0.03, green: 0.07, blue: 0.11, alpha: 1.00),
+        gridColor: SKColor(red: 0.12, green: 0.35, blue: 0.48, alpha: 0.28),
+        borderColor: SKColor(red: 0.37, green: 0.66, blue: 0.78, alpha: 0.70),
+        playerColor: SKColor(red: 0.97, green: 0.98, blue: 1.00, alpha: 1.00),
+        playerAccentColor: SKColor(red: 0.09, green: 0.78, blue: 1.00, alpha: 1.00),
+        enemyColor: SKColor(red: 1.00, green: 0.16, blue: 0.16, alpha: 1.00),
+        pickupAmber: SKColor(red: 1.00, green: 0.75, blue: 0.20, alpha: 1.00),
+        pickupBlue: SKColor(red: 0.16, green: 0.78, blue: 1.00, alpha: 1.00),
+        pickupViolet: SKColor(red: 0.55, green: 0.36, blue: 1.00, alpha: 1.00)
+    )
+
+    static let whitePrecisionBoard = ArenaTheme(
+        backgroundColor: SKColor(red: 0.96, green: 0.94, blue: 0.89, alpha: 1.00),
+        gridColor: SKColor(red: 0.68, green: 0.70, blue: 0.72, alpha: 0.28),
+        borderColor: SKColor(red: 0.11, green: 0.12, blue: 0.13, alpha: 0.70),
+        playerColor: SKColor(red: 0.10, green: 0.11, blue: 0.12, alpha: 1.00),
+        playerAccentColor: SKColor(red: 0.09, green: 0.78, blue: 1.00, alpha: 1.00),
+        enemyColor: SKColor(red: 1.00, green: 0.16, blue: 0.16, alpha: 1.00),
+        pickupAmber: SKColor(red: 1.00, green: 0.75, blue: 0.20, alpha: 1.00),
+        pickupBlue: SKColor(red: 0.16, green: 0.78, blue: 1.00, alpha: 1.00),
+        pickupViolet: SKColor(red: 0.55, green: 0.36, blue: 1.00, alpha: 1.00)
+    )
+}

--- a/TiltArena/Game/Theme/ArenaThemeRenderer.swift
+++ b/TiltArena/Game/Theme/ArenaThemeRenderer.swift
@@ -1,0 +1,90 @@
+import SpriteKit
+
+@MainActor
+final class ArenaThemeRenderer {
+    private let theme: ArenaTheme
+
+    init(theme: ArenaTheme) {
+        self.theme = theme
+    }
+
+    func makeArenaBackground(size: CGSize) -> SKNode {
+        let root = SKNode()
+        root.zPosition = -100
+
+        root.addChild(makeBackdrop(size: size))
+        root.addChild(makeGrid(size: size))
+        root.addChild(makeRadarRings(size: size))
+        root.addChild(makeBorder(size: size))
+
+        return root
+    }
+
+    private func makeBackdrop(size: CGSize) -> SKNode {
+        let node = SKShapeNode(rectOf: size)
+        node.position = CGPoint(x: size.width / 2, y: size.height / 2)
+        node.fillColor = theme.backgroundColor
+        node.strokeColor = .clear
+        return node
+    }
+
+    private func makeGrid(size: CGSize) -> SKNode {
+        let path = CGMutablePath()
+        let spacing: CGFloat = 48
+
+        var x: CGFloat = 0
+        while x <= size.width {
+            path.move(to: CGPoint(x: x, y: 0))
+            path.addLine(to: CGPoint(x: x, y: size.height))
+            x += spacing
+        }
+
+        var y: CGFloat = 0
+        while y <= size.height {
+            path.move(to: CGPoint(x: 0, y: y))
+            path.addLine(to: CGPoint(x: size.width, y: y))
+            y += spacing
+        }
+
+        let node = SKShapeNode(path: path)
+        node.strokeColor = theme.gridColor
+        node.lineWidth = 0.6
+        node.lineCap = .square
+        return node
+    }
+
+    private func makeRadarRings(size: CGSize) -> SKNode {
+        let root = SKNode()
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        let maxRadius = min(size.width, size.height) * 0.48
+
+        for index in 1...4 {
+            let radius = maxRadius * CGFloat(index) / 4
+            let ring = SKShapeNode(circleOfRadius: radius)
+            ring.position = center
+            ring.strokeColor = theme.gridColor.withAlphaComponent(0.55)
+            ring.lineWidth = 0.8
+            ring.fillColor = .clear
+            root.addChild(ring)
+        }
+
+        return root
+    }
+
+    private func makeBorder(size: CGSize) -> SKNode {
+        let inset: CGFloat = 14
+        let rect = CGRect(
+            x: inset,
+            y: inset,
+            width: max(0, size.width - inset * 2),
+            height: max(0, size.height - inset * 2)
+        )
+
+        let border = SKShapeNode(rect: rect, cornerRadius: 6)
+        border.strokeColor = theme.borderColor
+        border.lineWidth = 1.5
+        border.fillColor = .clear
+
+        return border
+    }
+}

--- a/TiltArena/Resources/Info.plist
+++ b/TiltArena/Resources/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>Black</string>
+	</dict>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UIStatusBarHidden</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,45 @@
+name: TiltArena
+
+options:
+  bundleIdPrefix: com.xlc
+  deploymentTarget:
+    iOS: "18.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+    TARGETED_DEVICE_FAMILY: "1"
+
+targets:
+  TiltArena:
+    type: application
+    platform: iOS
+    deploymentTarget: "18.0"
+    sources:
+      - path: TiltArena
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.xlc.TiltArena
+        INFOPLIST_FILE: TiltArena/Resources/Info.plist
+        SUPPORTS_MACCATALYST: false
+        SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: false
+        TARGETED_DEVICE_FAMILY: "1"
+
+schemes:
+  TiltArena:
+    build:
+      targets:
+        TiltArena: all
+    run:
+      config: Debug
+    test:
+      config: Debug
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release


### PR DESCRIPTION
## Summary
- Add XcodeGen configuration for an iPhone-only SpriteKit app.
- Add a UIKit app shell that presents a programmatic SpriteKit arena scene.
- Add initial dark and white arena theme scaffolding without gameplay systems.

## Validation
- `xcodegen generate`
- `plutil -lint TiltArena/Resources/Info.plist`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`

Closes #2