### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  verify:
+    name: Lint, build, and test
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      DERIVED_DATA_PATH: build/DerivedData
+      PROJECT: TiltArena.xcodeproj
+      SCHEME: TiltArena
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Install tools
+        run: brew install swiftlint xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Lint
+        run: swiftlint lint --no-cache
+
+      - name: Build
+        run: |
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Select test simulator
+        run: |
+          set -euo pipefail
+
+          test_device_id="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')"
+          if [ -z "$test_device_id" ]; then
+            echo "No available iPhone simulator found."
+            xcrun simctl list devices available
+            exit 1
+          fi
+
+          echo "TEST_DESTINATION=platform=iOS Simulator,id=$test_device_id" >> "$GITHUB_ENV"
+
+      - name: Test
+        run: |
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination "$TEST_DESTINATION" \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            CODE_SIGNING_ALLOWED=NO \
+            test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,31 @@
+included:
+  - TiltArena
+  - TiltArenaTests
+
+excluded:
+  - build
+  - TiltArena.xcodeproj
+
+identifier_name:
+  excluded:
+    - dx
+    - dy
+    - id
+    - x
+    - y
+
+line_length:
+  warning: 140
+  error: 180
+
+function_parameter_count:
+  warning: 6
+  error: 8
+
+file_length:
+  warning: 650
+  error: 1000
+
+type_body_length:
+  warning: 550
+  error: 700

--- a/TiltArena/Game/Run/ClassicRunController.swift
+++ b/TiltArena/Game/Run/ClassicRunController.swift
@@ -23,6 +23,8 @@ struct ClassicRunConfiguration: Equatable {
 }
 
 struct ClassicRunController {
+    private static let spawnTimerEpsilon: TimeInterval = 0.000_001
+
     var configuration = ClassicRunConfiguration()
     private(set) var phase: ClassicRunPhase = .preRun
     private(set) var survivalTime: TimeInterval = 0
@@ -88,7 +90,7 @@ struct ClassicRunController {
         var spawnCount = 0
         var projectedEnemyCount = activeEnemyCount
 
-        while timeUntilNextSpawn <= 0, projectedEnemyCount < configuration.maxActiveChasers {
+        while timeUntilNextSpawn <= Self.spawnTimerEpsilon, projectedEnemyCount < configuration.maxActiveChasers {
             spawnCount += 1
             projectedEnemyCount += 1
             timeUntilNextSpawn += configuration.spawnInterval


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow that installs XcodeGen and SwiftLint, generates the project, lints, builds, and runs XCTest on an available iPhone simulator.
- Add a SwiftLint configuration aligned with the current SpriteKit codebase.
- Fix the Classic Survival spawn timer boundary so existing tests pass reliably at exact interval edges.

## Validation
- `xcodegen generate`
- `swiftlint lint --no-cache`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id=F9038B9B-519B-49B6-9531-99DAA4F64D6C' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test`

Closes #23
Closes #24