### PR TITLE
Add run scoring and persistence

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -3,10 +3,13 @@ import SpriteKit
 final class ArenaScene: SKScene {
     private let theme = ArenaTheme.darkTacticalRadar
     private let tiltSettingsStore = TiltSettingsStore()
+    private let runProfileStore = RunProfileStore()
     private var arenaRoot = SKNode()
     private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
     private var movementController = PlayerMovementController()
     private var runController = ClassicRunController()
+    private var runProfile = RunProfile()
+    private var hasPersistedFinalRun = false
     private var spawnPlanner = ChaserSpawnPlanner()
     private let pickupSpawnConfiguration = PickupSpawnConfiguration()
     private var pickupPlanner = PickupSpawnPlanner()
@@ -22,6 +25,7 @@ final class ArenaScene: SKScene {
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let centerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let detailLabel = SKLabelNode(fontNamed: "Menlo")
+    private let comboLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let pauseControlNode = SKNode()
     private let pauseIconNode = SKNode()
     private let resumeIconNode = SKShapeNode()
@@ -39,6 +43,7 @@ final class ArenaScene: SKScene {
     }
 
     override func didMove(to view: SKView) {
+        runProfile = runProfileStore.profile
         rebuildArena()
         configureLabels()
         configurePauseControl()
@@ -168,7 +173,11 @@ final class ArenaScene: SKScene {
         detailLabel.horizontalAlignmentMode = .center
         detailLabel.verticalAlignmentMode = .center
 
-        [timerLabel, centerLabel, detailLabel].forEach { label in
+        configureLabel(comboLabel, fontSize: 14, color: theme.playerAccentColor)
+        comboLabel.horizontalAlignmentMode = .center
+        comboLabel.verticalAlignmentMode = .bottom
+
+        [timerLabel, centerLabel, detailLabel, comboLabel].forEach { label in
             if label.parent == nil {
                 addChild(label)
             }
@@ -201,6 +210,7 @@ final class ArenaScene: SKScene {
         timerLabel.position = CGPoint(x: 24, y: max(24, size.height - 24))
         centerLabel.position = CGPoint(x: size.width / 2, y: size.height / 2 + 24)
         detailLabel.position = CGPoint(x: size.width / 2, y: size.height / 2 - 12)
+        comboLabel.position = CGPoint(x: size.width / 2, y: 24)
     }
 
     private func layoutPauseControl() {
@@ -244,6 +254,7 @@ final class ArenaScene: SKScene {
     }
 
     private func resetActiveRun() {
+        hasPersistedFinalRun = false
         resetGameplayObjects()
         placePlayer(resetPosition: true)
         resetPlayerFeedback()
@@ -276,6 +287,7 @@ final class ArenaScene: SKScene {
         collectPickups(playerPosition: playerPosition)
         advanceChasers(deltaTime: deltaTime, playerPosition: playerPosition)
         updateRazorShield(deltaTime: deltaTime, playerPosition: playerPosition)
+        recordNearMisses(playerPosition: playerPosition)
         detectPlayerCollision(playerPosition: playerPosition)
         updateRunDisplay()
     }
@@ -346,6 +358,10 @@ final class ArenaScene: SKScene {
         }
 
         for pickup in collectedPickups {
+            if isDangerGrab(pickup) {
+                runController.recordDangerGrab(pickupID: pickup.id)
+            }
+
             removePickup(id: pickup.id)
             applyWeapon(pickup.kind, playerPosition: playerPosition)
         }
@@ -373,19 +389,19 @@ final class ArenaScene: SKScene {
             activateRazorShield(at: playerPosition)
         }
 
-        destroyEnemies(ids: resolution.destroyedEnemyIDs)
+        destroyEnemies(ids: resolution.destroyedEnemyIDs, weaponKind: kind)
     }
 
     private func positions(forEnemyIDs enemyIDs: Set<Int>) -> [CGPoint] {
         enemies.compactMap { enemyIDs.contains($0.id) ? $0.position : nil }
     }
 
-    private func destroyEnemies(ids enemyIDs: Set<Int>) {
+    private func destroyEnemies(ids enemyIDs: Set<Int>, weaponKind: WeaponKind?) {
         guard !enemyIDs.isEmpty else {
             return
         }
 
-        runController.recordEnemiesDestroyed(enemyIDs.count)
+        runController.recordEnemyKills(count: enemyIDs.count, weaponKind: weaponKind)
         enemies.removeAll { enemyIDs.contains($0.id) }
 
         for enemyID in enemyIDs {
@@ -431,7 +447,7 @@ final class ArenaScene: SKScene {
             playerPosition: playerPosition,
             enemies: enemies
         )
-        destroyEnemies(ids: targetIDs)
+        destroyEnemies(ids: targetIDs, weaponKind: .razorShield)
 
         razorShieldTimeRemaining = max(0, razorShieldTimeRemaining - max(0, deltaTime))
 
@@ -495,7 +511,12 @@ final class ArenaScene: SKScene {
             return
         }
 
+        finishRun()
+    }
+
+    private func finishRun() {
         runController.endRun()
+        persistFinalRunIfNeeded()
         playDeathFeedback()
         updateRunDisplay()
     }
@@ -513,21 +534,32 @@ final class ArenaScene: SKScene {
     private func updateRunDisplay() {
         switch runController.phase {
         case .preRun:
-            timerLabel.text = formatSurvivalTime(0)
+            timerLabel.text = "BEST \(runProfile.bestScore)"
             centerLabel.text = "TAP TO START"
             detailLabel.text = "CLASSIC SURVIVAL"
+            comboLabel.text = ""
         case .active:
-            timerLabel.text = formatSurvivalTime(runController.survivalTime)
+            timerLabel.text = "SCORE \(runController.score)  \(formatSurvivalTime(runController.survivalTime))"
             centerLabel.text = ""
             detailLabel.text = ""
+            comboLabel.text = formatCombo()
         case .paused:
-            timerLabel.text = formatSurvivalTime(runController.survivalTime)
+            timerLabel.text = "SCORE \(runController.score)  \(formatSurvivalTime(runController.survivalTime))"
             centerLabel.text = "PAUSED"
             detailLabel.text = ""
+            comboLabel.text = formatCombo()
         case .gameOver:
-            timerLabel.text = formatSurvivalTime(runController.survivalTime)
-            centerLabel.text = "GAME OVER"
-            detailLabel.text = "\(formatSurvivalTime(runController.survivalTime))  TAP TO RESTART"
+            timerLabel.text = "BEST \(runProfile.bestScore)"
+
+            if let summary = runController.finalizedSummary {
+                centerLabel.text = "GAME OVER  \(summary.score)"
+                detailLabel.text = "TIME \(formatSurvivalTime(summary.survivalTime))  MAX COMBO \(summary.maxCombo)  PLAY AGAIN"
+                comboLabel.text = "KILLS \(summary.enemiesDestroyed)  WEAPON \(formatWeapon(summary.bestWeapon))"
+            } else {
+                centerLabel.text = "GAME OVER"
+                detailLabel.text = "\(formatSurvivalTime(runController.survivalTime))  PLAY AGAIN"
+                comboLabel.text = ""
+            }
         }
 
         updatePauseControl()
@@ -535,6 +567,23 @@ final class ArenaScene: SKScene {
 
     private func formatSurvivalTime(_ time: TimeInterval) -> String {
         String(format: "%.1fs", time)
+    }
+
+    private func formatCombo() -> String {
+        guard runController.currentCombo > 0 else {
+            return ""
+        }
+
+        return String(
+            format: "COMBO %d  x%d  %.1fs",
+            runController.currentCombo,
+            runController.comboMultiplier,
+            runController.comboTimeRemaining
+        )
+    }
+
+    private func formatWeapon(_ weaponKind: WeaponKind?) -> String {
+        weaponKind?.displayName.uppercased() ?? "NONE"
     }
 
     private func isPauseControlTouch(_ touch: UITouch) -> Bool {
@@ -568,6 +617,49 @@ final class ArenaScene: SKScene {
         case .preRun, .gameOver:
             pauseControlNode.isHidden = true
         }
+    }
+
+    private func recordNearMisses(playerPosition: CGPoint) {
+        let hitCircle = CollisionCircle(
+            center: playerPosition,
+            radius: runController.configuration.playerHitRadius
+        )
+        let nearMissCircle = CollisionCircle(
+            center: playerPosition,
+            radius: runController.configuration.playerHitRadius + runController.configuration.nearMissEdgeGap
+        )
+
+        for enemy in enemies where nearMissCircle.intersects(enemy.collisionCircle) {
+            guard !hitCircle.intersects(enemy.collisionCircle) else {
+                continue
+            }
+
+            runController.recordNearMiss(enemyID: enemy.id)
+        }
+    }
+
+    private func isDangerGrab(_ pickup: WeaponPickup) -> Bool {
+        enemies.contains { enemy in
+            let dangerDistance = runController.configuration.dangerGrabEnemyDistance
+                + pickup.radius
+                + enemy.radius
+            return squaredDistance(from: pickup.position, to: enemy.position) <= dangerDistance * dangerDistance
+        }
+    }
+
+    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy
+    }
+
+    private func persistFinalRunIfNeeded() {
+        guard !hasPersistedFinalRun, let summary = runController.finalizedSummary else {
+            return
+        }
+
+        runProfile = runProfileStore.record(summary)
+        hasPersistedFinalRun = true
     }
 
     private func addPauseControlBackground() {

--- a/TiltArena/Game/Run/ClassicRunController.swift
+++ b/TiltArena/Game/Run/ClassicRunController.swift
@@ -16,10 +16,31 @@ struct ClassicRunConfiguration: Equatable {
     var spawnInterval: TimeInterval = 1.4
     var maxActiveChasers: Int = 40
     var playerSafetyRadius: CGFloat = 120
+    var baseEnemyScore = 10
+    var eliteEnemyScore = 25
+    var formationBonusScore = 100
+    var nearMissScore = 5
+    var dangerGrabScore = 25
+    var comboWindow: TimeInterval = 1.2
+    var killsPerMultiplierStep = 10
+    var survivalBonusStartTime: TimeInterval = 60
+    var survivalBonusInterval: TimeInterval = 10
+    var survivalBonusPointsPerInterval = 10
+    var nearMissEdgeGap: CGFloat = 18
+    var dangerGrabEnemyDistance: CGFloat = 80
 
     var playerHitRadius: CGFloat {
         playerVisualRadius * playerHitRadiusScale
     }
+}
+
+struct RunSummary: Codable, Equatable {
+    let score: Int
+    let survivalTime: TimeInterval
+    let maxCombo: Int
+    let enemiesDestroyed: Int
+    let bestWeapon: WeaponKind?
+    let timestamp: Date
 }
 
 struct ClassicRunController {
@@ -29,7 +50,17 @@ struct ClassicRunController {
     private(set) var phase: ClassicRunPhase = .preRun
     private(set) var survivalTime: TimeInterval = 0
     private(set) var enemiesDestroyed = 0
+    private(set) var score = 0
+    private(set) var currentCombo = 0
+    private(set) var maxCombo = 0
+    private(set) var comboTimeRemaining: TimeInterval = 0
+    private(set) var bestWeapon: WeaponKind?
+    private(set) var finalizedSummary: RunSummary?
     private var timeUntilNextSpawn: TimeInterval = 0
+    private var creditedSurvivalBonusIntervals = 0
+    private var creditedNearMissEnemyIDs: Set<Int> = []
+    private var creditedDangerGrabPickupIDs: Set<Int> = []
+    private var weaponKillCounts: [WeaponKind: Int] = [:]
 
     init(configuration: ClassicRunConfiguration = ClassicRunConfiguration()) {
         self.configuration = configuration
@@ -55,12 +86,20 @@ struct ClassicRunController {
         phase = .active
     }
 
-    mutating func endRun() {
+    mutating func endRun(at timestamp: Date = Date()) {
         guard phase == .active || phase == .paused else {
             return
         }
 
         phase = .gameOver
+        finalizedSummary = RunSummary(
+            score: score,
+            survivalTime: survivalTime,
+            maxCombo: maxCombo,
+            enemiesDestroyed: enemiesDestroyed,
+            bestWeapon: bestWeapon,
+            timestamp: timestamp
+        )
     }
 
     mutating func restart() {
@@ -74,6 +113,8 @@ struct ClassicRunController {
 
         let clampedDelta = max(0, deltaTime)
         survivalTime += clampedDelta
+        updateComboTimer(deltaTime: clampedDelta)
+        applySurvivalBonusIfNeeded()
 
         guard configuration.spawnInterval > 0 else {
             timeUntilNextSpawn = 0
@@ -99,14 +140,147 @@ struct ClassicRunController {
         return spawnCount
     }
 
-    mutating func recordEnemiesDestroyed(_ count: Int) {
-        enemiesDestroyed += max(0, count)
+    mutating func recordEnemyKills(count: Int, weaponKind: WeaponKind?) {
+        guard phase == .active else {
+            return
+        }
+
+        let killCount = max(0, count)
+        guard killCount > 0 else {
+            return
+        }
+
+        for _ in 0..<killCount {
+            recordKill(scoreValue: configuration.baseEnemyScore, weaponKind: weaponKind)
+        }
+    }
+
+    mutating func recordEliteKill(weaponKind: WeaponKind?) {
+        guard phase == .active else {
+            return
+        }
+
+        recordKill(scoreValue: configuration.eliteEnemyScore, weaponKind: weaponKind)
+    }
+
+    mutating func recordFormationBonus(_ bonus: Int? = nil) {
+        guard phase == .active else {
+            return
+        }
+
+        score += max(0, bonus ?? configuration.formationBonusScore)
+    }
+
+    @discardableResult
+    mutating func recordNearMiss(enemyID: Int) -> Bool {
+        guard phase == .active, !creditedNearMissEnemyIDs.contains(enemyID) else {
+            return false
+        }
+
+        creditedNearMissEnemyIDs.insert(enemyID)
+        score += max(0, configuration.nearMissScore)
+        return true
+    }
+
+    @discardableResult
+    mutating func recordDangerGrab(pickupID: Int) -> Bool {
+        guard phase == .active, !creditedDangerGrabPickupIDs.contains(pickupID) else {
+            return false
+        }
+
+        creditedDangerGrabPickupIDs.insert(pickupID)
+        score += max(0, configuration.dangerGrabScore)
+        return true
+    }
+
+    var comboMultiplier: Int {
+        guard currentCombo > 0 else {
+            return 1
+        }
+
+        return multiplier(forComboCount: currentCombo)
     }
 
     private mutating func resetForActiveRun() {
         phase = .active
         survivalTime = 0
         enemiesDestroyed = 0
+        score = 0
+        currentCombo = 0
+        maxCombo = 0
+        comboTimeRemaining = 0
+        bestWeapon = nil
+        finalizedSummary = nil
         timeUntilNextSpawn = 0
+        creditedSurvivalBonusIntervals = 0
+        creditedNearMissEnemyIDs.removeAll()
+        creditedDangerGrabPickupIDs.removeAll()
+        weaponKillCounts.removeAll()
+    }
+
+    private mutating func updateComboTimer(deltaTime: TimeInterval) {
+        guard currentCombo > 0 else {
+            comboTimeRemaining = 0
+            return
+        }
+
+        comboTimeRemaining = max(0, comboTimeRemaining - deltaTime)
+
+        if comboTimeRemaining == 0 {
+            currentCombo = 0
+        }
+    }
+
+    private mutating func applySurvivalBonusIfNeeded() {
+        guard configuration.survivalBonusInterval > 0 else {
+            return
+        }
+
+        guard survivalTime >= configuration.survivalBonusStartTime else {
+            return
+        }
+
+        let elapsedBonusTime = survivalTime - configuration.survivalBonusStartTime
+        let eligibleIntervals = Int(elapsedBonusTime / configuration.survivalBonusInterval)
+        guard eligibleIntervals > creditedSurvivalBonusIntervals else {
+            return
+        }
+
+        let newIntervals = eligibleIntervals - creditedSurvivalBonusIntervals
+        score += newIntervals * max(0, configuration.survivalBonusPointsPerInterval)
+        creditedSurvivalBonusIntervals = eligibleIntervals
+    }
+
+    private mutating func recordKill(scoreValue: Int, weaponKind: WeaponKind?) {
+        let nextCombo = currentCombo + 1
+        score += max(0, scoreValue) * multiplier(forComboCount: nextCombo)
+        currentCombo = nextCombo
+        maxCombo = max(maxCombo, currentCombo)
+        comboTimeRemaining = configuration.comboWindow
+        enemiesDestroyed += 1
+        recordWeaponKills(1, weaponKind: weaponKind)
+    }
+
+    private mutating func recordWeaponKills(_ killCount: Int, weaponKind: WeaponKind?) {
+        guard let weaponKind else {
+            return
+        }
+
+        let updatedCount = weaponKillCounts[weaponKind, default: 0] + killCount
+        weaponKillCounts[weaponKind] = updatedCount
+
+        guard let currentBestWeapon = bestWeapon else {
+            bestWeapon = weaponKind
+            return
+        }
+
+        if updatedCount > weaponKillCounts[currentBestWeapon, default: 0] {
+            bestWeapon = weaponKind
+        }
+    }
+
+    private func multiplier(forComboCount comboCount: Int) -> Int {
+        let step = max(1, configuration.killsPerMultiplierStep)
+        return 1 + max(0, comboCount) / step
     }
 }

--- a/TiltArena/Game/Run/RunProfileStore.swift
+++ b/TiltArena/Game/Run/RunProfileStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct RunProfile: Codable, Equatable {
+    var bestScore = 0
+    var highestCombo = 0
+    var longestSurvivalTime: TimeInterval = 0
+    var totalRuns = 0
+    var totalEnemiesDestroyed = 0
+    var recentRuns: [RunSummary] = []
+
+    mutating func record(_ summary: RunSummary, recentRunLimit: Int = 5) {
+        bestScore = max(bestScore, summary.score)
+        highestCombo = max(highestCombo, summary.maxCombo)
+        longestSurvivalTime = max(longestSurvivalTime, summary.survivalTime)
+        totalRuns += 1
+        totalEnemiesDestroyed += summary.enemiesDestroyed
+
+        recentRuns.insert(summary, at: 0)
+        recentRuns = Array(recentRuns.prefix(max(0, recentRunLimit)))
+    }
+}
+
+final class RunProfileStore {
+    private let defaults: UserDefaults
+    private let profileKey = "tiltArena.runProfile"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var profile: RunProfile {
+        get {
+            guard
+                let data = defaults.data(forKey: profileKey),
+                let profile = try? JSONDecoder().decode(RunProfile.self, from: data)
+            else {
+                return RunProfile()
+            }
+
+            return profile
+        }
+        set {
+            guard let data = try? JSONEncoder().encode(newValue) else {
+                return
+            }
+
+            defaults.set(data, forKey: profileKey)
+        }
+    }
+
+    @discardableResult
+    func record(_ summary: RunSummary) -> RunProfile {
+        var updatedProfile = profile
+        updatedProfile.record(summary)
+        profile = updatedProfile
+        return updatedProfile
+    }
+}

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -1,5 +1,16 @@
-enum WeaponKind: CaseIterable, Equatable {
+enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case shockwave
     case seekerSwarm
     case razorShield
+
+    var displayName: String {
+        switch self {
+        case .shockwave:
+            return "Shockwave"
+        case .seekerSwarm:
+            return "Seeker Swarm"
+        case .razorShield:
+            return "Razor Shield"
+        }
+    }
 }

--- a/TiltArenaTests/ClassicRunControllerTests.swift
+++ b/TiltArenaTests/ClassicRunControllerTests.swift
@@ -124,7 +124,7 @@ final class ClassicRunControllerTests: XCTestCase {
         controller.start()
         controller.recordEnemyKills(count: 12, weaponKind: .seekerSwarm)
 
-        XCTAssertEqual(controller.score, 170)
+        XCTAssertEqual(controller.score, 150)
         XCTAssertEqual(controller.currentCombo, 12)
         XCTAssertEqual(controller.comboMultiplier, 2)
     }

--- a/TiltArenaTests/ClassicRunControllerTests.swift
+++ b/TiltArenaTests/ClassicRunControllerTests.swift
@@ -7,12 +7,16 @@ final class ClassicRunControllerTests: XCTestCase {
 
         controller.start()
         _ = controller.update(deltaTime: 2, activeEnemyCount: 0)
-        controller.recordEnemiesDestroyed(3)
+        controller.recordEnemyKills(count: 3, weaponKind: .shockwave)
         controller.restart()
 
         XCTAssertEqual(controller.phase, .active)
         XCTAssertEqual(controller.survivalTime, 0)
         XCTAssertEqual(controller.enemiesDestroyed, 0)
+        XCTAssertEqual(controller.score, 0)
+        XCTAssertEqual(controller.currentCombo, 0)
+        XCTAssertEqual(controller.maxCombo, 0)
+        XCTAssertNil(controller.finalizedSummary)
     }
 
     func testUpdateOnlyAdvancesWhileActive() {
@@ -62,14 +66,143 @@ final class ClassicRunControllerTests: XCTestCase {
         XCTAssertEqual(controller.phase, .gameOver)
     }
 
-    func testDestroyedEnemyCountIgnoresNegativeCounts() {
+    func testEnemyKillCountIgnoresNegativeCounts() {
         var controller = ClassicRunController()
 
         controller.start()
-        controller.recordEnemiesDestroyed(3)
-        controller.recordEnemiesDestroyed(-1)
+        controller.recordEnemyKills(count: 3, weaponKind: .shockwave)
+        controller.recordEnemyKills(count: -1, weaponKind: .shockwave)
 
         XCTAssertEqual(controller.enemiesDestroyed, 3)
+        XCTAssertEqual(controller.score, 30)
+    }
+
+    func testKillsUpdateScoreComboAndBestWeapon() {
+        var controller = ClassicRunController()
+
+        controller.start()
+        controller.recordEnemyKills(count: 3, weaponKind: .shockwave)
+
+        XCTAssertEqual(controller.score, 30)
+        XCTAssertEqual(controller.enemiesDestroyed, 3)
+        XCTAssertEqual(controller.currentCombo, 3)
+        XCTAssertEqual(controller.maxCombo, 3)
+        XCTAssertEqual(controller.comboTimeRemaining, 1.2, accuracy: 0.0001)
+        XCTAssertEqual(controller.comboMultiplier, 1)
+        XCTAssertEqual(controller.bestWeapon, .shockwave)
+    }
+
+    func testComboExpiresAfterWindowAndPreservesMaxCombo() {
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0)
+        )
+
+        controller.start()
+        controller.recordEnemyKills(count: 2, weaponKind: .seekerSwarm)
+        _ = controller.update(deltaTime: 1.2, activeEnemyCount: 0)
+
+        XCTAssertEqual(controller.currentCombo, 0)
+        XCTAssertEqual(controller.comboTimeRemaining, 0)
+        XCTAssertEqual(controller.maxCombo, 2)
+        XCTAssertEqual(controller.score, 20)
+    }
+
+    func testMultiplierStartsAtTenthChainedKill() {
+        var controller = ClassicRunController()
+
+        controller.start()
+        controller.recordEnemyKills(count: 10, weaponKind: .shockwave)
+
+        XCTAssertEqual(controller.currentCombo, 10)
+        XCTAssertEqual(controller.comboMultiplier, 2)
+        XCTAssertEqual(controller.score, 110)
+    }
+
+    func testBatchKillsCrossMultiplierThresholdSequentially() {
+        var controller = ClassicRunController()
+
+        controller.start()
+        controller.recordEnemyKills(count: 12, weaponKind: .seekerSwarm)
+
+        XCTAssertEqual(controller.score, 170)
+        XCTAssertEqual(controller.currentCombo, 12)
+        XCTAssertEqual(controller.comboMultiplier, 2)
+    }
+
+    func testComboBreakResetsCurrentComboOnly() {
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0)
+        )
+
+        controller.start()
+        controller.recordEnemyKills(count: 10, weaponKind: .shockwave)
+        _ = controller.update(deltaTime: 1.2, activeEnemyCount: 0)
+        controller.recordEnemyKills(count: 1, weaponKind: .razorShield)
+
+        XCTAssertEqual(controller.currentCombo, 1)
+        XCTAssertEqual(controller.maxCombo, 10)
+        XCTAssertEqual(controller.comboMultiplier, 1)
+        XCTAssertEqual(controller.score, 120)
+    }
+
+    func testNearMissAndDangerGrabScoreOncePerID() {
+        var controller = ClassicRunController()
+
+        controller.start()
+
+        XCTAssertTrue(controller.recordNearMiss(enemyID: 7))
+        XCTAssertFalse(controller.recordNearMiss(enemyID: 7))
+        XCTAssertTrue(controller.recordDangerGrab(pickupID: 3))
+        XCTAssertFalse(controller.recordDangerGrab(pickupID: 3))
+
+        XCTAssertEqual(controller.score, 30)
+    }
+
+    func testEliteFormationAndSurvivalBonusHooks() {
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0)
+        )
+
+        controller.start()
+        controller.recordEliteKill(weaponKind: .razorShield)
+        controller.recordFormationBonus()
+        _ = controller.update(deltaTime: 70, activeEnemyCount: 0)
+
+        XCTAssertEqual(controller.score, 135)
+        XCTAssertEqual(controller.enemiesDestroyed, 1)
+        XCTAssertEqual(controller.bestWeapon, .razorShield)
+    }
+
+    func testRunSummaryFinalizesOnceAndResetsOnRestart() {
+        let timestamp = Date(timeIntervalSince1970: 123)
+        var controller = ClassicRunController(
+            configuration: ClassicRunConfiguration(spawnInterval: 0)
+        )
+
+        controller.start()
+        _ = controller.update(deltaTime: 2, activeEnemyCount: 0)
+        controller.recordEnemyKills(count: 2, weaponKind: .seekerSwarm)
+        controller.endRun(at: timestamp)
+        controller.endRun(at: Date(timeIntervalSince1970: 999))
+
+        XCTAssertEqual(
+            controller.finalizedSummary,
+            RunSummary(
+                score: 20,
+                survivalTime: 2,
+                maxCombo: 2,
+                enemiesDestroyed: 2,
+                bestWeapon: .seekerSwarm,
+                timestamp: timestamp
+            )
+        )
+
+        controller.restart()
+
+        XCTAssertEqual(controller.phase, .active)
+        XCTAssertNil(controller.finalizedSummary)
+        XCTAssertEqual(controller.score, 0)
+        XCTAssertEqual(controller.currentCombo, 0)
     }
 
     func testSpawnCountRespectsMaximumEnemies() {

--- a/TiltArenaTests/RunProfileStoreTests.swift
+++ b/TiltArenaTests/RunProfileStoreTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import TiltArena
+
+final class RunProfileStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "RunProfileStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testRunProfilePersistsBestTotalsAndRecentRuns() {
+        let store = RunProfileStore(defaults: defaults)
+
+        for runNumber in 1...6 {
+            store.record(
+                RunSummary(
+                    score: runNumber * 100,
+                    survivalTime: TimeInterval(runNumber * 10),
+                    maxCombo: runNumber,
+                    enemiesDestroyed: runNumber * 3,
+                    bestWeapon: .shockwave,
+                    timestamp: Date(timeIntervalSince1970: TimeInterval(runNumber))
+                )
+            )
+        }
+
+        let reloadedProfile = RunProfileStore(defaults: defaults).profile
+
+        XCTAssertEqual(reloadedProfile.bestScore, 600)
+        XCTAssertEqual(reloadedProfile.highestCombo, 6)
+        XCTAssertEqual(reloadedProfile.longestSurvivalTime, 60)
+        XCTAssertEqual(reloadedProfile.totalRuns, 6)
+        XCTAssertEqual(reloadedProfile.totalEnemiesDestroyed, 63)
+        XCTAssertEqual(reloadedProfile.recentRuns.count, 5)
+        XCTAssertEqual(reloadedProfile.recentRuns.first?.score, 600)
+        XCTAssertEqual(reloadedProfile.recentRuns.last?.score, 200)
+    }
+
+    func testMissingOrCorruptProfileFallsBackToEmptyProfile() {
+        let store = RunProfileStore(defaults: defaults)
+
+        XCTAssertEqual(store.profile, RunProfile())
+
+        defaults.set(Data([0, 1, 2]), forKey: "tiltArena.runProfile")
+
+        XCTAssertEqual(store.profile, RunProfile())
+    }
+}


### PR DESCRIPTION
## Summary
- add run scoring, combo timing, run summaries, and local run profile persistence
- wire score/combo HUD updates, weapon-attributed kills, near-miss scoring, danger-grab scoring, and one-shot post-run persistence
- add focused tests for scoring, combo expiry, run summaries, and profile storage

## Validation
- `git diff --check`
- `xcodegen generate`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`

Note: local test execution is blocked because CoreSimulator only reports placeholder destinations.

Closes #7