### PR TITLE
Add Hunter Dot enemy pattern

### DIFF
--- a/TiltArena/Game/Enemies/ArenaEnemy.swift
+++ b/TiltArena/Game/Enemies/ArenaEnemy.swift
@@ -6,6 +6,7 @@ enum EnemyBehavior: Equatable {
     case formationLine(velocity: CGVector, formationID: Int)
     case arrowRush(velocity: CGVector)
     case mineDot
+    case hunterDot(predictionLead: CGFloat, previousTarget: CGPoint?)
 }
 
 struct ArenaEnemy: Equatable, Identifiable {
@@ -17,7 +18,7 @@ struct ArenaEnemy: Equatable, Identifiable {
 
     var formationID: Int? {
         switch behavior {
-        case .chaser, .arrowRush, .mineDot:
+        case .chaser, .arrowRush, .mineDot, .hunterDot:
             return nil
         case let .formationLine(_, formationID):
             return formationID
@@ -26,7 +27,7 @@ struct ArenaEnemy: Equatable, Identifiable {
 
     var isLinearPatternEnemy: Bool {
         switch behavior {
-        case .chaser, .mineDot:
+        case .chaser, .mineDot, .hunterDot:
             return false
         case .formationLine, .arrowRush:
             return true
@@ -35,6 +36,14 @@ struct ArenaEnemy: Equatable, Identifiable {
 
     var isMineDot: Bool {
         behavior == .mineDot
+    }
+
+    var isHunterDot: Bool {
+        guard case .hunterDot = behavior else {
+            return false
+        }
+
+        return true
     }
 
     var collisionCircle: CollisionCircle {
@@ -53,6 +62,8 @@ struct ArenaEnemy: Equatable, Identifiable {
             advanceLinearly(velocity: velocity, deltaTime: clampedDelta)
         case .mineDot:
             return
+        case let .hunterDot(predictionLead, previousTarget):
+            advanceHunter(toward: target, predictionLead: predictionLead, previousTarget: previousTarget, deltaTime: clampedDelta)
         }
     }
 
@@ -82,5 +93,26 @@ struct ArenaEnemy: Equatable, Identifiable {
             x: position.x + (dx / distance) * step,
             y: position.y + (dy / distance) * step
         )
+    }
+
+    private mutating func advanceHunter(
+        toward target: CGPoint,
+        predictionLead: CGFloat,
+        previousTarget: CGPoint?,
+        deltaTime: CGFloat
+    ) {
+        let predictedTarget: CGPoint
+
+        if let previousTarget {
+            predictedTarget = CGPoint(
+                x: target.x + (target.x - previousTarget.x) * max(0, predictionLead),
+                y: target.y + (target.y - previousTarget.y) * max(0, predictionLead)
+            )
+        } else {
+            predictedTarget = target
+        }
+
+        advanceChaser(toward: predictedTarget, deltaTime: deltaTime)
+        behavior = .hunterDot(predictionLead: predictionLead, previousTarget: target)
     }
 }

--- a/TiltArena/Game/Enemies/EnemyNode.swift
+++ b/TiltArena/Game/Enemies/EnemyNode.swift
@@ -29,6 +29,11 @@ final class EnemyNode: SKNode {
             ringNode.lineWidth = 2
             bodyNode.fillColor = theme.enemyColor.withAlphaComponent(0.82)
             bodyNode.glowWidth = 1.5
+        } else if enemy.isHunterDot {
+            ringNode.strokeColor = theme.enemyColor.withAlphaComponent(0.9)
+            ringNode.lineWidth = 1.8
+            ringNode.glowWidth = 2
+            bodyNode.strokeColor = theme.enemyColor
         }
 
         apply(enemy)

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+ArrowRush.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+ArrowRush.swift
@@ -1,0 +1,202 @@
+import CoreGraphics
+import Foundation
+
+extension EnemySpawnDirector {
+    mutating func spawnArrowRushTelegraphIfNeeded(
+        deltaTime: TimeInterval,
+        projectedEnemyCount: Int,
+        tuning: EnemyPhaseTuning,
+        playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        frame: inout EnemySpawnFrame
+    ) {
+        guard deltaTime > 0, let arrowRushSpawnInterval = tuning.arrowRushSpawnInterval else {
+            timeUntilNextArrowRush = 0
+            return
+        }
+
+        let configuredEnemyCount = max(0, tuning.arrowRushEnemyCount)
+        guard arrowRushSpawnInterval > 0, configuredEnemyCount > 0 else {
+            return
+        }
+
+        let requiredEnemyCount = requiredArrowRushEnemyCount(configuredEnemyCount: configuredEnemyCount)
+
+        guard pendingSpawns.count < configuration.maxPendingEnemyTelegraphs else {
+            timeUntilNextArrowRush = max(timeUntilNextArrowRush, arrowRushSpawnInterval)
+            return
+        }
+
+        guard projectedEnemyCount + requiredEnemyCount <= tuning.maxActiveEnemies else {
+            timeUntilNextArrowRush = max(timeUntilNextArrowRush, arrowRushSpawnInterval)
+            return
+        }
+
+        timeUntilNextArrowRush -= deltaTime
+
+        guard timeUntilNextArrowRush <= 0 else {
+            return
+        }
+
+        let availableSlots = tuning.maxActiveEnemies - projectedEnemyCount
+        guard let arrowRush = makePendingArrowRush(
+            in: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            tuning: tuning,
+            enemyCount: min(configuredEnemyCount, availableSlots),
+            requiredEnemyCount: requiredEnemyCount
+        ) else {
+            timeUntilNextArrowRush = arrowRushSpawnInterval
+            return
+        }
+
+        pendingSpawns[arrowRush.telegraph.id] = arrowRush
+        frame.telegraphsToShow.append(arrowRush.telegraph)
+        timeUntilNextArrowRush += arrowRushSpawnInterval
+    }
+
+    private mutating func makePendingArrowRush(
+        in playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        tuning: EnemyPhaseTuning,
+        enemyCount: Int,
+        requiredEnemyCount: Int
+    ) -> PendingEnemySpawn? {
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return nil
+        }
+
+        let direction = nextArrowRushDirection()
+        let telegraphID = nextTelegraphID
+        var nextID = nextEnemyID
+        var enemies: [ArenaEnemy] = []
+        var segments: [EnemyTelegraphSegment] = []
+
+        for position in arrowRushSpawnPositions(
+            direction: direction,
+            enemyCount: enemyCount,
+            playableRect: playableRect,
+            targetPosition: playerPosition
+        ) where isSafeSpawn(position, avoiding: playerPosition, pickupCircles: pickupCircles) {
+            guard let velocity = normalizedVelocity(
+                from: position,
+                to: playerPosition,
+                speed: tuning.arrowRushSpeed
+            ) else {
+                continue
+            }
+
+            enemies.append(ArenaEnemy(
+                id: nextID,
+                position: position,
+                radius: configuration.enemyRadius,
+                speed: tuning.arrowRushSpeed,
+                behavior: .arrowRush(velocity: velocity)
+            ))
+            segments.append(EnemyTelegraphSegment(
+                start: position,
+                end: arrowRushTelegraphEnd(from: position, velocity: velocity, playableRect: playableRect)
+            ))
+            nextID += 1
+        }
+
+        guard enemies.count >= requiredEnemyCount else {
+            return nil
+        }
+
+        nextEnemyID += enemies.count
+        nextTelegraphID += 1
+
+        return PendingEnemySpawn(
+            timeRemaining: configuration.arrowRushTelegraphDuration,
+            requiredEnemyCount: requiredEnemyCount,
+            enemies: enemies,
+            telegraph: EnemyTelegraph(id: telegraphID, segments: segments)
+        )
+    }
+
+    private mutating func nextArrowRushDirection() -> EdgeDirection {
+        let directions = EdgeDirection.allCases
+        let direction = directions[nextArrowRushDirectionIndex % directions.count]
+        nextArrowRushDirectionIndex += 1
+        return direction
+    }
+
+    private func arrowRushSpawnPositions(
+        direction: EdgeDirection,
+        enemyCount: Int,
+        playableRect: CGRect,
+        targetPosition: CGPoint
+    ) -> [CGPoint] {
+        guard enemyCount > 0 else {
+            return []
+        }
+
+        let targetX = min(playableRect.maxX, max(playableRect.minX, targetPosition.x))
+        let targetY = min(playableRect.maxY, max(playableRect.minY, targetPosition.y))
+        let spawnOffset = configuration.enemyRadius + configuration.arrowRushSpawnOffset
+        let basePosition: CGPoint
+        let perpendicular: CGVector
+
+        switch direction {
+        case .leftToRight:
+            basePosition = CGPoint(x: playableRect.minX - spawnOffset, y: targetY)
+            perpendicular = CGVector(dx: 0, dy: 1)
+        case .rightToLeft:
+            basePosition = CGPoint(x: playableRect.maxX + spawnOffset, y: targetY)
+            perpendicular = CGVector(dx: 0, dy: 1)
+        case .bottomToTop:
+            basePosition = CGPoint(x: targetX, y: playableRect.minY - spawnOffset)
+            perpendicular = CGVector(dx: 1, dy: 0)
+        case .topToBottom:
+            basePosition = CGPoint(x: targetX, y: playableRect.maxY + spawnOffset)
+            perpendicular = CGVector(dx: 1, dy: 0)
+        }
+
+        return (0..<enemyCount).map { index in
+            let offset = (CGFloat(index) - CGFloat(enemyCount - 1) / 2) * configuration.arrowRushEnemySpacing
+            return CGPoint(
+                x: basePosition.x + perpendicular.dx * offset,
+                y: basePosition.y + perpendicular.dy * offset
+            )
+        }
+    }
+
+    private func arrowRushTelegraphEnd(
+        from start: CGPoint,
+        velocity: CGVector,
+        playableRect: CGRect
+    ) -> CGPoint {
+        let speed = max(1, hypot(velocity.dx, velocity.dy))
+        let cullingRect = playableRect.insetBy(
+            dx: -configuration.cullingOutset,
+            dy: -configuration.cullingOutset
+        )
+        let travelDistance = hypot(cullingRect.width, cullingRect.height)
+
+        return CGPoint(
+            x: start.x + velocity.dx / speed * travelDistance,
+            y: start.y + velocity.dy / speed * travelDistance
+        )
+    }
+
+    private func normalizedVelocity(from start: CGPoint, to target: CGPoint, speed: CGFloat) -> CGVector? {
+        let dx = target.x - start.x
+        let dy = target.y - start.y
+        let distance = hypot(dx, dy)
+        let clampedSpeed = max(0, speed)
+
+        guard distance > 0, clampedSpeed > 0 else {
+            return nil
+        }
+
+        return CGVector(dx: dx / distance * clampedSpeed, dy: dy / distance * clampedSpeed)
+    }
+
+    private func requiredArrowRushEnemyCount(configuredEnemyCount: Int) -> Int {
+        min(max(1, configuration.minimumArrowRushEnemyCount), configuredEnemyCount)
+    }
+}

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+HunterDot.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+HunterDot.swift
@@ -1,0 +1,129 @@
+import CoreGraphics
+import Foundation
+
+extension EnemySpawnDirector {
+    mutating func spawnHunterDotTelegraphIfNeeded(
+        deltaTime: TimeInterval,
+        tuning: EnemyPhaseTuning,
+        playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        activeEnemies: [ArenaEnemy],
+        frame: inout EnemySpawnFrame
+    ) {
+        guard deltaTime > 0, let hunterDotSpawnInterval = tuning.hunterDotSpawnInterval else {
+            timeUntilNextHunterDot = 0
+            return
+        }
+
+        guard hunterDotSpawnInterval > 0, tuning.maxActiveHunterDots > 0, tuning.hunterDotSpeed > 0 else {
+            return
+        }
+
+        guard pendingSpawns.count < configuration.maxPendingEnemyTelegraphs else {
+            timeUntilNextHunterDot = max(timeUntilNextHunterDot, hunterDotSpawnInterval)
+            return
+        }
+
+        let activeAndNewEnemies = activeEnemies + frame.newEnemies
+        let projectedEnemyCount = activeAndNewEnemies.count + pendingEnemyCount
+        let projectedHunterDotCount = activeAndNewEnemies.filter(\.isHunterDot).count + pendingHunterDotCount
+
+        guard projectedEnemyCount + 1 <= tuning.maxActiveEnemies,
+              projectedHunterDotCount < tuning.maxActiveHunterDots else {
+            timeUntilNextHunterDot = max(timeUntilNextHunterDot, hunterDotSpawnInterval)
+            return
+        }
+
+        timeUntilNextHunterDot -= deltaTime
+
+        guard timeUntilNextHunterDot <= 0 else {
+            return
+        }
+
+        guard let hunterDot = makePendingHunterDot(
+            in: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            tuning: tuning
+        ) else {
+            timeUntilNextHunterDot = hunterDotSpawnInterval
+            return
+        }
+
+        pendingSpawns[hunterDot.telegraph.id] = hunterDot
+        frame.telegraphsToShow.append(hunterDot.telegraph)
+        timeUntilNextHunterDot += hunterDotSpawnInterval
+    }
+
+    private mutating func makePendingHunterDot(
+        in playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        tuning: EnemyPhaseTuning
+    ) -> PendingEnemySpawn? {
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return nil
+        }
+
+        let candidateCount = Self.candidateSideCount * Self.candidateLaneCount
+
+        for _ in 0..<candidateCount {
+            let position = candidatePosition(in: playableRect, index: nextHunterDotCandidateIndex)
+            nextHunterDotCandidateIndex += 1
+
+            guard isSafeSpawn(position, avoiding: playerPosition, pickupCircles: pickupCircles) else {
+                continue
+            }
+
+            let enemy = ArenaEnemy(
+                id: nextEnemyID,
+                position: position,
+                radius: configuration.enemyRadius,
+                speed: tuning.hunterDotSpeed,
+                behavior: .hunterDot(predictionLead: tuning.hunterDotPredictionLead, previousTarget: nil)
+            )
+            let telegraph = EnemyTelegraph(
+                id: nextTelegraphID,
+                segments: hunterDotTelegraphSegments(center: position)
+            )
+
+            nextEnemyID += 1
+            nextTelegraphID += 1
+
+            return PendingEnemySpawn(
+                timeRemaining: configuration.hunterDotTelegraphDuration,
+                requiredEnemyCount: 1,
+                enemies: [enemy],
+                telegraph: telegraph
+            )
+        }
+
+        return nil
+    }
+
+    private func hunterDotTelegraphSegments(center: CGPoint) -> [EnemyTelegraphSegment] {
+        let radius = configuration.enemyRadius * 2.3
+        let horizontalInset = radius * 0.35
+        let verticalInset = radius * 0.35
+
+        return [
+            EnemyTelegraphSegment(
+                start: CGPoint(x: center.x - radius, y: center.y),
+                end: CGPoint(x: center.x - horizontalInset, y: center.y)
+            ),
+            EnemyTelegraphSegment(
+                start: CGPoint(x: center.x + horizontalInset, y: center.y),
+                end: CGPoint(x: center.x + radius, y: center.y)
+            ),
+            EnemyTelegraphSegment(
+                start: CGPoint(x: center.x, y: center.y - radius),
+                end: CGPoint(x: center.x, y: center.y - verticalInset)
+            ),
+            EnemyTelegraphSegment(
+                start: CGPoint(x: center.x, y: center.y + verticalInset),
+                end: CGPoint(x: center.x, y: center.y + radius)
+            )
+        ]
+    }
+}

--- a/TiltArena/Game/Enemies/EnemySpawnDirector.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector.swift
@@ -47,6 +47,10 @@ struct EnemyPhaseTuning: Equatable {
     var arrowRushEnemyCount: Int = 0
     var mineDotSpawnInterval: TimeInterval?
     var maxActiveMineDots: Int = 0
+    var hunterDotSpawnInterval: TimeInterval?
+    var hunterDotSpeed: CGFloat = 0
+    var hunterDotPredictionLead: CGFloat = 0
+    var maxActiveHunterDots: Int = 0
 }
 
 struct EnemySpawnConfiguration: Equatable {
@@ -67,6 +71,7 @@ struct EnemySpawnConfiguration: Equatable {
     var mineDotPickupGuardDistance: CGFloat = 44
     var mineDotCandidateInset: CGFloat = 48
     var mineDotMinimumSpacing: CGFloat = 52
+    var hunterDotTelegraphDuration: TimeInterval = 0.75
     var maxPendingEnemyTelegraphs = 2
     var cullingOutset: CGFloat = 72
     var warmup = EnemyPhaseTuning(
@@ -80,7 +85,11 @@ struct EnemySpawnConfiguration: Equatable {
         arrowRushSpeed: 0,
         arrowRushEnemyCount: 0,
         mineDotSpawnInterval: nil,
-        maxActiveMineDots: 0
+        maxActiveMineDots: 0,
+        hunterDotSpawnInterval: nil,
+        hunterDotSpeed: 0,
+        hunterDotPredictionLead: 0,
+        maxActiveHunterDots: 0
     )
     var pressure = EnemyPhaseTuning(
         chaserSpawnInterval: 1.05,
@@ -93,7 +102,11 @@ struct EnemySpawnConfiguration: Equatable {
         arrowRushSpeed: 0,
         arrowRushEnemyCount: 0,
         mineDotSpawnInterval: nil,
-        maxActiveMineDots: 0
+        maxActiveMineDots: 0,
+        hunterDotSpawnInterval: nil,
+        hunterDotSpeed: 0,
+        hunterDotPredictionLead: 0,
+        maxActiveHunterDots: 0
     )
     var chaos = EnemyPhaseTuning(
         chaserSpawnInterval: 0.75,
@@ -106,7 +119,11 @@ struct EnemySpawnConfiguration: Equatable {
         arrowRushSpeed: 150,
         arrowRushEnemyCount: 3,
         mineDotSpawnInterval: 14,
-        maxActiveMineDots: 4
+        maxActiveMineDots: 4,
+        hunterDotSpawnInterval: 18,
+        hunterDotSpeed: 108,
+        hunterDotPredictionLead: 0.6,
+        maxActiveHunterDots: 2
     )
     var survivalHell = EnemyPhaseTuning(
         chaserSpawnInterval: 0.5,
@@ -119,7 +136,11 @@ struct EnemySpawnConfiguration: Equatable {
         arrowRushSpeed: 175,
         arrowRushEnemyCount: 5,
         mineDotSpawnInterval: 10,
-        maxActiveMineDots: 7
+        maxActiveMineDots: 7,
+        hunterDotSpawnInterval: 13,
+        hunterDotSpeed: 132,
+        hunterDotPredictionLead: 0.9,
+        maxActiveHunterDots: 3
     )
 
     func tuning(at survivalTime: TimeInterval) -> EnemyPhaseTuning {
@@ -173,6 +194,24 @@ struct EnemySpawnConfiguration: Equatable {
                 round(interpolate(
                     from: CGFloat(current.tuning.maxActiveMineDots),
                     to: CGFloat(next?.tuning.maxActiveMineDots ?? current.tuning.maxActiveMineDots),
+                    progress: progress
+                ))
+            )),
+            hunterDotSpawnInterval: current.tuning.hunterDotSpawnInterval,
+            hunterDotSpeed: interpolate(
+                from: current.tuning.hunterDotSpeed,
+                to: next?.tuning.hunterDotSpeed ?? current.tuning.hunterDotSpeed,
+                progress: progress
+            ),
+            hunterDotPredictionLead: interpolate(
+                from: current.tuning.hunterDotPredictionLead,
+                to: next?.tuning.hunterDotPredictionLead ?? current.tuning.hunterDotPredictionLead,
+                progress: progress
+            ),
+            maxActiveHunterDots: max(0, Int(
+                round(interpolate(
+                    from: CGFloat(current.tuning.maxActiveHunterDots),
+                    to: CGFloat(next?.tuning.maxActiveHunterDots ?? current.tuning.maxActiveHunterDots),
                     progress: progress
                 ))
             ))
@@ -232,7 +271,7 @@ struct EnemySpawnFrame: Equatable {
 }
 
 struct EnemySpawnDirector {
-    private enum EdgeDirection: CaseIterable {
+    enum EdgeDirection: CaseIterable {
         case leftToRight
         case rightToLeft
         case bottomToTop
@@ -255,8 +294,8 @@ struct EnemySpawnDirector {
         let telegraph: EnemyTelegraph
     }
 
-    private static let candidateSideCount = 4
-    private static let candidateLaneCount = 7
+    static let candidateSideCount = 4
+    static let candidateLaneCount = 7
 
     var configuration: EnemySpawnConfiguration
     var nextEnemyID = 1
@@ -264,12 +303,14 @@ struct EnemySpawnDirector {
     var nextTelegraphID = 1
     private var nextChaserCandidateIndex = 0
     private var nextFormationDirectionIndex = 0
-    private var nextArrowRushDirectionIndex = 0
+    var nextArrowRushDirectionIndex = 0
     var nextMineDotCandidateIndex = 0
+    var nextHunterDotCandidateIndex = 0
     private var timeUntilNextChaser: TimeInterval = 0
     private var timeUntilNextFormation: TimeInterval = 0
-    private var timeUntilNextArrowRush: TimeInterval = 0
+    var timeUntilNextArrowRush: TimeInterval = 0
     var timeUntilNextMineDot: TimeInterval = 0
+    var timeUntilNextHunterDot: TimeInterval = 0
     var pendingSpawns: [Int: PendingEnemySpawn] = [:]
 
     var pendingEnemyCount: Int {
@@ -279,6 +320,12 @@ struct EnemySpawnDirector {
     var pendingMineDotCount: Int {
         pendingSpawns.values.reduce(0) { count, pendingSpawn in
             count + pendingSpawn.enemies.filter(\.isMineDot).count
+        }
+    }
+
+    var pendingHunterDotCount: Int {
+        pendingSpawns.values.reduce(0) { count, pendingSpawn in
+            count + pendingSpawn.enemies.filter(\.isHunterDot).count
         }
     }
 
@@ -294,10 +341,12 @@ struct EnemySpawnDirector {
         nextFormationDirectionIndex = 0
         nextArrowRushDirectionIndex = 0
         nextMineDotCandidateIndex = 0
+        nextHunterDotCandidateIndex = 0
         timeUntilNextChaser = 0
         timeUntilNextFormation = 0
         timeUntilNextArrowRush = 0
         timeUntilNextMineDot = 0
+        timeUntilNextHunterDot = 0
         pendingSpawns.removeAll()
     }
 
@@ -352,6 +401,16 @@ struct EnemySpawnDirector {
         )
 
         spawnMineDotTelegraphIfNeeded(
+            deltaTime: clampedDelta,
+            tuning: tuning,
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            activeEnemies: activeEnemies,
+            frame: &frame
+        )
+
+        spawnHunterDotTelegraphIfNeeded(
             deltaTime: clampedDelta,
             tuning: tuning,
             playableRect: playableRect,
@@ -599,122 +658,6 @@ struct EnemySpawnDirector {
         )
     }
 
-    private mutating func spawnArrowRushTelegraphIfNeeded(
-        deltaTime: TimeInterval,
-        projectedEnemyCount: Int,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
-        frame: inout EnemySpawnFrame
-    ) {
-        guard deltaTime > 0, let arrowRushSpawnInterval = tuning.arrowRushSpawnInterval else {
-            timeUntilNextArrowRush = 0
-            return
-        }
-
-        let configuredEnemyCount = max(0, tuning.arrowRushEnemyCount)
-        guard arrowRushSpawnInterval > 0, configuredEnemyCount > 0 else {
-            return
-        }
-
-        let requiredEnemyCount = requiredArrowRushEnemyCount(configuredEnemyCount: configuredEnemyCount)
-
-        guard pendingSpawns.count < configuration.maxPendingEnemyTelegraphs else {
-            timeUntilNextArrowRush = max(timeUntilNextArrowRush, arrowRushSpawnInterval)
-            return
-        }
-
-        guard projectedEnemyCount + requiredEnemyCount <= tuning.maxActiveEnemies else {
-            timeUntilNextArrowRush = max(timeUntilNextArrowRush, arrowRushSpawnInterval)
-            return
-        }
-
-        timeUntilNextArrowRush -= deltaTime
-
-        guard timeUntilNextArrowRush <= 0 else {
-            return
-        }
-
-        let availableSlots = tuning.maxActiveEnemies - projectedEnemyCount
-        guard let arrowRush = makePendingArrowRush(
-            in: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            tuning: tuning,
-            enemyCount: min(configuredEnemyCount, availableSlots),
-            requiredEnemyCount: requiredEnemyCount
-        ) else {
-            timeUntilNextArrowRush = arrowRushSpawnInterval
-            return
-        }
-
-        pendingSpawns[arrowRush.telegraph.id] = arrowRush
-        frame.telegraphsToShow.append(arrowRush.telegraph)
-        timeUntilNextArrowRush += arrowRushSpawnInterval
-    }
-
-    private mutating func makePendingArrowRush(
-        in playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
-        tuning: EnemyPhaseTuning,
-        enemyCount: Int,
-        requiredEnemyCount: Int
-    ) -> PendingEnemySpawn? {
-        guard playableRect.width > 0, playableRect.height > 0 else {
-            return nil
-        }
-
-        let direction = nextArrowRushDirection()
-        let telegraphID = nextTelegraphID
-        var nextID = nextEnemyID
-        var enemies: [ArenaEnemy] = []
-        var segments: [EnemyTelegraphSegment] = []
-
-        for position in arrowRushSpawnPositions(
-            direction: direction,
-            enemyCount: enemyCount,
-            playableRect: playableRect,
-            targetPosition: playerPosition
-        ) where isSafeSpawn(position, avoiding: playerPosition, pickupCircles: pickupCircles) {
-            guard let velocity = normalizedVelocity(
-                from: position,
-                to: playerPosition,
-                speed: tuning.arrowRushSpeed
-            ) else {
-                continue
-            }
-
-            enemies.append(ArenaEnemy(
-                id: nextID,
-                position: position,
-                radius: configuration.enemyRadius,
-                speed: tuning.arrowRushSpeed,
-                behavior: .arrowRush(velocity: velocity)
-            ))
-            segments.append(EnemyTelegraphSegment(
-                start: position,
-                end: arrowRushTelegraphEnd(from: position, velocity: velocity, playableRect: playableRect)
-            ))
-            nextID += 1
-        }
-
-        guard enemies.count >= requiredEnemyCount else {
-            return nil
-        }
-
-        nextEnemyID += enemies.count
-        nextTelegraphID += 1
-
-        return PendingEnemySpawn(
-            timeRemaining: configuration.arrowRushTelegraphDuration,
-            requiredEnemyCount: requiredEnemyCount,
-            enemies: enemies,
-            telegraph: EnemyTelegraph(id: telegraphID, segments: segments)
-        )
-    }
-
     private mutating func nextFormationDirection() -> EdgeDirection {
         let directions = EdgeDirection.allCases
         let direction = directions[nextFormationDirectionIndex % directions.count]
@@ -722,14 +665,7 @@ struct EnemySpawnDirector {
         return direction
     }
 
-    private mutating func nextArrowRushDirection() -> EdgeDirection {
-        let directions = EdgeDirection.allCases
-        let direction = directions[nextArrowRushDirectionIndex % directions.count]
-        nextArrowRushDirectionIndex += 1
-        return direction
-    }
-
-    private func candidatePosition(in rect: CGRect, index: Int) -> CGPoint {
+    func candidatePosition(in rect: CGRect, index: Int) -> CGPoint {
         let side = index % Self.candidateSideCount
         let lane = CGFloat(((index / Self.candidateSideCount) % Self.candidateLaneCount) + 1)
             / CGFloat(Self.candidateLaneCount + 1)
@@ -858,64 +794,6 @@ struct EnemySpawnDirector {
         }
     }
 
-    private func arrowRushSpawnPositions(
-        direction: EdgeDirection,
-        enemyCount: Int,
-        playableRect: CGRect,
-        targetPosition: CGPoint
-    ) -> [CGPoint] {
-        guard enemyCount > 0 else {
-            return []
-        }
-
-        let targetX = min(playableRect.maxX, max(playableRect.minX, targetPosition.x))
-        let targetY = min(playableRect.maxY, max(playableRect.minY, targetPosition.y))
-        let spawnOffset = configuration.enemyRadius + configuration.arrowRushSpawnOffset
-        let basePosition: CGPoint
-        let perpendicular: CGVector
-
-        switch direction {
-        case .leftToRight:
-            basePosition = CGPoint(x: playableRect.minX - spawnOffset, y: targetY)
-            perpendicular = CGVector(dx: 0, dy: 1)
-        case .rightToLeft:
-            basePosition = CGPoint(x: playableRect.maxX + spawnOffset, y: targetY)
-            perpendicular = CGVector(dx: 0, dy: 1)
-        case .bottomToTop:
-            basePosition = CGPoint(x: targetX, y: playableRect.minY - spawnOffset)
-            perpendicular = CGVector(dx: 1, dy: 0)
-        case .topToBottom:
-            basePosition = CGPoint(x: targetX, y: playableRect.maxY + spawnOffset)
-            perpendicular = CGVector(dx: 1, dy: 0)
-        }
-
-        return (0..<enemyCount).map { index in
-            let offset = (CGFloat(index) - CGFloat(enemyCount - 1) / 2) * configuration.arrowRushEnemySpacing
-            return CGPoint(
-                x: basePosition.x + perpendicular.dx * offset,
-                y: basePosition.y + perpendicular.dy * offset
-            )
-        }
-    }
-
-    private func arrowRushTelegraphEnd(
-        from start: CGPoint,
-        velocity: CGVector,
-        playableRect: CGRect
-    ) -> CGPoint {
-        let speed = max(1, hypot(velocity.dx, velocity.dy))
-        let cullingRect = playableRect.insetBy(
-            dx: -configuration.cullingOutset,
-            dy: -configuration.cullingOutset
-        )
-        let travelDistance = hypot(cullingRect.width, cullingRect.height)
-
-        return CGPoint(
-            x: start.x + velocity.dx / speed * travelDistance,
-            y: start.y + velocity.dy / speed * travelDistance
-        )
-    }
-
     private func laneCoordinate(
         laneIndex: Int,
         laneCount: Int,
@@ -945,19 +823,6 @@ struct EnemySpawnDirector {
         }
     }
 
-    private func normalizedVelocity(from start: CGPoint, to target: CGPoint, speed: CGFloat) -> CGVector? {
-        let dx = target.x - start.x
-        let dy = target.y - start.y
-        let distance = hypot(dx, dy)
-        let clampedSpeed = max(0, speed)
-
-        guard distance > 0, clampedSpeed > 0 else {
-            return nil
-        }
-
-        return CGVector(dx: dx / distance * clampedSpeed, dy: dy / distance * clampedSpeed)
-    }
-
     func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
         let dx = lhs.x - rhs.x
         let dy = lhs.y - rhs.y
@@ -968,7 +833,4 @@ struct EnemySpawnDirector {
         max(1, configuration.minimumFormationEnemyCount)
     }
 
-    private func requiredArrowRushEnemyCount(configuredEnemyCount: Int) -> Int {
-        min(max(1, configuration.minimumArrowRushEnemyCount), configuredEnemyCount)
-    }
 }

--- a/TiltArenaTests/ArenaEnemyTests.swift
+++ b/TiltArenaTests/ArenaEnemyTests.swift
@@ -74,6 +74,24 @@ final class ArenaEnemyTests: XCTestCase {
         XCTAssertTrue(enemy.isMineDot)
     }
 
+    func testHunterDotUsesPredictedPlayerPosition() {
+        var enemy = ArenaEnemy(
+            id: 1,
+            position: CGPoint(x: 0, y: 0),
+            radius: 8,
+            speed: 100,
+            behavior: .hunterDot(predictionLead: 1, previousTarget: CGPoint(x: 100, y: 0))
+        )
+
+        enemy.advance(toward: CGPoint(x: 100, y: 100), deltaTime: 1)
+
+        XCTAssertEqual(enemy.position.x, 44.7214, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 89.4427, accuracy: 0.0001)
+        XCTAssertNil(enemy.formationID)
+        XCTAssertFalse(enemy.isLinearPatternEnemy)
+        XCTAssertTrue(enemy.isHunterDot)
+    }
+
     func testCircleCollisionUsesCombinedRadii() {
         let player = CollisionCircle(center: CGPoint(x: 0, y: 0), radius: 9)
         let touchingEnemy = CollisionCircle(center: CGPoint(x: 17, y: 0), radius: 8)

--- a/TiltArenaTests/EnemySpawnDirectorHunterDotTests.swift
+++ b/TiltArenaTests/EnemySpawnDirectorHunterDotTests.swift
@@ -1,0 +1,369 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class EnemySpawnDirectorHunterDotTests: XCTestCase {
+    func testHunterDotDoesNotTelegraphBeforeChaos() {
+        var director = EnemySpawnDirector(configuration: hunterDotTestConfiguration())
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+
+        let pressureFrame = director.update(
+            deltaTime: 100,
+            survivalTime: 89.9,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: CGPoint(x: 150, y: 150),
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(pressureFrame.telegraphsToShow.isEmpty)
+
+        let chaosFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: CGPoint(x: 150, y: 150),
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(chaosFrame.telegraphsToShow.count, 1)
+        XCTAssertTrue(chaosFrame.newEnemies.isEmpty)
+    }
+
+    func testHunterDotUsesChaosAndSurvivalHellDefaults() {
+        let configuration = EnemySpawnConfiguration()
+        let chaos = configuration.tuning(at: 90)
+        let survivalHell = configuration.tuning(at: 180)
+
+        XCTAssertEqual(chaos.hunterDotSpawnInterval, 18)
+        XCTAssertEqual(chaos.hunterDotSpeed, 108, accuracy: 0.0001)
+        XCTAssertEqual(chaos.hunterDotPredictionLead, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(chaos.maxActiveHunterDots, 2)
+        XCTAssertEqual(survivalHell.hunterDotSpawnInterval, 13)
+        XCTAssertEqual(survivalHell.hunterDotSpeed, 132, accuracy: 0.0001)
+        XCTAssertEqual(survivalHell.hunterDotPredictionLead, 0.9, accuracy: 0.0001)
+        XCTAssertEqual(survivalHell.maxActiveHunterDots, 3)
+    }
+
+    func testHunterDotTelegraphsBeforeSpawningAndUsesPredictionBehavior() throws {
+        var configuration = hunterDotTestConfiguration()
+        configuration.hunterDotTelegraphDuration = 0.75
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+        XCTAssertEqual(telegraphFrame.telegraphsToShow[0].segments.count, 4)
+        XCTAssertTrue(telegraphFrame.newEnemies.isEmpty)
+
+        let waitingFrame = director.update(
+            deltaTime: 0.35,
+            survivalTime: 90.35,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(waitingFrame.newEnemies.isEmpty)
+        XCTAssertTrue(waitingFrame.telegraphIDsToRemove.isEmpty)
+
+        let spawnFrame = director.update(
+            deltaTime: 0.4,
+            survivalTime: 90.75,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        let enemy = try XCTUnwrap(spawnFrame.newEnemies.first)
+        XCTAssertEqual(spawnFrame.telegraphIDsToRemove, [telegraphFrame.telegraphsToShow[0].id])
+        XCTAssertEqual(spawnFrame.newEnemies.count, 1)
+        XCTAssertNil(enemy.formationID)
+        XCTAssertFalse(enemy.isLinearPatternEnemy)
+        XCTAssertTrue(enemy.isHunterDot)
+
+        guard case let .hunterDot(predictionLead, previousTarget) = enemy.behavior else {
+            XCTFail("Expected Hunter Dot behavior.")
+            return
+        }
+
+        XCTAssertEqual(predictionLead, 0.6, accuracy: 0.0001)
+        XCTAssertNil(previousTarget)
+    }
+
+    func testPendingHunterDotCountsAgainstActiveCap() {
+        var configuration = hunterDotTestConfiguration()
+        configuration.chaos.maxActiveEnemies = 1
+        configuration.chaos.hunterDotSpawnInterval = 0.1
+        configuration.chaos.maxActiveHunterDots = 2
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+
+        let cappedFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90.1,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(cappedFrame.newEnemies.isEmpty)
+        XCTAssertTrue(cappedFrame.telegraphsToShow.isEmpty)
+    }
+
+    func testPendingHunterDotCountsAgainstHunterSpecificCap() {
+        var configuration = hunterDotTestConfiguration()
+        configuration.chaos.hunterDotSpawnInterval = 0.1
+        configuration.chaos.maxActiveHunterDots = 1
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+
+        let cappedFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90.1,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(cappedFrame.newEnemies.isEmpty)
+        XCTAssertTrue(cappedFrame.telegraphsToShow.isEmpty)
+    }
+
+    func testActiveHunterDotCountsAgainstHunterSpecificCap() {
+        var configuration = hunterDotTestConfiguration()
+        configuration.chaos.maxActiveHunterDots = 1
+        var director = EnemySpawnDirector(configuration: configuration)
+
+        let frame = director.update(
+            deltaTime: 1,
+            survivalTime: 90,
+            activeEnemies: [hunterEnemy()],
+            playableRect: CGRect(x: 0, y: 0, width: 300, height: 300),
+            playerPosition: CGPoint(x: 150, y: 150),
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(frame.newEnemies.isEmpty)
+        XCTAssertTrue(frame.telegraphsToShow.isEmpty)
+    }
+
+    func testHunterDotRespectsPendingTelegraphCap() {
+        var configuration = hunterDotTestConfiguration()
+        configuration.maxPendingEnemyTelegraphs = 1
+        configuration.chaos.hunterDotSpawnInterval = 0.1
+        configuration.chaos.maxActiveHunterDots = 3
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let firstFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(firstFrame.telegraphsToShow.count, 1)
+
+        let cappedFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90.1,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(cappedFrame.newEnemies.isEmpty)
+        XCTAssertTrue(cappedFrame.telegraphsToShow.isEmpty)
+    }
+
+    func testHunterDotPlacementRespectsPlayerSafetyAndPickupAvoidance() throws {
+        var configuration = hunterDotTestConfiguration()
+        configuration.playerSafetyRadius = 30
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 0, y: 37.5)
+        let pickupCircle = CollisionCircle(center: CGPoint(x: 300, y: 37.5), radius: 16)
+
+        _ = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: [pickupCircle]
+        )
+
+        let spawnFrame = director.update(
+            deltaTime: 0.75,
+            survivalTime: 90.75,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: [pickupCircle]
+        )
+
+        let enemy = try XCTUnwrap(spawnFrame.newEnemies.first)
+        XCTAssertTrue(director.isSafeSpawn(
+            enemy.position,
+            avoiding: playerPosition,
+            pickupCircles: [pickupCircle]
+        ))
+    }
+
+    func testResetRestartsHunterDotTelegraphsAndEnemyIDs() throws {
+        var director = EnemySpawnDirector(configuration: hunterDotTestConfiguration())
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let firstTelegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+        let firstSpawnFrame = director.update(
+            deltaTime: 0.75,
+            survivalTime: 90.75,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        director.reset()
+
+        let resetTelegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+        let resetSpawnFrame = director.update(
+            deltaTime: 0.75,
+            survivalTime: 90.75,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        let firstEnemy = try XCTUnwrap(firstSpawnFrame.newEnemies.first)
+        let resetEnemy = try XCTUnwrap(resetSpawnFrame.newEnemies.first)
+        XCTAssertEqual(firstTelegraphFrame.telegraphsToShow.first?.id, 1)
+        XCTAssertEqual(resetTelegraphFrame.telegraphsToShow.first?.id, 1)
+        XCTAssertEqual(firstEnemy.id, 1)
+        XCTAssertEqual(resetEnemy.id, 1)
+        XCTAssertEqual(firstEnemy.position, resetEnemy.position)
+    }
+
+    private func hunterDotTestConfiguration() -> EnemySpawnConfiguration {
+        var configuration = EnemySpawnConfiguration()
+        configuration.playerSafetyRadius = 20
+        configuration.hunterDotTelegraphDuration = 0.75
+        configuration.warmup = disabledPhaseTuning(maxActiveEnemies: 20)
+        configuration.pressure = disabledPhaseTuning(maxActiveEnemies: 20)
+        configuration.chaos = EnemyPhaseTuning(
+            chaserSpawnInterval: 0,
+            chaserSpeed: 0,
+            maxActiveEnemies: 20,
+            formationSpawnInterval: nil,
+            formationSpeed: 0,
+            formationLaneCount: 5,
+            arrowRushSpawnInterval: nil,
+            arrowRushSpeed: 0,
+            arrowRushEnemyCount: 0,
+            mineDotSpawnInterval: nil,
+            maxActiveMineDots: 0,
+            hunterDotSpawnInterval: 18,
+            hunterDotSpeed: 108,
+            hunterDotPredictionLead: 0.6,
+            maxActiveHunterDots: 2
+        )
+        configuration.survivalHell = EnemyPhaseTuning(
+            chaserSpawnInterval: 0,
+            chaserSpeed: 0,
+            maxActiveEnemies: 20,
+            formationSpawnInterval: nil,
+            formationSpeed: 0,
+            formationLaneCount: 5,
+            arrowRushSpawnInterval: nil,
+            arrowRushSpeed: 0,
+            arrowRushEnemyCount: 0,
+            mineDotSpawnInterval: nil,
+            maxActiveMineDots: 0,
+            hunterDotSpawnInterval: 13,
+            hunterDotSpeed: 132,
+            hunterDotPredictionLead: 0.9,
+            maxActiveHunterDots: 3
+        )
+        return configuration
+    }
+
+    private func disabledPhaseTuning(maxActiveEnemies: Int) -> EnemyPhaseTuning {
+        EnemyPhaseTuning(
+            chaserSpawnInterval: 0,
+            chaserSpeed: 0,
+            maxActiveEnemies: maxActiveEnemies,
+            formationSpawnInterval: nil,
+            formationSpeed: 0,
+            formationLaneCount: 5
+        )
+    }
+
+    private func hunterEnemy() -> ArenaEnemy {
+        ArenaEnemy(
+            id: 10_000,
+            position: CGPoint(x: 20, y: 20),
+            radius: 8,
+            speed: 108,
+            behavior: .hunterDot(predictionLead: 0.6, previousTarget: nil)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add Hunter Dot as a limited-count elite chaser in Chaos and Survival Hell.
- Telegraph Hunter Dot spawns, count pending hunters against caps, and keep existing enemy patterns unchanged.
- Add focused Hunter Dot model/director coverage and keep visual differentiation inside the existing EnemyNode.

## Validation
- `xcodegen generate`
- `swiftlint lint --no-cache`
- `git diff --check`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`

Note: iPhone 16 simulator test execution could not run locally because Xcode reported only placeholder simulator destinations.

Parent: #9
Closes #32
