### PR TITLE
Implement tilt input and player movement

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -2,7 +2,13 @@ import SpriteKit
 
 final class ArenaScene: SKScene {
     private let theme = ArenaTheme.darkTacticalRadar
+    private let tiltSettingsStore = TiltSettingsStore()
     private var arenaRoot = SKNode()
+    private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
+    private var movementController = PlayerMovementController()
+    private var playerNode: PlayerCraftNode?
+    private var playerTrailNode: PlayerTrailNode?
+    private var lastUpdateTime: TimeInterval?
 
     override init(size: CGSize) {
         super.init(size: size)
@@ -16,15 +22,88 @@ final class ArenaScene: SKScene {
 
     override func didMove(to view: SKView) {
         rebuildArena()
+        placePlayer(resetPosition: true)
+        tiltInputController.start()
     }
 
     override func didChangeSize(_ oldSize: CGSize) {
         rebuildArena()
+        placePlayer(resetPosition: playerNode == nil)
+    }
+
+    override func willMove(from view: SKView) {
+        tiltInputController.stop()
+        lastUpdateTime = nil
+    }
+
+    override func update(_ currentTime: TimeInterval) {
+        defer {
+            lastUpdateTime = currentTime
+        }
+
+        guard let lastUpdateTime else {
+            return
+        }
+
+        let deltaTime = min(1.0 / 15.0, max(0, currentTime - lastUpdateTime))
+        guard deltaTime > 0 else {
+            return
+        }
+
+        let input = tiltInputController.update(deltaTime: deltaTime)
+        let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
+        applyPlayerState(state, resetTrail: false)
+    }
+
+    func recalibrateTiltControls() {
+        tiltInputController.recalibrateToCurrentAttitude()
     }
 
     private func rebuildArena() {
         arenaRoot.removeFromParent()
         arenaRoot = ArenaThemeRenderer(theme: theme).makeArenaBackground(size: size)
         addChild(arenaRoot)
+    }
+
+    private func placePlayer(resetPosition: Bool) {
+        ensurePlayerNodes()
+
+        let state = resetPosition
+            ? movementController.reset(in: size)
+            : movementController.clampToArena(size)
+
+        applyPlayerState(state, resetTrail: true)
+    }
+
+    private func ensurePlayerNodes() {
+        if playerTrailNode == nil {
+            let trailNode = PlayerTrailNode(theme: theme)
+            addChild(trailNode)
+            playerTrailNode = trailNode
+        }
+
+        if playerNode == nil {
+            let craftNode = PlayerCraftNode(
+                theme: theme,
+                visualRadius: movementController.configuration.visualRadius
+            )
+            addChild(craftNode)
+            playerNode = craftNode
+        }
+    }
+
+    private func applyPlayerState(_ state: PlayerMovementState, resetTrail: Bool) {
+        playerNode?.apply(state: state)
+
+        let speedFraction = state.velocity.length / max(
+            1,
+            movementController.configuration.maximumSpeed(in: size)
+        )
+
+        if resetTrail {
+            playerTrailNode?.reset(to: state.position)
+        } else {
+            playerTrailNode?.record(position: state.position, speedFraction: speedFraction)
+        }
     }
 }

--- a/TiltArena/Game/Input/TiltCalibration.swift
+++ b/TiltArena/Game/Input/TiltCalibration.swift
@@ -1,0 +1,58 @@
+import CoreGraphics
+import Foundation
+
+enum TiltCalibrationPreset: String, CaseIterable, Codable {
+    case standard
+    case flatTable
+    case reclined
+    case custom
+
+    var defaultNeutralGravity: TiltGravityVector {
+        switch self {
+        case .standard:
+            TiltGravityVector(x: 0, y: -0.35)
+        case .flatTable:
+            TiltGravityVector(x: 0, y: 0)
+        case .reclined:
+            TiltGravityVector(x: 0, y: -0.65)
+        case .custom:
+            TiltGravityVector(x: 0, y: -0.35)
+        }
+    }
+}
+
+struct TiltGravityVector: Codable, Equatable {
+    var x: Double
+    var y: Double
+}
+
+struct TiltCalibration: Codable, Equatable {
+    var preset: TiltCalibrationPreset
+    var neutralGravity: TiltGravityVector
+
+    static func defaultCalibration(for preset: TiltCalibrationPreset) -> TiltCalibration {
+        TiltCalibration(preset: preset, neutralGravity: preset.defaultNeutralGravity)
+    }
+
+    static func custom(neutralGravity: TiltGravityVector) -> TiltCalibration {
+        TiltCalibration(preset: .custom, neutralGravity: neutralGravity)
+    }
+}
+
+struct TiltControlSettings: Codable, Equatable {
+    static let defaultSensitivity = 1.0
+    static let minimumSensitivity = 0.6
+    static let maximumSensitivity = 1.4
+
+    var calibration: TiltCalibration
+    var sensitivity: Double
+
+    static let defaults = TiltControlSettings(
+        calibration: .defaultCalibration(for: .standard),
+        sensitivity: defaultSensitivity
+    )
+
+    var clampedSensitivity: Double {
+        min(Self.maximumSensitivity, max(Self.minimumSensitivity, sensitivity))
+    }
+}

--- a/TiltArena/Game/Input/TiltInputController.swift
+++ b/TiltArena/Game/Input/TiltInputController.swift
@@ -1,0 +1,63 @@
+import CoreMotion
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class TiltInputController {
+    private let motionManager: CMMotionManager
+    private let settingsStore: TiltSettingsStore
+    private var signalProcessor = TiltSignalProcessor()
+
+    init(
+        motionManager: CMMotionManager = CMMotionManager(),
+        settingsStore: TiltSettingsStore = TiltSettingsStore()
+    ) {
+        self.motionManager = motionManager
+        self.settingsStore = settingsStore
+        motionManager.deviceMotionUpdateInterval = 1.0 / 120.0
+    }
+
+    func start() {
+        guard motionManager.isDeviceMotionAvailable, !motionManager.isDeviceMotionActive else {
+            return
+        }
+
+        motionManager.startDeviceMotionUpdates()
+    }
+
+    func stop() {
+        motionManager.stopDeviceMotionUpdates()
+        signalProcessor.reset()
+    }
+
+    func recalibrateToCurrentAttitude() {
+        guard let gravity = currentGravityVector() else {
+            return
+        }
+
+        settingsStore.recalibrate(using: gravity)
+        signalProcessor.reset()
+    }
+
+    func update(deltaTime: TimeInterval) -> CGVector {
+        guard let gravity = currentGravityVector() else {
+            return .zero
+        }
+
+        settingsStore.ensureInitialCalibration(using: gravity)
+
+        return signalProcessor.inputVector(
+            gravity: gravity,
+            settings: settingsStore.settings,
+            deltaTime: deltaTime
+        )
+    }
+
+    private func currentGravityVector() -> TiltGravityVector? {
+        guard let gravity = motionManager.deviceMotion?.gravity else {
+            return nil
+        }
+
+        return TiltGravityVector(x: gravity.x, y: gravity.y)
+    }
+}

--- a/TiltArena/Game/Input/TiltSettingsStore.swift
+++ b/TiltArena/Game/Input/TiltSettingsStore.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+final class TiltSettingsStore {
+    private let defaults: UserDefaults
+    private let settingsKey = "tiltArena.tiltControlSettings"
+    private let initialCalibrationKey = "tiltArena.hasCapturedInitialTiltCalibration"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var settings: TiltControlSettings {
+        get {
+            guard
+                let data = defaults.data(forKey: settingsKey),
+                let settings = try? JSONDecoder().decode(TiltControlSettings.self, from: data)
+            else {
+                return .defaults
+            }
+
+            return settings
+        }
+        set {
+            guard let data = try? JSONEncoder().encode(newValue) else {
+                return
+            }
+
+            defaults.set(data, forKey: settingsKey)
+        }
+    }
+
+    var needsInitialCalibration: Bool {
+        !defaults.bool(forKey: initialCalibrationKey)
+    }
+
+    func ensureInitialCalibration(using gravity: TiltGravityVector) {
+        guard needsInitialCalibration else {
+            return
+        }
+
+        recalibrate(using: gravity)
+        defaults.set(true, forKey: initialCalibrationKey)
+    }
+
+    func recalibrate(using gravity: TiltGravityVector) {
+        var currentSettings = settings
+        currentSettings.calibration = .custom(neutralGravity: gravity)
+        settings = currentSettings
+    }
+
+    func selectPreset(_ preset: TiltCalibrationPreset) {
+        var currentSettings = settings
+        currentSettings.calibration = .defaultCalibration(for: preset)
+        settings = currentSettings
+        defaults.set(true, forKey: initialCalibrationKey)
+    }
+
+    func updateSensitivity(_ sensitivity: Double) {
+        var currentSettings = settings
+        currentSettings.sensitivity = min(
+            TiltControlSettings.maximumSensitivity,
+            max(TiltControlSettings.minimumSensitivity, sensitivity)
+        )
+        settings = currentSettings
+    }
+}

--- a/TiltArena/Game/Input/TiltSignalProcessor.swift
+++ b/TiltArena/Game/Input/TiltSignalProcessor.swift
@@ -1,0 +1,102 @@
+import CoreGraphics
+import Foundation
+
+struct TiltSignalConfiguration: Equatable {
+    var deadZoneDegrees: Double = 3
+    var maximumTiltDegrees: Double = 25
+    var smoothingDuration: TimeInterval = 0.11
+
+    var deadZoneMagnitude: Double {
+        sin(deadZoneDegrees * .pi / 180)
+    }
+
+    var maximumTiltMagnitude: Double {
+        sin(maximumTiltDegrees * .pi / 180)
+    }
+}
+
+struct TiltSignalProcessor {
+    var configuration = TiltSignalConfiguration()
+    private(set) var smoothedInput = CGVector.zero
+
+    mutating func reset() {
+        smoothedInput = .zero
+    }
+
+    mutating func inputVector(
+        gravity: TiltGravityVector,
+        settings: TiltControlSettings,
+        deltaTime: TimeInterval
+    ) -> CGVector {
+        let target = normalizedInputVector(gravity: gravity, settings: settings)
+        let smoothing = smoothingAlpha(deltaTime: deltaTime)
+
+        smoothedInput = CGVector(
+            dx: smoothedInput.dx + (target.dx - smoothedInput.dx) * smoothing,
+            dy: smoothedInput.dy + (target.dy - smoothedInput.dy) * smoothing
+        )
+
+        if smoothedInput.length < 0.001 {
+            smoothedInput = .zero
+        }
+
+        return smoothedInput.clamped(toMaximumLength: 1)
+    }
+
+    func normalizedInputVector(gravity: TiltGravityVector, settings: TiltControlSettings) -> CGVector {
+        let neutral = settings.calibration.neutralGravity
+        let rawInput = CGVector(
+            dx: gravity.x - neutral.x,
+            dy: -(gravity.y - neutral.y)
+        )
+        let magnitude = rawInput.length
+        let deadZone = configuration.deadZoneMagnitude
+
+        guard magnitude > deadZone else {
+            return .zero
+        }
+
+        let activeRange = max(0.001, configuration.maximumTiltMagnitude - deadZone)
+        let normalizedMagnitude = min(1, (magnitude - deadZone) / activeRange)
+        let scaledMagnitude = min(1, normalizedMagnitude * settings.clampedSensitivity)
+
+        let direction = rawInput.normalized
+
+        return CGVector(
+            dx: direction.dx * CGFloat(scaledMagnitude),
+            dy: direction.dy * CGFloat(scaledMagnitude)
+        )
+    }
+
+    private func smoothingAlpha(deltaTime: TimeInterval) -> CGFloat {
+        guard deltaTime > 0 else {
+            return 0
+        }
+
+        let duration = max(0.001, configuration.smoothingDuration)
+        return CGFloat(1 - exp(-deltaTime / duration))
+    }
+}
+
+extension CGVector {
+    var length: CGFloat {
+        sqrt(dx * dx + dy * dy)
+    }
+
+    var normalized: CGVector {
+        guard length > 0 else {
+            return .zero
+        }
+
+        return CGVector(dx: dx / length, dy: dy / length)
+    }
+
+    func clamped(toMaximumLength maximumLength: CGFloat) -> CGVector {
+        guard length > maximumLength else {
+            return self
+        }
+
+        let scale = maximumLength / length
+        return CGVector(dx: dx * scale, dy: dy * scale)
+    }
+}

--- a/TiltArena/Game/Player/PlayerCraftNode.swift
+++ b/TiltArena/Game/Player/PlayerCraftNode.swift
@@ -1,0 +1,52 @@
+import SpriteKit
+
+@MainActor
+final class PlayerCraftNode: SKNode {
+    private let bodyNode: SKShapeNode
+    private let coreNode: SKShapeNode
+
+    init(theme: ArenaTheme, visualRadius: CGFloat) {
+        bodyNode = SKShapeNode(path: Self.makeBodyPath(radius: visualRadius))
+        coreNode = SKShapeNode(circleOfRadius: visualRadius * 0.2)
+        super.init()
+
+        zPosition = 20
+
+        bodyNode.fillColor = theme.playerColor
+        bodyNode.strokeColor = theme.playerAccentColor
+        bodyNode.lineWidth = 1.4
+        bodyNode.lineJoin = .round
+        bodyNode.glowWidth = 1.5
+        addChild(bodyNode)
+
+        coreNode.fillColor = theme.playerAccentColor
+        coreNode.strokeColor = .clear
+        coreNode.position = CGPoint(x: 0, y: -visualRadius * 0.03)
+        coreNode.glowWidth = 3
+        addChild(coreNode)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("PlayerCraftNode does not support storyboard initialization.")
+    }
+
+    func apply(state: PlayerMovementState) {
+        position = state.position
+
+        guard state.velocity.length > 2 else {
+            return
+        }
+
+        zRotation = atan2(state.velocity.dy, state.velocity.dx) - (.pi / 2)
+    }
+
+    private static func makeBodyPath(radius: CGFloat) -> CGPath {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: radius))
+        path.addLine(to: CGPoint(x: -radius * 0.72, y: -radius * 0.68))
+        path.addLine(to: CGPoint(x: 0, y: -radius * 0.34))
+        path.addLine(to: CGPoint(x: radius * 0.72, y: -radius * 0.68))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/TiltArena/Game/Player/PlayerMovementController.swift
+++ b/TiltArena/Game/Player/PlayerMovementController.swift
@@ -1,0 +1,80 @@
+import CoreGraphics
+import Foundation
+
+struct PlayerMovementConfiguration: Equatable {
+    var visualRadius: CGFloat = 14
+    var borderInset: CGFloat = 18
+    var arenaCrossingDuration: TimeInterval = 2.5
+
+    func maximumSpeed(in arenaSize: CGSize) -> CGFloat {
+        playableRect(in: arenaSize).width / CGFloat(max(0.001, arenaCrossingDuration))
+    }
+
+    func playableRect(in arenaSize: CGSize) -> CGRect {
+        let inset = borderInset + visualRadius
+        let width = max(0, arenaSize.width - inset * 2)
+        let height = max(0, arenaSize.height - inset * 2)
+
+        return CGRect(x: inset, y: inset, width: width, height: height)
+    }
+}
+
+struct PlayerMovementState: Equatable {
+    var position: CGPoint
+    var velocity: CGVector
+}
+
+struct PlayerMovementController {
+    var configuration = PlayerMovementConfiguration()
+    private(set) var state = PlayerMovementState(position: .zero, velocity: .zero)
+
+    mutating func reset(in arenaSize: CGSize) -> PlayerMovementState {
+        let rect = configuration.playableRect(in: arenaSize)
+        state = PlayerMovementState(
+            position: CGPoint(x: rect.midX, y: rect.midY),
+            velocity: .zero
+        )
+        return state
+    }
+
+    mutating func update(input: CGVector, deltaTime: TimeInterval, arenaSize: CGSize) -> PlayerMovementState {
+        let clampedInput = input.clamped(toMaximumLength: 1)
+        let maximumSpeed = configuration.maximumSpeed(in: arenaSize)
+        let velocity = CGVector(
+            dx: clampedInput.dx * maximumSpeed,
+            dy: clampedInput.dy * maximumSpeed
+        )
+        let proposedPosition = CGPoint(
+            x: state.position.x + velocity.dx * CGFloat(max(0, deltaTime)),
+            y: state.position.y + velocity.dy * CGFloat(max(0, deltaTime))
+        )
+
+        state = PlayerMovementState(
+            position: clampedPosition(proposedPosition, in: arenaSize),
+            velocity: velocity
+        )
+
+        return state
+    }
+
+    mutating func clampToArena(_ arenaSize: CGSize) -> PlayerMovementState {
+        state = PlayerMovementState(
+            position: clampedPosition(state.position, in: arenaSize),
+            velocity: state.velocity
+        )
+        return state
+    }
+
+    func clampedPosition(_ position: CGPoint, in arenaSize: CGSize) -> CGPoint {
+        let rect = configuration.playableRect(in: arenaSize)
+
+        guard rect.width > 0, rect.height > 0 else {
+            return CGPoint(x: arenaSize.width / 2, y: arenaSize.height / 2)
+        }
+
+        return CGPoint(
+            x: min(rect.maxX, max(rect.minX, position.x)),
+            y: min(rect.maxY, max(rect.minY, position.y))
+        )
+    }
+}

--- a/TiltArena/Game/Player/PlayerTrailNode.swift
+++ b/TiltArena/Game/Player/PlayerTrailNode.swift
@@ -1,0 +1,58 @@
+import SpriteKit
+
+@MainActor
+final class PlayerTrailNode: SKShapeNode {
+    private var points: [CGPoint] = []
+    private let maximumPoints = 18
+
+    init(theme: ArenaTheme) {
+        super.init()
+
+        zPosition = 8
+        strokeColor = theme.playerAccentColor.withAlphaComponent(0.65)
+        fillColor = .clear
+        lineCap = .round
+        lineJoin = .round
+        lineWidth = 3
+        glowWidth = 2
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("PlayerTrailNode does not support storyboard initialization.")
+    }
+
+    func reset(to position: CGPoint) {
+        points = [position]
+        path = nil
+    }
+
+    func record(position: CGPoint, speedFraction: CGFloat) {
+        if let lastPoint = points.last, hypot(position.x - lastPoint.x, position.y - lastPoint.y) < 1 {
+            return
+        }
+
+        points.append(position)
+
+        if points.count > maximumPoints {
+            points.removeFirst(points.count - maximumPoints)
+        }
+
+        lineWidth = 2 + min(1, max(0, speedFraction)) * 2
+        path = makePath()
+    }
+
+    private func makePath() -> CGPath? {
+        guard let firstPoint = points.first, points.count > 1 else {
+            return nil
+        }
+
+        let path = CGMutablePath()
+        path.move(to: firstPoint)
+
+        for point in points.dropFirst() {
+            path.addLine(to: point)
+        }
+
+        return path
+    }
+}

--- a/TiltArena/Resources/Info.plist
+++ b/TiltArena/Resources/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMotionUsageDescription</key>
+	<string>Tilt Arena uses device motion to steer the player craft.</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/TiltArenaTests/PlayerMovementControllerTests.swift
+++ b/TiltArenaTests/PlayerMovementControllerTests.swift
@@ -1,0 +1,37 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class PlayerMovementControllerTests: XCTestCase {
+    func testResetPlacesPlayerAtPlayableCenter() {
+        var controller = PlayerMovementController()
+        let state = controller.reset(in: CGSize(width: 390, height: 844))
+
+        XCTAssertEqual(state.position.x, 195, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, 422, accuracy: 0.0001)
+    }
+
+    func testFullTiltCrossesPlayableWidthAtConfiguredSpeed() {
+        let arenaSize = CGSize(width: 390, height: 844)
+        var controller = PlayerMovementController()
+        _ = controller.reset(in: arenaSize)
+
+        let state = controller.update(input: CGVector(dx: 1, dy: 0), deltaTime: 1, arenaSize: arenaSize)
+        let expectedSpeed = controller.configuration.playableRect(in: arenaSize).width / 2.5
+
+        XCTAssertEqual(state.velocity.dx, expectedSpeed, accuracy: 0.0001)
+        XCTAssertEqual(state.velocity.dy, 0, accuracy: 0.0001)
+    }
+
+    func testMovementClampsToPlayableBounds() {
+        let arenaSize = CGSize(width: 390, height: 844)
+        var controller = PlayerMovementController()
+        _ = controller.reset(in: arenaSize)
+
+        let state = controller.update(input: CGVector(dx: 20, dy: 20), deltaTime: 10, arenaSize: arenaSize)
+        let playableRect = controller.configuration.playableRect(in: arenaSize)
+
+        XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, playableRect.maxY, accuracy: 0.0001)
+    }
+}

--- a/TiltArenaTests/TiltSettingsStoreTests.swift
+++ b/TiltArenaTests/TiltSettingsStoreTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import TiltArena
+
+final class TiltSettingsStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "TiltSettingsStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testInitialCalibrationCapturesOnlyOnce() {
+        let store = TiltSettingsStore(defaults: defaults)
+
+        store.ensureInitialCalibration(using: TiltGravityVector(x: 0.2, y: -0.4))
+        store.ensureInitialCalibration(using: TiltGravityVector(x: -0.3, y: 0.1))
+
+        XCTAssertFalse(store.needsInitialCalibration)
+        XCTAssertEqual(store.settings.calibration.preset, .custom)
+        XCTAssertEqual(store.settings.calibration.neutralGravity, TiltGravityVector(x: 0.2, y: -0.4))
+    }
+
+    func testSensitivityUpdatesArePersistedAndClamped() {
+        let store = TiltSettingsStore(defaults: defaults)
+
+        store.updateSensitivity(10)
+
+        XCTAssertEqual(store.settings.sensitivity, TiltControlSettings.maximumSensitivity)
+
+        store.updateSensitivity(-10)
+
+        XCTAssertEqual(store.settings.sensitivity, TiltControlSettings.minimumSensitivity)
+    }
+
+    func testPresetSelectionMarksCalibrationComplete() {
+        let store = TiltSettingsStore(defaults: defaults)
+
+        store.selectPreset(.flatTable)
+
+        XCTAssertFalse(store.needsInitialCalibration)
+        XCTAssertEqual(store.settings.calibration, .defaultCalibration(for: .flatTable))
+    }
+}

