### PR TITLE
Issue #6: Pickup spawning and starting weapons

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -8,10 +8,17 @@ final class ArenaScene: SKScene {
     private var movementController = PlayerMovementController()
     private var runController = ClassicRunController()
     private var spawnPlanner = ChaserSpawnPlanner()
+    private let pickupSpawnConfiguration = PickupSpawnConfiguration()
+    private var pickupPlanner = PickupSpawnPlanner()
+    private let weaponResolver = StartingWeaponResolver()
     private var enemies: [ChaserEnemy] = []
     private var enemyNodes: [Int: ChaserEnemyNode] = [:]
+    private var pickups: [WeaponPickup] = []
+    private var pickupNodes: [Int: WeaponPickupNode] = [:]
     private var playerNode: PlayerCraftNode?
     private var playerTrailNode: PlayerTrailNode?
+    private var razorShieldTimeRemaining: TimeInterval = 0
+    private var razorShieldNode: SKShapeNode?
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let centerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let detailLabel = SKLabelNode(fontNamed: "Menlo")
@@ -248,6 +255,12 @@ final class ArenaScene: SKScene {
         enemyNodes.values.forEach { $0.removeFromParent() }
         enemyNodes.removeAll()
         spawnPlanner.reset()
+
+        pickups.removeAll()
+        pickupNodes.values.forEach { $0.removeFromParent() }
+        pickupNodes.removeAll()
+        pickupPlanner.reset(configuration: pickupSpawnConfiguration)
+        deactivateRazorShield()
     }
 
     private func resetPlayerFeedback() {
@@ -259,7 +272,10 @@ final class ArenaScene: SKScene {
     private func updateActiveRun(deltaTime: TimeInterval, playerPosition: CGPoint) {
         let spawnCount = runController.update(deltaTime: deltaTime, activeEnemyCount: enemies.count)
         spawnChasers(count: spawnCount, playerPosition: playerPosition)
+        spawnPickupIfNeeded(deltaTime: deltaTime, playerPosition: playerPosition)
+        collectPickups(playerPosition: playerPosition)
         advanceChasers(deltaTime: deltaTime, playerPosition: playerPosition)
+        updateRazorShield(deltaTime: deltaTime, playerPosition: playerPosition)
         detectPlayerCollision(playerPosition: playerPosition)
         updateRunDisplay()
     }
@@ -288,10 +304,184 @@ final class ArenaScene: SKScene {
         }
     }
 
+    private func spawnPickupIfNeeded(deltaTime: TimeInterval, playerPosition: CGPoint) {
+        let playableRect = movementController.configuration.playableRect(in: size)
+        let enemyCircles = enemies.map(\.collisionCircle)
+
+        guard let pickup = pickupPlanner.update(
+            deltaTime: deltaTime,
+            phase: runController.phase,
+            activePickupCount: pickups.count,
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            enemyCircles: enemyCircles,
+            configuration: pickupSpawnConfiguration
+        ) else {
+            return
+        }
+
+        pickups.append(pickup)
+
+        let node = WeaponPickupNode(pickup: pickup, theme: theme)
+        pickupNodes[pickup.id] = node
+        addChild(node)
+    }
+
     private func advanceChasers(deltaTime: TimeInterval, playerPosition: CGPoint) {
         for index in enemies.indices {
             enemies[index].advance(toward: playerPosition, deltaTime: deltaTime)
             enemyNodes[enemies[index].id]?.apply(enemies[index])
+        }
+    }
+
+    private func collectPickups(playerPosition: CGPoint) {
+        let playerCircle = CollisionCircle(
+            center: playerPosition,
+            radius: movementController.configuration.visualRadius
+        )
+        let collectedPickups = pickups.filter { playerCircle.intersects($0.collisionCircle) }
+
+        guard !collectedPickups.isEmpty else {
+            return
+        }
+
+        for pickup in collectedPickups {
+            removePickup(id: pickup.id)
+            applyWeapon(pickup.kind, playerPosition: playerPosition)
+        }
+    }
+
+    private func removePickup(id: Int) {
+        pickups.removeAll { $0.id == id }
+        pickupNodes.removeValue(forKey: id)?.removeFromParent()
+    }
+
+    private func applyWeapon(_ kind: WeaponKind, playerPosition: CGPoint) {
+        let resolution = weaponResolver.resolve(
+            kind: kind,
+            playerPosition: playerPosition,
+            enemies: enemies
+        )
+
+        switch kind {
+        case .shockwave:
+            playShockwaveEffect(at: playerPosition)
+        case .seekerSwarm:
+            let targetPositions = positions(forEnemyIDs: resolution.destroyedEnemyIDs)
+            playSeekerSwarmEffect(from: playerPosition, to: targetPositions)
+        case .razorShield:
+            activateRazorShield(at: playerPosition)
+        }
+
+        destroyEnemies(ids: resolution.destroyedEnemyIDs)
+    }
+
+    private func positions(forEnemyIDs enemyIDs: Set<Int>) -> [CGPoint] {
+        enemies.compactMap { enemyIDs.contains($0.id) ? $0.position : nil }
+    }
+
+    private func destroyEnemies(ids enemyIDs: Set<Int>) {
+        guard !enemyIDs.isEmpty else {
+            return
+        }
+
+        runController.recordEnemiesDestroyed(enemyIDs.count)
+        enemies.removeAll { enemyIDs.contains($0.id) }
+
+        for enemyID in enemyIDs {
+            guard let node = enemyNodes.removeValue(forKey: enemyID) else {
+                continue
+            }
+
+            let fade = SKAction.group([
+                .scale(to: 0.35, duration: 0.08),
+                .fadeOut(withDuration: 0.08)
+            ])
+            node.run(.sequence([fade, .removeFromParent()]))
+        }
+    }
+
+    private func activateRazorShield(at playerPosition: CGPoint) {
+        razorShieldTimeRemaining = weaponResolver.configuration.razorShieldDuration
+
+        if razorShieldNode == nil {
+            let node = SKShapeNode(circleOfRadius: weaponResolver.configuration.razorShieldRadius)
+            node.strokeColor = theme.pickupBlue.withAlphaComponent(0.9)
+            node.fillColor = .clear
+            node.lineWidth = 2
+            node.glowWidth = 4
+            node.zPosition = 19
+            addChild(node)
+            razorShieldNode = node
+        }
+
+        razorShieldNode?.position = playerPosition
+        razorShieldNode?.isHidden = false
+    }
+
+    private func updateRazorShield(deltaTime: TimeInterval, playerPosition: CGPoint) {
+        guard razorShieldTimeRemaining > 0 else {
+            deactivateRazorShield()
+            return
+        }
+
+        razorShieldNode?.position = playerPosition
+
+        let targetIDs = weaponResolver.shieldTargets(
+            playerPosition: playerPosition,
+            enemies: enemies
+        )
+        destroyEnemies(ids: targetIDs)
+
+        razorShieldTimeRemaining = max(0, razorShieldTimeRemaining - max(0, deltaTime))
+
+        if razorShieldTimeRemaining == 0 {
+            deactivateRazorShield()
+        }
+    }
+
+    private func deactivateRazorShield() {
+        razorShieldTimeRemaining = 0
+        razorShieldNode?.removeFromParent()
+        razorShieldNode = nil
+    }
+
+    private func playShockwaveEffect(at position: CGPoint) {
+        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.shockwaveRadius)
+        ring.position = position
+        ring.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 5
+        ring.zPosition = 18
+        ring.setScale(0.2)
+        addChild(ring)
+
+        let expand = SKAction.group([
+            .scale(to: 1.0, duration: 0.16),
+            .fadeOut(withDuration: 0.16)
+        ])
+        ring.run(.sequence([expand, .removeFromParent()]))
+    }
+
+    private func playSeekerSwarmEffect(from origin: CGPoint, to targets: [CGPoint]) {
+        for target in targets {
+            let path = CGMutablePath()
+            path.move(to: origin)
+            path.addLine(to: target)
+
+            let streak = SKShapeNode(path: path)
+            streak.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
+            streak.lineWidth = 1.5
+            streak.glowWidth = 3
+            streak.zPosition = 18
+            addChild(streak)
+
+            let fade = SKAction.group([
+                .fadeOut(withDuration: 0.12),
+                .scale(to: 0.9, duration: 0.12)
+            ])
+            streak.run(.sequence([fade, .removeFromParent()]))
         }
     }
 

--- a/TiltArena/Game/Run/ClassicRunController.swift
+++ b/TiltArena/Game/Run/ClassicRunController.swift
@@ -26,6 +26,7 @@ struct ClassicRunController {
     var configuration = ClassicRunConfiguration()
     private(set) var phase: ClassicRunPhase = .preRun
     private(set) var survivalTime: TimeInterval = 0
+    private(set) var enemiesDestroyed = 0
     private var timeUntilNextSpawn: TimeInterval = 0
 
     init(configuration: ClassicRunConfiguration = ClassicRunConfiguration()) {
@@ -96,9 +97,14 @@ struct ClassicRunController {
         return spawnCount
     }
 
+    mutating func recordEnemiesDestroyed(_ count: Int) {
+        enemiesDestroyed += max(0, count)
+    }
+
     private mutating func resetForActiveRun() {
         phase = .active
         survivalTime = 0
+        enemiesDestroyed = 0
         timeUntilNextSpawn = 0
     }
 }

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -1,0 +1,162 @@
+import CoreGraphics
+import Foundation
+
+struct PickupSpawnConfiguration: Equatable {
+    var initialSpawnDelay: TimeInterval = 4.5
+    var spawnInterval: TimeInterval = 4.5
+    var maxActivePickups: Int = 2
+    var pickupRadius: CGFloat = 12
+    var edgeInset: CGFloat = 44
+    var playerClearance: CGFloat = 84
+    var enemyClearance: CGFloat = 8
+}
+
+struct PickupSpawnPlanner {
+    private static let candidatePositions: [(x: CGFloat, y: CGFloat)] = [
+        (0.50, 0.28),
+        (0.24, 0.52),
+        (0.76, 0.52),
+        (0.42, 0.72),
+        (0.58, 0.38),
+        (0.32, 0.34),
+        (0.68, 0.68),
+        (0.50, 0.58)
+    ]
+
+    private(set) var nextPickupID = 1
+    private var nextKindIndex = 0
+    private var nextCandidateIndex = 0
+    private var timeUntilNextSpawn: TimeInterval
+
+    init(configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()) {
+        timeUntilNextSpawn = configuration.initialSpawnDelay
+    }
+
+    mutating func reset(configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()) {
+        nextPickupID = 1
+        nextKindIndex = 0
+        nextCandidateIndex = 0
+        timeUntilNextSpawn = configuration.initialSpawnDelay
+    }
+
+    mutating func update(
+        deltaTime: TimeInterval,
+        phase: ClassicRunPhase,
+        activePickupCount: Int,
+        playableRect: CGRect,
+        playerPosition: CGPoint,
+        enemyCircles: [CollisionCircle],
+        configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()
+    ) -> WeaponPickup? {
+        guard phase == .active else {
+            return nil
+        }
+
+        guard configuration.spawnInterval > 0, configuration.maxActivePickups > 0 else {
+            return nil
+        }
+
+        guard activePickupCount < configuration.maxActivePickups else {
+            timeUntilNextSpawn = max(timeUntilNextSpawn, configuration.spawnInterval)
+            return nil
+        }
+
+        timeUntilNextSpawn -= max(0, deltaTime)
+
+        guard timeUntilNextSpawn <= 0 else {
+            return nil
+        }
+
+        guard let pickup = spawnPickup(
+            in: playableRect,
+            avoiding: playerPosition,
+            enemyCircles: enemyCircles,
+            configuration: configuration
+        ) else {
+            timeUntilNextSpawn = configuration.spawnInterval
+            return nil
+        }
+
+        timeUntilNextSpawn = configuration.spawnInterval
+        return pickup
+    }
+
+    mutating func spawnPickup(
+        in playableRect: CGRect,
+        avoiding playerPosition: CGPoint,
+        enemyCircles: [CollisionCircle],
+        configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()
+    ) -> WeaponPickup? {
+        let spawnRect = playableRect.insetBy(
+            dx: min(configuration.edgeInset, playableRect.width / 4),
+            dy: min(configuration.edgeInset, playableRect.height / 4)
+        )
+
+        guard spawnRect.width > 0, spawnRect.height > 0 else {
+            return nil
+        }
+
+        for _ in 0..<Self.candidatePositions.count {
+            let position = candidatePosition(in: spawnRect, index: nextCandidateIndex)
+            nextCandidateIndex += 1
+
+            guard isSafePickupPosition(
+                position,
+                avoiding: playerPosition,
+                enemyCircles: enemyCircles,
+                configuration: configuration
+            ) else {
+                continue
+            }
+
+            let pickup = WeaponPickup(
+                id: nextPickupID,
+                kind: nextKind(),
+                position: position,
+                radius: configuration.pickupRadius
+            )
+            nextPickupID += 1
+            return pickup
+        }
+
+        return nil
+    }
+
+    func isSafePickupPosition(
+        _ position: CGPoint,
+        avoiding playerPosition: CGPoint,
+        enemyCircles: [CollisionCircle],
+        configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()
+    ) -> Bool {
+        let playerClearance = configuration.playerClearance + configuration.pickupRadius
+        guard squaredDistance(from: position, to: playerPosition) >= playerClearance * playerClearance else {
+            return false
+        }
+
+        return enemyCircles.allSatisfy { enemyCircle in
+            let clearance = enemyCircle.radius + configuration.pickupRadius + configuration.enemyClearance
+            return squaredDistance(from: position, to: enemyCircle.center) >= clearance * clearance
+        }
+    }
+
+    private mutating func nextKind() -> WeaponKind {
+        let kinds = WeaponKind.allCases
+        let kind = kinds[nextKindIndex % kinds.count]
+        nextKindIndex += 1
+        return kind
+    }
+
+    private func candidatePosition(in rect: CGRect, index: Int) -> CGPoint {
+        let normalized = Self.candidatePositions[index % Self.candidatePositions.count]
+        return CGPoint(
+            x: rect.minX + rect.width * normalized.x,
+            y: rect.minY + rect.height * normalized.y
+        )
+    }
+
+    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy
+    }
+}

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -1,0 +1,62 @@
+import CoreGraphics
+import Foundation
+
+struct StartingWeaponConfiguration: Equatable {
+    var shockwaveRadius: CGFloat = 96
+    var seekerTargetLimit: Int = 4
+    var razorShieldRadius: CGFloat = 32
+    var razorShieldDuration: TimeInterval = 4
+}
+
+struct WeaponResolution: Equatable {
+    var destroyedEnemyIDs: Set<Int> = []
+}
+
+struct StartingWeaponResolver {
+    var configuration = StartingWeaponConfiguration()
+
+    func resolve(kind: WeaponKind, playerPosition: CGPoint, enemies: [ChaserEnemy]) -> WeaponResolution {
+        switch kind {
+        case .shockwave:
+            return WeaponResolution(destroyedEnemyIDs: shockwaveTargets(playerPosition: playerPosition, enemies: enemies))
+        case .seekerSwarm:
+            return WeaponResolution(destroyedEnemyIDs: seekerTargets(playerPosition: playerPosition, enemies: enemies))
+        case .razorShield:
+            return WeaponResolution()
+        }
+    }
+
+    func shieldTargets(playerPosition: CGPoint, enemies: [ChaserEnemy]) -> Set<Int> {
+        let shieldCircle = CollisionCircle(center: playerPosition, radius: configuration.razorShieldRadius)
+        return Set(enemies.filter { shieldCircle.intersects($0.collisionCircle) }.map(\.id))
+    }
+
+    private func shockwaveTargets(playerPosition: CGPoint, enemies: [ChaserEnemy]) -> Set<Int> {
+        let shockwaveCircle = CollisionCircle(center: playerPosition, radius: configuration.shockwaveRadius)
+        return Set(enemies.filter { shockwaveCircle.intersects($0.collisionCircle) }.map(\.id))
+    }
+
+    private func seekerTargets(playerPosition: CGPoint, enemies: [ChaserEnemy]) -> Set<Int> {
+        let targetLimit = max(0, configuration.seekerTargetLimit)
+
+        guard targetLimit > 0 else {
+            return []
+        }
+
+        return Set(
+            enemies
+                .sorted {
+                    squaredDistance(from: $0.position, to: playerPosition)
+                        < squaredDistance(from: $1.position, to: playerPosition)
+                }
+                .prefix(targetLimit)
+                .map(\.id)
+        )
+    }
+
+    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy
+    }
+}

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -1,0 +1,5 @@
+enum WeaponKind: CaseIterable, Equatable {
+    case shockwave
+    case seekerSwarm
+    case razorShield
+}

