### PR TITLE
Implement classic survival core loop

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -6,8 +6,15 @@ final class ArenaScene: SKScene {
     private var arenaRoot = SKNode()
     private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
     private var movementController = PlayerMovementController()
+    private var runController = ClassicRunController()
+    private var spawnPlanner = ChaserSpawnPlanner()
+    private var enemies: [ChaserEnemy] = []
+    private var enemyNodes: [Int: ChaserEnemyNode] = [:]
     private var playerNode: PlayerCraftNode?
     private var playerTrailNode: PlayerTrailNode?
+    private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
+    private let centerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
+    private let detailLabel = SKLabelNode(fontNamed: "Menlo")
     private var lastUpdateTime: TimeInterval?
 
     override init(size: CGSize) {
@@ -22,13 +29,16 @@ final class ArenaScene: SKScene {
 
     override func didMove(to view: SKView) {
         rebuildArena()
+        configureLabels()
         placePlayer(resetPosition: true)
+        updateRunDisplay()
         tiltInputController.start()
     }
 
     override func didChangeSize(_ oldSize: CGSize) {
         rebuildArena()
         placePlayer(resetPosition: playerNode == nil)
+        layoutLabels()
     }
 
     override func willMove(from view: SKView) {
@@ -50,13 +60,33 @@ final class ArenaScene: SKScene {
             return
         }
 
+        guard runController.phase == .active else {
+            return
+        }
+
         let input = tiltInputController.update(deltaTime: deltaTime)
         let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
         applyPlayerState(state, resetTrail: false)
+        updateActiveRun(deltaTime: deltaTime, playerPosition: state.position)
     }
 
     func recalibrateTiltControls() {
         tiltInputController.recalibrateToCurrentAttitude()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard !touches.isEmpty else {
+            return
+        }
+
+        switch runController.phase {
+        case .preRun:
+            startRun()
+        case .gameOver:
+            restartRun()
+        case .active, .paused:
+            break
+        }
     }
 
     private func rebuildArena() {
@@ -105,5 +135,157 @@ final class ArenaScene: SKScene {
         } else {
             playerTrailNode?.record(position: state.position, speedFraction: speedFraction)
         }
+    }
+
+    private func configureLabels() {
+        configureLabel(timerLabel, fontSize: 16, color: theme.borderColor)
+        timerLabel.horizontalAlignmentMode = .left
+        timerLabel.verticalAlignmentMode = .top
+
+        configureLabel(centerLabel, fontSize: 22, color: theme.playerColor)
+        centerLabel.horizontalAlignmentMode = .center
+        centerLabel.verticalAlignmentMode = .center
+
+        configureLabel(detailLabel, fontSize: 14, color: theme.borderColor)
+        detailLabel.horizontalAlignmentMode = .center
+        detailLabel.verticalAlignmentMode = .center
+
+        [timerLabel, centerLabel, detailLabel].forEach { label in
+            if label.parent == nil {
+                addChild(label)
+            }
+        }
+
+        layoutLabels()
+    }
+
+    private func configureLabel(_ label: SKLabelNode, fontSize: CGFloat, color: SKColor) {
+        label.fontSize = fontSize
+        label.fontColor = color
+        label.zPosition = 50
+    }
+
+    private func layoutLabels() {
+        timerLabel.position = CGPoint(x: 24, y: max(24, size.height - 24))
+        centerLabel.position = CGPoint(x: size.width / 2, y: size.height / 2 + 24)
+        detailLabel.position = CGPoint(x: size.width / 2, y: size.height / 2 - 12)
+    }
+
+    private func startRun() {
+        runController.start()
+        resetGameplayObjects()
+        placePlayer(resetPosition: true)
+        resetPlayerFeedback()
+        updateRunDisplay()
+    }
+
+    private func restartRun() {
+        runController.restart()
+        resetGameplayObjects()
+        placePlayer(resetPosition: true)
+        resetPlayerFeedback()
+        updateRunDisplay()
+    }
+
+    private func resetGameplayObjects() {
+        enemies.removeAll()
+        enemyNodes.values.forEach { $0.removeFromParent() }
+        enemyNodes.removeAll()
+        spawnPlanner.reset()
+    }
+
+    private func resetPlayerFeedback() {
+        playerNode?.removeAllActions()
+        playerNode?.alpha = 1
+        playerNode?.setScale(1)
+    }
+
+    private func updateActiveRun(deltaTime: TimeInterval, playerPosition: CGPoint) {
+        let spawnCount = runController.update(deltaTime: deltaTime, activeEnemyCount: enemies.count)
+        spawnChasers(count: spawnCount, playerPosition: playerPosition)
+        advanceChasers(deltaTime: deltaTime, playerPosition: playerPosition)
+        detectPlayerCollision(playerPosition: playerPosition)
+        updateRunDisplay()
+    }
+
+    private func spawnChasers(count: Int, playerPosition: CGPoint) {
+        guard count > 0 else {
+            return
+        }
+
+        let playableRect = movementController.configuration.playableRect(in: size)
+
+        for _ in 0..<count {
+            guard let enemy = spawnPlanner.spawnChaser(
+                in: playableRect,
+                avoiding: playerPosition,
+                configuration: runController.configuration
+            ) else {
+                continue
+            }
+
+            enemies.append(enemy)
+
+            let node = ChaserEnemyNode(enemy: enemy, theme: theme)
+            enemyNodes[enemy.id] = node
+            addChild(node)
+        }
+    }
+
+    private func advanceChasers(deltaTime: TimeInterval, playerPosition: CGPoint) {
+        for index in enemies.indices {
+            enemies[index].advance(toward: playerPosition, deltaTime: deltaTime)
+            enemyNodes[enemies[index].id]?.apply(enemies[index])
+        }
+    }
+
+    private func detectPlayerCollision(playerPosition: CGPoint) {
+        let playerCircle = CollisionCircle(
+            center: playerPosition,
+            radius: runController.configuration.playerHitRadius
+        )
+
+        guard enemies.contains(where: { playerCircle.intersects($0.collisionCircle) }) else {
+            return
+        }
+
+        runController.endRun()
+        playDeathFeedback()
+        updateRunDisplay()
+    }
+
+    private func playDeathFeedback() {
+        let pulse = SKAction.group([
+            .scale(to: 1.45, duration: 0.08),
+            .fadeAlpha(to: 0.35, duration: 0.08)
+        ])
+        let settle = SKAction.scale(to: 1.0, duration: 0.08)
+
+        playerNode?.run(.sequence([pulse, settle]))
+    }
+
+    private func updateRunDisplay() {
+        switch runController.phase {
+        case .preRun:
+            timerLabel.text = formatSurvivalTime(0)
+            centerLabel.text = "TAP TO START"
+            detailLabel.text = "CLASSIC SURVIVAL"
+        case .active:
+            timerLabel.text = formatSurvivalTime(runController.survivalTime)
+            centerLabel.text = ""
+            detailLabel.text = ""
+        case .paused:
+            timerLabel.text = formatSurvivalTime(runController.survivalTime)
+            centerLabel.text = "PAUSED"
+            detailLabel.text = ""
+        case .gameOver:
+            timerLabel.text = formatSurvivalTime(runController.survivalTime)
+            centerLabel.text = "GAME OVER"
+            detailLabel.text = "\(formatSurvivalTime(runController.survivalTime))  TAP TO RESTART"
+        }
+    }
+
+    private func formatSurvivalTime(_ time: TimeInterval) -> String {
+        String(format: "%.1fs", time)
     }
 }

--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -173,14 +173,15 @@ final class ArenaScene: SKScene {
 
     private func startRun() {
         runController.start()
-        resetGameplayObjects()
-        placePlayer(resetPosition: true)
-        resetPlayerFeedback()
-        updateRunDisplay()
+        resetActiveRun()
     }
 
     private func restartRun() {
         runController.restart()
+        resetActiveRun()
+    }
+
+    private func resetActiveRun() {
         resetGameplayObjects()
         placePlayer(resetPosition: true)
         resetPlayerFeedback()

--- a/TiltArena/Game/Enemies/ChaserEnemy.swift
+++ b/TiltArena/Game/Enemies/ChaserEnemy.swift
@@ -20,7 +20,12 @@ struct ChaserEnemy: Equatable, Identifiable {
             return
         }
 
-        let step = min(distance, speed * CGFloat(max(0, deltaTime)))
+        let movementDistance = max(0, speed) * CGFloat(max(0, deltaTime))
+        guard movementDistance > 0 else {
+            return
+        }
+
+        let step = min(distance, movementDistance)
         position = CGPoint(
             x: position.x + (dx / distance) * step,
             y: position.y + (dy / distance) * step

--- a/TiltArena/Game/Enemies/ChaserEnemy.swift
+++ b/TiltArena/Game/Enemies/ChaserEnemy.swift
@@ -1,0 +1,29 @@
+import CoreGraphics
+import Foundation
+
+struct ChaserEnemy: Equatable, Identifiable {
+    let id: Int
+    var position: CGPoint
+    var radius: CGFloat
+    var speed: CGFloat
+
+    var collisionCircle: CollisionCircle {
+        CollisionCircle(center: position, radius: radius)
+    }
+
+    mutating func advance(toward target: CGPoint, deltaTime: TimeInterval) {
+        let dx = target.x - position.x
+        let dy = target.y - position.y
+        let distance = hypot(dx, dy)
+
+        guard distance > 0 else {
+            return
+        }
+
+        let step = min(distance, speed * CGFloat(max(0, deltaTime)))
+        position = CGPoint(
+            x: position.x + (dx / distance) * step,
+            y: position.y + (dy / distance) * step
+        )
+    }
+}

--- a/TiltArena/Game/Enemies/ChaserEnemyNode.swift
+++ b/TiltArena/Game/Enemies/ChaserEnemyNode.swift
@@ -1,0 +1,37 @@
+import SpriteKit
+
+@MainActor
+final class ChaserEnemyNode: SKNode {
+    private let bodyNode: SKShapeNode
+    private let ringNode: SKShapeNode
+
+    init(enemy: ChaserEnemy, theme: ArenaTheme) {
+        bodyNode = SKShapeNode(circleOfRadius: enemy.radius)
+        ringNode = SKShapeNode(circleOfRadius: enemy.radius * 1.45)
+        super.init()
+
+        zPosition = 15
+
+        ringNode.strokeColor = theme.enemyColor.withAlphaComponent(0.55)
+        ringNode.lineWidth = 1.1
+        ringNode.fillColor = .clear
+        ringNode.glowWidth = 1
+        addChild(ringNode)
+
+        bodyNode.fillColor = theme.enemyColor
+        bodyNode.strokeColor = theme.enemyColor.withAlphaComponent(0.85)
+        bodyNode.lineWidth = 1
+        bodyNode.glowWidth = 3
+        addChild(bodyNode)
+
+        apply(enemy)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("ChaserEnemyNode does not support storyboard initialization.")
+    }
+
+    func apply(_ enemy: ChaserEnemy) {
+        position = enemy.position
+    }
+}

--- a/TiltArena/Game/Enemies/ChaserSpawnPlanner.swift
+++ b/TiltArena/Game/Enemies/ChaserSpawnPlanner.swift
@@ -1,0 +1,61 @@
+import CoreGraphics
+
+struct ChaserSpawnPlanner {
+    private(set) var nextEnemyID = 1
+    private var nextCandidateIndex = 0
+
+    mutating func reset() {
+        nextEnemyID = 1
+        nextCandidateIndex = 0
+    }
+
+    mutating func spawnChaser(
+        in playableRect: CGRect,
+        avoiding playerPosition: CGPoint,
+        configuration: ClassicRunConfiguration
+    ) -> ChaserEnemy? {
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return nil
+        }
+
+        for _ in 0..<24 {
+            let position = candidatePosition(in: playableRect, index: nextCandidateIndex)
+            nextCandidateIndex += 1
+
+            if isSafeSpawn(position, avoiding: playerPosition, safetyRadius: configuration.playerSafetyRadius) {
+                let enemy = ChaserEnemy(
+                    id: nextEnemyID,
+                    position: position,
+                    radius: configuration.enemyRadius,
+                    speed: configuration.chaserSpeed
+                )
+                nextEnemyID += 1
+                return enemy
+            }
+        }
+
+        return nil
+    }
+
+    func isSafeSpawn(_ position: CGPoint, avoiding playerPosition: CGPoint, safetyRadius: CGFloat) -> Bool {
+        let dx = position.x - playerPosition.x
+        let dy = position.y - playerPosition.y
+        return dx * dx + dy * dy >= safetyRadius * safetyRadius
+    }
+
+    private func candidatePosition(in rect: CGRect, index: Int) -> CGPoint {
+        let side = index % 4
+        let lane = CGFloat(((index / 4) % 7) + 1) / 8
+
+        switch side {
+        case 0:
+            return CGPoint(x: rect.minX, y: rect.minY + rect.height * lane)
+        case 1:
+            return CGPoint(x: rect.maxX, y: rect.minY + rect.height * lane)
+        case 2:
+            return CGPoint(x: rect.minX + rect.width * lane, y: rect.minY)
+        default:
+            return CGPoint(x: rect.minX + rect.width * lane, y: rect.maxY)
+        }
+    }
+}

--- a/TiltArena/Game/Enemies/ChaserSpawnPlanner.swift
+++ b/TiltArena/Game/Enemies/ChaserSpawnPlanner.swift
@@ -1,6 +1,9 @@
 import CoreGraphics
 
 struct ChaserSpawnPlanner {
+    private static let candidateSideCount = 4
+    private static let candidateLaneCount = 7
+
     private(set) var nextEnemyID = 1
     private var nextCandidateIndex = 0
 
@@ -18,7 +21,7 @@ struct ChaserSpawnPlanner {
             return nil
         }
 
-        for _ in 0..<24 {
+        for _ in 0..<(Self.candidateSideCount * Self.candidateLaneCount) {
             let position = candidatePosition(in: playableRect, index: nextCandidateIndex)
             nextCandidateIndex += 1
 
@@ -44,8 +47,9 @@ struct ChaserSpawnPlanner {
     }
 
     private func candidatePosition(in rect: CGRect, index: Int) -> CGPoint {
-        let side = index % 4
-        let lane = CGFloat(((index / 4) % 7) + 1) / 8
+        let side = index % Self.candidateSideCount
+        let lane = CGFloat(((index / Self.candidateSideCount) % Self.candidateLaneCount) + 1)
+            / CGFloat(Self.candidateLaneCount + 1)
 
         switch side {
         case 0:

--- a/TiltArena/Game/Run/CircleCollision.swift
+++ b/TiltArena/Game/Run/CircleCollision.swift
@@ -1,0 +1,14 @@
+import CoreGraphics
+
+struct CollisionCircle: Equatable {
+    var center: CGPoint
+    var radius: CGFloat
+
+    func intersects(_ other: CollisionCircle) -> Bool {
+        let dx = center.x - other.center.x
+        let dy = center.y - other.center.y
+        let radiusSum = radius + other.radius
+
+        return dx * dx + dy * dy <= radiusSum * radiusSum
+    }
+}

--- a/TiltArena/Game/Run/ClassicRunController.swift
+++ b/TiltArena/Game/Run/ClassicRunController.swift
@@ -71,13 +71,16 @@ struct ClassicRunController {
 
         let clampedDelta = max(0, deltaTime)
         survivalTime += clampedDelta
-        timeUntilNextSpawn -= clampedDelta
 
-        guard activeEnemyCount < configuration.maxActiveChasers else {
+        guard configuration.spawnInterval > 0 else {
+            timeUntilNextSpawn = 0
             return 0
         }
 
-        guard configuration.spawnInterval > 0 else {
+        timeUntilNextSpawn -= clampedDelta
+
+        guard activeEnemyCount < configuration.maxActiveChasers else {
+            timeUntilNextSpawn = max(timeUntilNextSpawn, configuration.spawnInterval)
             return 0
         }
 

--- a/TiltArena/Game/Run/ClassicRunController.swift
+++ b/TiltArena/Game/Run/ClassicRunController.swift
@@ -1,0 +1,101 @@
+import CoreGraphics
+import Foundation
+
+enum ClassicRunPhase: Equatable {
+    case preRun
+    case active
+    case paused
+    case gameOver
+}
+
+struct ClassicRunConfiguration: Equatable {
+    var playerVisualRadius: CGFloat = 14
+    var playerHitRadiusScale: CGFloat = 0.65
+    var enemyRadius: CGFloat = 8
+    var chaserSpeed: CGFloat = 55
+    var spawnInterval: TimeInterval = 1.4
+    var maxActiveChasers: Int = 40
+    var playerSafetyRadius: CGFloat = 120
+
+    var playerHitRadius: CGFloat {
+        playerVisualRadius * playerHitRadiusScale
+    }
+}
+
+struct ClassicRunController {
+    var configuration = ClassicRunConfiguration()
+    private(set) var phase: ClassicRunPhase = .preRun
+    private(set) var survivalTime: TimeInterval = 0
+    private var timeUntilNextSpawn: TimeInterval = 0
+
+    init(configuration: ClassicRunConfiguration = ClassicRunConfiguration()) {
+        self.configuration = configuration
+    }
+
+    mutating func start() {
+        resetForActiveRun()
+    }
+
+    mutating func pause() {
+        guard phase == .active else {
+            return
+        }
+
+        phase = .paused
+    }
+
+    mutating func resume() {
+        guard phase == .paused else {
+            return
+        }
+
+        phase = .active
+    }
+
+    mutating func endRun() {
+        guard phase == .active || phase == .paused else {
+            return
+        }
+
+        phase = .gameOver
+    }
+
+    mutating func restart() {
+        resetForActiveRun()
+    }
+
+    mutating func update(deltaTime: TimeInterval, activeEnemyCount: Int) -> Int {
+        guard phase == .active else {
+            return 0
+        }
+
+        let clampedDelta = max(0, deltaTime)
+        survivalTime += clampedDelta
+        timeUntilNextSpawn -= clampedDelta
+
+        guard activeEnemyCount < configuration.maxActiveChasers else {
+            return 0
+        }
+
+        guard configuration.spawnInterval > 0 else {
+            return 0
+        }
+
+        var spawnCount = 0
+        var projectedEnemyCount = activeEnemyCount
+
+        while timeUntilNextSpawn <= 0, projectedEnemyCount < configuration.maxActiveChasers {
+            spawnCount += 1
+            projectedEnemyCount += 1
+            timeUntilNextSpawn += configuration.spawnInterval
+        }
+
+        return spawnCount
+    }
+
+    private mutating func resetForActiveRun() {
+        phase = .active
+        survivalTime = 0
+        timeUntilNextSpawn = 0
+    }
+}

--- a/TiltArenaTests/ChaserEnemyTests.swift
+++ b/TiltArenaTests/ChaserEnemyTests.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class ChaserEnemyTests: XCTestCase {
+    func testChaserMovesTowardPlayerWithoutOvershooting() {
+        var enemy = ChaserEnemy(id: 1, position: CGPoint(x: 0, y: 0), radius: 8, speed: 100)
+
+        enemy.advance(toward: CGPoint(x: 30, y: 0), deltaTime: 1)
+
+        XCTAssertEqual(enemy.position.x, 30, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 0, accuracy: 0.0001)
+    }
+
+    func testSpawnPlannerSkipsPositionsInsidePlayerSafetyRadius() {
+        var planner = ChaserSpawnPlanner()
+        let config = ClassicRunConfiguration(playerSafetyRadius: 120)
+        let playableRect = CGRect(x: 0, y: 0, width: 320, height: 600)
+        let playerPosition = CGPoint(x: 0, y: 75)
+
+        let enemy = planner.spawnChaser(
+            in: playableRect,
+            avoiding: playerPosition,
+            configuration: config
+        )
+
+        guard let enemy else {
+            return XCTFail("Expected a safe spawn candidate.")
+        }
+
+        XCTAssertTrue(planner.isSafeSpawn(enemy.position, avoiding: playerPosition, safetyRadius: 120))
+    }
+
+    func testCircleCollisionUsesCombinedRadii() {
+        let player = CollisionCircle(center: CGPoint(x: 0, y: 0), radius: 9)
+        let touchingEnemy = CollisionCircle(center: CGPoint(x: 17, y: 0), radius: 8)
+        let distantEnemy = CollisionCircle(center: CGPoint(x: 18, y: 0), radius: 8)
+
+        XCTAssertTrue(player.intersects(touchingEnemy))
+        XCTAssertFalse(player.intersects(distantEnemy))
+    }
+
+    func testPlayerHitRadiusIsSmallerThanVisibleCraft() {
+        let config = ClassicRunConfiguration(playerVisualRadius: 14, playerHitRadiusScale: 0.65)
+
+        XCTAssertLessThan(config.playerHitRadius, config.playerVisualRadius)
+        XCTAssertEqual(config.playerHitRadius, 9.1, accuracy: 0.0001)
+    }
+}

--- a/TiltArenaTests/ChaserEnemyTests.swift
+++ b/TiltArenaTests/ChaserEnemyTests.swift
@@ -12,6 +12,17 @@ final class ChaserEnemyTests: XCTestCase {
         XCTAssertEqual(enemy.position.y, 0, accuracy: 0.0001)
     }
 
+    func testChaserDoesNotMoveWithNegativeSpeedOrDeltaTime() {
+        var enemy = ChaserEnemy(id: 1, position: CGPoint(x: 10, y: 0), radius: 8, speed: -100)
+
+        enemy.advance(toward: CGPoint(x: 30, y: 0), deltaTime: 1)
+        XCTAssertEqual(enemy.position.x, 10, accuracy: 0.0001)
+
+        enemy.speed = 100
+        enemy.advance(toward: CGPoint(x: 30, y: 0), deltaTime: -1)
+        XCTAssertEqual(enemy.position.x, 10, accuracy: 0.0001)
+    }
+
     func testSpawnPlannerSkipsPositionsInsidePlayerSafetyRadius() {
         var planner = ChaserSpawnPlanner()
         let config = ClassicRunConfiguration(playerSafetyRadius: 120)
@@ -29,6 +40,24 @@ final class ChaserEnemyTests: XCTestCase {
         }
 
         XCTAssertTrue(planner.isSafeSpawn(enemy.position, avoiding: playerPosition, safetyRadius: 120))
+    }
+
+    func testSpawnPlannerChecksFullEdgeCandidateCycle() {
+        var planner = ChaserSpawnPlanner()
+        let config = ClassicRunConfiguration(playerSafetyRadius: 355)
+        let playableRect = CGRect(x: 0, y: 0, width: 280, height: 280)
+
+        let enemy = planner.spawnChaser(
+            in: playableRect,
+            avoiding: .zero,
+            configuration: config
+        )
+
+        guard let enemy else {
+            return XCTFail("Expected a safe candidate in the final edge lane.")
+        }
+
+        XCTAssertTrue(planner.isSafeSpawn(enemy.position, avoiding: .zero, safetyRadius: 355))
     }
 
     func testCircleCollisionUsesCombinedRadii() {

--- a/TiltArenaTests/ClassicRunControllerTests.swift
+++ b/TiltArenaTests/ClassicRunControllerTests.swift
@@ -52,6 +52,17 @@ final class ClassicRunControllerTests: XCTestCase {
         XCTAssertEqual(spawnCount, 1)
     }
 
+    func testSpawnScheduleDoesNotAccumulateDebtWhileAtEnemyCap() {
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0.5, maxActiveChasers: 5)
+        )
+
+        controller.start()
+        XCTAssertEqual(controller.update(deltaTime: 2, activeEnemyCount: 5), 0)
+        XCTAssertEqual(controller.update(deltaTime: 0.1, activeEnemyCount: 0), 0)
+        XCTAssertEqual(controller.update(deltaTime: 0.4, activeEnemyCount: 0), 1)
+    }
+
     func testNonPositiveSpawnIntervalDoesNotScheduleEnemies() {
         var controller = ClassicRunController(
             configuration: ClassicRunConfiguration(spawnInterval: 0)

--- a/TiltArenaTests/ClassicRunControllerTests.swift
+++ b/TiltArenaTests/ClassicRunControllerTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import TiltArena
+
+final class ClassicRunControllerTests: XCTestCase {
+    func testStartAndRestartEnterActiveRunAtZeroTime() {
+        var controller = ClassicRunController()
+
+        controller.start()
+        _ = controller.update(deltaTime: 2, activeEnemyCount: 0)
+        controller.restart()
+
+        XCTAssertEqual(controller.phase, .active)
+        XCTAssertEqual(controller.survivalTime, 0)
+    }
+
+    func testUpdateOnlyAdvancesWhileActive() {
+        var controller = ClassicRunController()
+
+        XCTAssertEqual(controller.update(deltaTime: 1, activeEnemyCount: 0), 0)
+        XCTAssertEqual(controller.survivalTime, 0)
+
+        controller.start()
+        _ = controller.update(deltaTime: 1, activeEnemyCount: 0)
+        controller.pause()
+        _ = controller.update(deltaTime: 1, activeEnemyCount: 0)
+
+        XCTAssertEqual(controller.survivalTime, 1)
+    }
+
+    func testPauseResumeAndGameOverTransitions() {
+        var controller = ClassicRunController()
+
+        controller.start()
+        controller.pause()
+        XCTAssertEqual(controller.phase, .paused)
+
+        controller.resume()
+        XCTAssertEqual(controller.phase, .active)
+
+        controller.endRun()
+        XCTAssertEqual(controller.phase, .gameOver)
+    }
+
+    func testSpawnCountRespectsMaximumEnemies() {
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0.5, maxActiveChasers: 3)
+        )
+
+        controller.start()
+        let spawnCount = controller.update(deltaTime: 2, activeEnemyCount: 2)
+
+        XCTAssertEqual(spawnCount, 1)
+    }
+
+    func testNonPositiveSpawnIntervalDoesNotScheduleEnemies() {
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0)
+        )
+
+        controller.start()
+        let spawnCount = controller.update(deltaTime: 1, activeEnemyCount: 0)
+
+        XCTAssertEqual(spawnCount, 0)
+        XCTAssertEqual(controller.survivalTime, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a focused Classic Survival run controller with pre-run, active, paused, game-over, and restart state handling.
- Add basic chaser enemies, deterministic edge spawning with a player safety radius, circle collision helpers, and SpriteKit enemy rendering.
- Wire ArenaScene into tap-to-start, tilt-driven active play, survival timer display, collision death feedback, and tap-to-restart.
- Add focused pure Swift coverage for run state, spawn scheduling, safe spawns, chaser movement, collision radii, and fair player hit radius.

Closes #5

## Follow-up
- User-facing pause/resume controls are tracked separately in #20 so this PR stays focused on the issue #5 start/survive/die/restart loop.

## Validation
- `xcodegen generate`
- `plutil -lint TiltArena/Resources/Info.plist`
- `git diff --check`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`