--- a/TiltArenaTests/TiltSignalProcessorTests.swift
+++ b/TiltArenaTests/TiltSignalProcessorTests.swift
@@ -1,0 +1,78 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class TiltSignalProcessorTests: XCTestCase {
+    func testDeadZoneSuppressesTinyTilt() {
+        var processor = TiltSignalProcessor(
+            configuration: TiltSignalConfiguration(deadZoneDegrees: 3, maximumTiltDegrees: 25, smoothingDuration: 0.11)
+        )
+
+        let input = processor.inputVector(
+            gravity: TiltGravityVector(x: 0.01, y: -0.35),
+            settings: .defaults,
+            deltaTime: 1
+        )
+
+        XCTAssertEqual(input.dx, 0, accuracy: 0.0001)
+        XCTAssertEqual(input.dy, 0, accuracy: 0.0001)
+    }
+
+    func testCalibrationOffsetCreatesRelativeNeutral() {
+        var processor = TiltSignalProcessor()
+        let settings = TiltControlSettings(
+            calibration: .custom(neutralGravity: TiltGravityVector(x: 0.2, y: -0.4)),
+            sensitivity: 1
+        )
+
+        let input = processor.inputVector(
+            gravity: TiltGravityVector(x: 0.35, y: -0.4),
+            settings: settings,
+            deltaTime: 1
+        )
+
+        XCTAssertGreaterThan(input.dx, 0)
+        XCTAssertEqual(input.dy, 0, accuracy: 0.0001)
+    }
+
+    func testSensitivityScalesAndClampsInput() {
+        var slowProcessor = TiltSignalProcessor()
+        var fastProcessor = TiltSignalProcessor()
+        let gravity = TiltGravityVector(x: 0.2, y: -0.35)
+
+        let slowInput = slowProcessor.inputVector(
+            gravity: gravity,
+            settings: TiltControlSettings(calibration: .defaultCalibration(for: .standard), sensitivity: 0.6),
+            deltaTime: 1
+        )
+        let fastInput = fastProcessor.inputVector(
+            gravity: gravity,
+            settings: TiltControlSettings(calibration: .defaultCalibration(for: .standard), sensitivity: 1.4),
+            deltaTime: 1
+        )
+
+        XCTAssertLessThan(slowInput.length, fastInput.length)
+        XCTAssertLessThanOrEqual(fastInput.length, 1.0001)
+    }
+
+    func testSmoothingMovesTowardTargetOverTime() {
+        var processor = TiltSignalProcessor(
+            configuration: TiltSignalConfiguration(deadZoneDegrees: 3, maximumTiltDegrees: 25, smoothingDuration: 0.2)
+        )
+        let settings = TiltControlSettings(calibration: .defaultCalibration(for: .standard), sensitivity: 1)
+
+        let firstInput = processor.inputVector(
+            gravity: TiltGravityVector(x: 0.3, y: -0.35),
+            settings: settings,
+            deltaTime: 1.0 / 60.0
+        )
+        let laterInput = processor.inputVector(
+            gravity: TiltGravityVector(x: 0.3, y: -0.35),
+            settings: settings,
+            deltaTime: 1.0 / 60.0
+        )
+
+        XCTAssertGreaterThan(laterInput.length, firstInput.length)
+        XCTAssertLessThan(firstInput.length, 1)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -28,6 +28,19 @@ targets:
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: false
         TARGETED_DEVICE_FAMILY: "1"
 
+  TiltArenaTests:
+    type: bundle.unit-test
+    platform: iOS
+    deploymentTarget: "18.0"
+    sources:
+      - path: TiltArenaTests
+    dependencies:
+      - target: TiltArena
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.xlc.TiltArenaTests
+        GENERATE_INFOPLIST_FILE: true
+
 schemes:
   TiltArena:
     build:
@@ -37,6 +50,8 @@ schemes:
       config: Debug
     test:
       config: Debug
+      targets:
+        - TiltArenaTests
     profile:
       config: Release
     analyze:


### PR DESCRIPTION
## Summary
- Add CoreMotion-backed tilt input with calibration presets, first-launch neutral capture, sensitivity, dead zone, max-tilt scaling, and smoothing.
- Add player movement, arena clamping, triangular craft rendering, and a cyan motion trail.
- Add focused unit coverage for tilt signal processing, settings persistence, and movement bounds.

Closes #4
Follow-up: #18 owns real-device tilt validation and any tuning.

## Provisional movement values
- Dead zone: 3 degrees
- Maximum tilt: 25 degrees
- Smoothing duration: 0.11 seconds
- Full-width arena crossing target: 2.5 seconds
- Sensitivity range: 0.6-1.4, default 1.0

## Validation
- `git status --short --branch`
- `xcodegen generate`
- `plutil -lint TiltArena/Resources/Info.plist`
- `git diff --check`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`

## Notes
- Real-device tilt notes are intentionally not claimed in this PR; they are tracked by #18.
- Local simulator execution remains blocked by the machine's CoreSimulator mismatch, but generic simulator build and build-for-testing pass.