--- a/TiltArena/Game/Weapons/WeaponPickup.swift
+++ b/TiltArena/Game/Weapons/WeaponPickup.swift
@@ -1,0 +1,12 @@
+import CoreGraphics
+
+struct WeaponPickup: Equatable, Identifiable {
+    let id: Int
+    let kind: WeaponKind
+    let position: CGPoint
+    let radius: CGFloat
+
+    var collisionCircle: CollisionCircle {
+        CollisionCircle(center: position, radius: radius)
+    }
+}

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -1,0 +1,59 @@
+import SpriteKit
+
+@MainActor
+final class WeaponPickupNode: SKNode {
+    private let bodyNode: SKShapeNode
+    private let ringNode: SKShapeNode
+
+    init(pickup: WeaponPickup, theme: ArenaTheme) {
+        bodyNode = SKShapeNode(path: Self.makeDiamondPath(radius: pickup.radius))
+        ringNode = SKShapeNode(circleOfRadius: pickup.radius * 1.45)
+        super.init()
+
+        zPosition = 14
+
+        let color = Self.color(for: pickup.kind, theme: theme)
+        ringNode.strokeColor = color.withAlphaComponent(0.45)
+        ringNode.lineWidth = 1
+        ringNode.fillColor = .clear
+        ringNode.glowWidth = 1
+        addChild(ringNode)
+
+        bodyNode.fillColor = color.withAlphaComponent(0.9)
+        bodyNode.strokeColor = theme.playerColor.withAlphaComponent(0.8)
+        bodyNode.lineWidth = 1.1
+        bodyNode.glowWidth = 2
+        addChild(bodyNode)
+
+        apply(pickup)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("WeaponPickupNode does not support storyboard initialization.")
+    }
+
+    func apply(_ pickup: WeaponPickup) {
+        position = pickup.position
+    }
+
+    private static func color(for kind: WeaponKind, theme: ArenaTheme) -> SKColor {
+        switch kind {
+        case .shockwave:
+            return theme.pickupAmber
+        case .seekerSwarm:
+            return theme.pickupViolet
+        case .razorShield:
+            return theme.pickupBlue
+        }
+    }
+
+    private static func makeDiamondPath(radius: CGFloat) -> CGPath {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: radius))
+        path.addLine(to: CGPoint(x: radius * 0.78, y: 0))
+        path.addLine(to: CGPoint(x: 0, y: -radius))
+        path.addLine(to: CGPoint(x: -radius * 0.78, y: 0))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/TiltArenaTests/ClassicRunControllerTests.swift
+++ b/TiltArenaTests/ClassicRunControllerTests.swift
@@ -7,10 +7,12 @@ final class ClassicRunControllerTests: XCTestCase {
 
         controller.start()
         _ = controller.update(deltaTime: 2, activeEnemyCount: 0)
+        controller.recordEnemiesDestroyed(3)
         controller.restart()
 
         XCTAssertEqual(controller.phase, .active)
         XCTAssertEqual(controller.survivalTime, 0)
+        XCTAssertEqual(controller.enemiesDestroyed, 0)
     }
 
     func testUpdateOnlyAdvancesWhileActive() {
@@ -58,6 +60,16 @@ final class ClassicRunControllerTests: XCTestCase {
 
         controller.endRun()
         XCTAssertEqual(controller.phase, .gameOver)
+    }
+
+    func testDestroyedEnemyCountIgnoresNegativeCounts() {
+        var controller = ClassicRunController()
+
+        controller.start()
+        controller.recordEnemiesDestroyed(3)
+        controller.recordEnemiesDestroyed(-1)
+
+        XCTAssertEqual(controller.enemiesDestroyed, 3)
     }
 
     func testSpawnCountRespectsMaximumEnemies() {

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import TiltArena
+
+final class PickupSpawnPlannerTests: XCTestCase {
+    func testPickupScheduleWaitsForInitialDelayAndRespectsActiveCap() {
+        let configuration = PickupSpawnConfiguration(
+            initialSpawnDelay: 1,
+            spawnInterval: 4.5,
+            maxActivePickups: 1
+        )
+        var planner = PickupSpawnPlanner(configuration: configuration)
+        let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let playerPosition = CGPoint(x: 160, y: 320)
+
+        XCTAssertNil(planner.update(
+            deltaTime: 0.9,
+            phase: .active,
+            activePickupCount: 0,
+            playableRect: rect,
+            playerPosition: playerPosition,
+            enemyCircles: [],
+            configuration: configuration
+        ))
+
+        let firstPickup = planner.update(
+            deltaTime: 0.1,
+            phase: .active,
+            activePickupCount: 0,
+            playableRect: rect,
+            playerPosition: playerPosition,
+            enemyCircles: [],
+            configuration: configuration
+        )
+        XCTAssertNotNil(firstPickup)
+
+        XCTAssertNil(planner.update(
+            deltaTime: 10,
+            phase: .active,
+            activePickupCount: 1,
+            playableRect: rect,
+            playerPosition: playerPosition,
+            enemyCircles: [],
+            configuration: configuration
+        ))
+    }
+
+    func testPickupScheduleDoesNotAdvanceWhilePaused() {
+        let configuration = PickupSpawnConfiguration(initialSpawnDelay: 1, spawnInterval: 4.5)
+        var planner = PickupSpawnPlanner(configuration: configuration)
+        let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
+
+        XCTAssertNil(planner.update(
+            deltaTime: 5,
+            phase: .paused,
+            activePickupCount: 0,
+            playableRect: rect,
+            playerPosition: CGPoint(x: 160, y: 320),
+            enemyCircles: [],
+            configuration: configuration
+        ))
+
+        XCTAssertNil(planner.update(
+            deltaTime: 0.9,
+            phase: .active,
+            activePickupCount: 0,
+            playableRect: rect,
+            playerPosition: CGPoint(x: 160, y: 320),
+            enemyCircles: [],
+            configuration: configuration
+        ))
+    }
+
+    func testPickupPlacementAvoidsPlayerAndEnemiesInsideInsetPlayableRect() {
+        let configuration = PickupSpawnConfiguration(
+            initialSpawnDelay: 0,
+            spawnInterval: 4.5,
+            pickupRadius: 10,
+            edgeInset: 40,
+            playerClearance: 70,
+            enemyClearance: 6
+        )
+        var planner = PickupSpawnPlanner(configuration: configuration)
+        let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let playerPosition = CGPoint(x: 160, y: 320)
+        let blockingEnemy = CollisionCircle(center: CGPoint(x: 160, y: 207.2), radius: 8)
+
+        let pickup = planner.spawnPickup(
+            in: rect,
+            avoiding: playerPosition,
+            enemyCircles: [blockingEnemy],
+            configuration: configuration
+        )
+
+        XCTAssertNotNil(pickup)
+        XCTAssertGreaterThanOrEqual(pickup?.position.x ?? 0, 40)
+        XCTAssertLessThanOrEqual(pickup?.position.x ?? 0, 280)
+        XCTAssertGreaterThanOrEqual(pickup?.position.y ?? 0, 40)
+        XCTAssertLessThanOrEqual(pickup?.position.y ?? 0, 600)
+        XCTAssertNotEqual(pickup?.position, blockingEnemy.center)
+        XCTAssertTrue(planner.isSafePickupPosition(
+            pickup?.position ?? .zero,
+            avoiding: playerPosition,
+            enemyCircles: [blockingEnemy],
+            configuration: configuration
+        ))
+    }
+
+    func testResetRestartsPickupIDsAndKindCycle() {
+        let configuration = PickupSpawnConfiguration(initialSpawnDelay: 0)
+        var planner = PickupSpawnPlanner(configuration: configuration)
+        let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let playerPosition = CGPoint(x: 160, y: 320)
+
+        let first = planner.spawnPickup(
+            in: rect,
+            avoiding: playerPosition,
+            enemyCircles: [],
+            configuration: configuration
+        )
+        planner.reset(configuration: configuration)
+        let resetFirst = planner.spawnPickup(
+            in: rect,
+            avoiding: playerPosition,
+            enemyCircles: [],
+            configuration: configuration
+        )
+
+        XCTAssertEqual(first?.id, 1)
+        XCTAssertEqual(first?.kind, .shockwave)
+        XCTAssertEqual(resetFirst?.id, 1)
+        XCTAssertEqual(resetFirst?.kind, .shockwave)
+    }
+}

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import TiltArena
+
+final class StartingWeaponResolverTests: XCTestCase {
+    func testShockwaveClearsEnemiesInsideRadius() {
+        let resolver = StartingWeaponResolver(
+            configuration: StartingWeaponConfiguration(shockwaveRadius: 50)
+        )
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 20, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 60, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .shockwave,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [1])
+    }
+
+    func testSeekerSwarmClearsNearestCappedEnemies() {
+        let resolver = StartingWeaponResolver(
+            configuration: StartingWeaponConfiguration(seekerTargetLimit: 2)
+        )
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 200, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 20, y: 0)),
+            enemy(id: 3, position: CGPoint(x: 60, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .seekerSwarm,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [2, 3])
+    }
+
+    func testRazorShieldClearsContactEnemies() {
+        let resolver = StartingWeaponResolver(
+            configuration: StartingWeaponConfiguration(razorShieldRadius: 24)
+        )
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 28, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 80, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .razorShield,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+        XCTAssertEqual(resolver.shieldTargets(playerPosition: .zero, enemies: enemies), [1])
+    }
+
+    private func enemy(id: Int, position: CGPoint) -> ChaserEnemy {
+        ChaserEnemy(id: id, position: position, radius: 8, speed: 0)
+    }
+}


### PR DESCRIPTION
Summary: Adds deterministic Classic Survival pickup spawning with max two active pickups; adds gem pickup nodes; implements Shockwave, Seeker Swarm, and Razor Shield effects; adds enemies-destroyed tracking hooks and unit coverage. Validation: xcodegen generate; plutil -lint TiltArena/Resources/Info.plist; git diff --check; xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing; xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build. Simulator-executed tests were not run because CoreSimulatorService is unavailable. Closes #6