### PR TITLE
Add Paddle Trap enemy pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -291,6 +291,7 @@ final class ArenaScene: SKScene {
         spawnPickupIfNeeded(deltaTime: deltaTime, playerPosition: playerPosition)
         collectPickups(playerPosition: playerPosition)
         advanceEnemies(deltaTime: deltaTime, playerPosition: playerPosition)
+        removeExpiredEnemies()
         cullExitedLinearPatternEnemies()
         updateRazorShield(deltaTime: deltaTime, playerPosition: playerPosition)
         recordNearMisses(playerPosition: playerPosition)
@@ -392,6 +393,21 @@ final class ArenaScene: SKScene {
 
         enemies.removeAll { exitedEnemyIDs.contains($0.id) }
         for enemyID in exitedEnemyIDs {
+            enemyNodes.removeValue(forKey: enemyID)?.removeFromParent()
+        }
+    }
+
+    private func removeExpiredEnemies() {
+        let expiredEnemyIDs = Set(enemies.filter(\.isExpired).map(\.id))
+
+        guard !expiredEnemyIDs.isEmpty else {
+            return
+        }
+
+        enemies.removeAll { expiredEnemyIDs.contains($0.id) }
+        removeFormationEnemies(ids: expiredEnemyIDs, awardCompletion: false)
+
+        for enemyID in expiredEnemyIDs {
             enemyNodes.removeValue(forKey: enemyID)?.removeFromParent()
         }
     }

--- a/TiltArena/Game/Enemies/ArenaEnemy.swift
+++ b/TiltArena/Game/Enemies/ArenaEnemy.swift
@@ -7,6 +7,8 @@ enum EnemyBehavior: Equatable {
     case arrowRush(velocity: CGVector)
     case mineDot
     case hunterDot(predictionLead: CGFloat, previousTarget: CGPoint?)
+    case paddleTrapBar(trapID: Int, remainingLifetime: TimeInterval)
+    case paddleTrapDot(trapID: Int, velocity: CGVector, bounds: CGRect, remainingLifetime: TimeInterval)
 }
 
 struct ArenaEnemy: Equatable, Identifiable {
@@ -18,7 +20,7 @@ struct ArenaEnemy: Equatable, Identifiable {
 
     var formationID: Int? {
         switch behavior {
-        case .chaser, .arrowRush, .mineDot, .hunterDot:
+        case .chaser, .arrowRush, .mineDot, .hunterDot, .paddleTrapBar, .paddleTrapDot:
             return nil
         case let .formationLine(_, formationID):
             return formationID
@@ -27,7 +29,7 @@ struct ArenaEnemy: Equatable, Identifiable {
 
     var isLinearPatternEnemy: Bool {
         switch behavior {
-        case .chaser, .mineDot, .hunterDot:
+        case .chaser, .mineDot, .hunterDot, .paddleTrapBar, .paddleTrapDot:
             return false
         case .formationLine, .arrowRush:
             return true
@@ -46,12 +48,35 @@ struct ArenaEnemy: Equatable, Identifiable {
         return true
     }
 
+    var isPaddleTrap: Bool {
+        paddleTrapID != nil
+    }
+
+    var paddleTrapID: Int? {
+        switch behavior {
+        case let .paddleTrapBar(trapID, _), let .paddleTrapDot(trapID, _, _, _):
+            return trapID
+        case .chaser, .formationLine, .arrowRush, .mineDot, .hunterDot:
+            return nil
+        }
+    }
+
+    var isExpired: Bool {
+        switch behavior {
+        case let .paddleTrapBar(_, remainingLifetime), let .paddleTrapDot(_, _, _, remainingLifetime):
+            return remainingLifetime <= 0
+        case .chaser, .formationLine, .arrowRush, .mineDot, .hunterDot:
+            return false
+        }
+    }
+
     var collisionCircle: CollisionCircle {
         CollisionCircle(center: position, radius: radius)
     }
 
     mutating func advance(toward target: CGPoint, deltaTime: TimeInterval) {
-        let clampedDelta = CGFloat(max(0, deltaTime))
+        let clampedTime = max(0, deltaTime)
+        let clampedDelta = CGFloat(clampedTime)
 
         switch behavior {
         case .chaser:
@@ -64,6 +89,16 @@ struct ArenaEnemy: Equatable, Identifiable {
             return
         case let .hunterDot(predictionLead, previousTarget):
             advanceHunter(toward: target, predictionLead: predictionLead, previousTarget: previousTarget, deltaTime: clampedDelta)
+        case let .paddleTrapBar(trapID, remainingLifetime):
+            behavior = .paddleTrapBar(trapID: trapID, remainingLifetime: remainingLifetime - clampedTime)
+        case let .paddleTrapDot(trapID, velocity, bounds, remainingLifetime):
+            advancePaddleTrapDot(
+                trapID: trapID,
+                velocity: velocity,
+                bounds: bounds,
+                remainingLifetime: remainingLifetime,
+                deltaTime: clampedDelta
+            )
         }
     }
 
@@ -114,5 +149,43 @@ struct ArenaEnemy: Equatable, Identifiable {
 
         advanceChaser(toward: predictedTarget, deltaTime: deltaTime)
         behavior = .hunterDot(predictionLead: predictionLead, previousTarget: target)
+    }
+
+    private mutating func advancePaddleTrapDot(
+        trapID: Int,
+        velocity: CGVector,
+        bounds: CGRect,
+        remainingLifetime: TimeInterval,
+        deltaTime: CGFloat
+    ) {
+        var nextVelocity = velocity
+        var nextPosition = CGPoint(
+            x: position.x + velocity.dx * deltaTime,
+            y: position.y + velocity.dy * deltaTime
+        )
+
+        if nextPosition.x < bounds.minX {
+            nextPosition.x = bounds.minX
+            nextVelocity.dx = abs(nextVelocity.dx)
+        } else if nextPosition.x > bounds.maxX {
+            nextPosition.x = bounds.maxX
+            nextVelocity.dx = -abs(nextVelocity.dx)
+        }
+
+        if nextPosition.y < bounds.minY {
+            nextPosition.y = bounds.minY
+            nextVelocity.dy = abs(nextVelocity.dy)
+        } else if nextPosition.y > bounds.maxY {
+            nextPosition.y = bounds.maxY
+            nextVelocity.dy = -abs(nextVelocity.dy)
+        }
+
+        position = nextPosition
+        behavior = .paddleTrapDot(
+            trapID: trapID,
+            velocity: nextVelocity,
+            bounds: bounds,
+            remainingLifetime: remainingLifetime - TimeInterval(deltaTime)
+        )
     }
 }

--- a/TiltArena/Game/Enemies/EnemyNode.swift
+++ b/TiltArena/Game/Enemies/EnemyNode.swift
@@ -34,6 +34,11 @@ final class EnemyNode: SKNode {
             ringNode.lineWidth = 1.8
             ringNode.glowWidth = 2
             bodyNode.strokeColor = theme.enemyColor
+        } else if enemy.isPaddleTrap {
+            ringNode.strokeColor = theme.enemyColor.withAlphaComponent(0.7)
+            ringNode.lineWidth = 1.5
+            bodyNode.fillColor = theme.enemyColor.withAlphaComponent(0.9)
+            bodyNode.glowWidth = 2
         }
 
         apply(enemy)

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+PaddleTrap.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+PaddleTrap.swift
@@ -1,0 +1,390 @@
+import CoreGraphics
+import Foundation
+
+extension EnemySpawnDirector {
+    private enum PaddleTrapOrientation {
+        case horizontal
+        case vertical
+    }
+
+    private enum PaddleTrapGrid {
+        static let columnCount = 3
+        static let rowCount = 3
+    }
+
+    private struct PaddleTrapLayout {
+        let barPositions: [CGPoint]
+        let dotPosition: CGPoint
+        let dotVelocity: CGVector
+        let dotBounds: CGRect
+        let telegraphSegments: [EnemyTelegraphSegment]
+
+        var componentPositions: [CGPoint] {
+            barPositions + [dotPosition]
+        }
+    }
+
+    mutating func spawnPaddleTrapTelegraphIfNeeded(
+        deltaTime: TimeInterval,
+        tuning: EnemyPhaseTuning,
+        playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        activeEnemies: [ArenaEnemy],
+        frame: inout EnemySpawnFrame
+    ) {
+        guard deltaTime > 0, let paddleTrapSpawnInterval = tuning.paddleTrapSpawnInterval else {
+            timeUntilNextPaddleTrap = 0
+            return
+        }
+
+        let componentCount = paddleTrapComponentCount(tuning: tuning)
+        guard paddleTrapSpawnInterval > 0,
+              tuning.maxActivePaddleTraps > 0,
+              tuning.paddleTrapLifetime > 0,
+              componentCount > 0,
+              tuning.paddleTrapDotSpeed > 0 else {
+            return
+        }
+
+        guard pendingSpawns.count < configuration.maxPendingEnemyTelegraphs else {
+            timeUntilNextPaddleTrap = max(timeUntilNextPaddleTrap, paddleTrapSpawnInterval)
+            return
+        }
+
+        let activeAndNewEnemies = activeEnemies + frame.newEnemies
+        let projectedEnemyCount = activeAndNewEnemies.count + pendingEnemyCount
+        let projectedTrapCount = Set(activeAndNewEnemies.compactMap(\.paddleTrapID)).count + pendingPaddleTrapCount
+
+        guard projectedEnemyCount + componentCount <= tuning.maxActiveEnemies,
+              projectedTrapCount < tuning.maxActivePaddleTraps else {
+            timeUntilNextPaddleTrap = max(timeUntilNextPaddleTrap, paddleTrapSpawnInterval)
+            return
+        }
+
+        timeUntilNextPaddleTrap -= deltaTime
+
+        guard timeUntilNextPaddleTrap <= 0 else {
+            return
+        }
+
+        guard let paddleTrap = makePendingPaddleTrap(
+            in: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            activeEnemies: activeAndNewEnemies,
+            tuning: tuning
+        ) else {
+            timeUntilNextPaddleTrap = paddleTrapSpawnInterval
+            return
+        }
+
+        pendingSpawns[paddleTrap.telegraph.id] = paddleTrap
+        frame.telegraphsToShow.append(paddleTrap.telegraph)
+        timeUntilNextPaddleTrap += paddleTrapSpawnInterval
+    }
+
+    private mutating func makePendingPaddleTrap(
+        in playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        activeEnemies: [ArenaEnemy],
+        tuning: EnemyPhaseTuning
+    ) -> PendingEnemySpawn? {
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return nil
+        }
+
+        let barEnemyCount = max(1, tuning.paddleTrapBarEnemyCount)
+        let pendingTrapPositions = pendingSpawns.values.flatMap { pendingSpawn in
+            pendingSpawn.enemies.compactMap { enemy in
+                enemy.isPaddleTrap ? enemy.position : nil
+            }
+        }
+        let candidateCount = PaddleTrapGrid.columnCount * PaddleTrapGrid.rowCount * 2
+
+        for _ in 0..<candidateCount {
+            let orientation = nextPaddleTrapOrientation()
+            let center = paddleTrapCandidateCenter(
+                in: playableRect,
+                index: nextPaddleTrapCandidateIndex,
+                orientation: orientation,
+                barEnemyCount: barEnemyCount
+            )
+            nextPaddleTrapCandidateIndex += 1
+
+            let layout = paddleTrapLayout(
+                center: center,
+                orientation: orientation,
+                barEnemyCount: barEnemyCount,
+                dotSpeed: tuning.paddleTrapDotSpeed
+            )
+
+            guard isSafePaddleTrapLayout(
+                layout,
+                playableRect: playableRect,
+                playerPosition: playerPosition,
+                pickupCircles: pickupCircles,
+                activeEnemies: activeEnemies,
+                pendingTrapPositions: pendingTrapPositions
+            ) else {
+                continue
+            }
+
+            return pendingPaddleTrap(from: layout, tuning: tuning)
+        }
+
+        return nil
+    }
+
+    private mutating func pendingPaddleTrap(
+        from layout: PaddleTrapLayout,
+        tuning: EnemyPhaseTuning
+    ) -> PendingEnemySpawn {
+        let trapID = nextPaddleTrapID
+        let telegraphID = nextTelegraphID
+        var nextID = nextEnemyID
+        var enemies = layout.barPositions.map { position in
+            defer {
+                nextID += 1
+            }
+
+            return ArenaEnemy(
+                id: nextID,
+                position: position,
+                radius: configuration.enemyRadius,
+                speed: 0,
+                behavior: .paddleTrapBar(trapID: trapID, remainingLifetime: tuning.paddleTrapLifetime)
+            )
+        }
+
+        enemies.append(ArenaEnemy(
+            id: nextID,
+            position: layout.dotPosition,
+            radius: configuration.enemyRadius,
+            speed: tuning.paddleTrapDotSpeed,
+            behavior: .paddleTrapDot(
+                trapID: trapID,
+                velocity: layout.dotVelocity,
+                bounds: layout.dotBounds,
+                remainingLifetime: tuning.paddleTrapLifetime
+            )
+        ))
+
+        nextEnemyID += enemies.count
+        nextTelegraphID += 1
+        nextPaddleTrapID += 1
+
+        return PendingEnemySpawn(
+            timeRemaining: configuration.paddleTrapTelegraphDuration,
+            requiredEnemyCount: enemies.count,
+            enemies: enemies,
+            telegraph: EnemyTelegraph(id: telegraphID, segments: layout.telegraphSegments)
+        )
+    }
+
+    private mutating func nextPaddleTrapOrientation() -> PaddleTrapOrientation {
+        let orientation: PaddleTrapOrientation = nextPaddleTrapOrientationIndex.isMultiple(of: 2) ? .horizontal : .vertical
+        nextPaddleTrapOrientationIndex += 1
+        return orientation
+    }
+
+    private func paddleTrapCandidateCenter(
+        in playableRect: CGRect,
+        index: Int,
+        orientation: PaddleTrapOrientation,
+        barEnemyCount: Int
+    ) -> CGPoint {
+        let spawnRect = paddleTrapCandidateRect(
+            in: playableRect,
+            orientation: orientation,
+            barEnemyCount: barEnemyCount
+        )
+        let column = index % PaddleTrapGrid.columnCount
+        let row = (index / PaddleTrapGrid.columnCount) % PaddleTrapGrid.rowCount
+
+        return CGPoint(
+            x: spawnRect.minX + spawnRect.width * CGFloat(column + 1) / CGFloat(PaddleTrapGrid.columnCount + 1),
+            y: spawnRect.minY + spawnRect.height * CGFloat(row + 1) / CGFloat(PaddleTrapGrid.rowCount + 1)
+        )
+    }
+
+    private func paddleTrapCandidateRect(
+        in playableRect: CGRect,
+        orientation: PaddleTrapOrientation,
+        barEnemyCount: Int
+    ) -> CGRect {
+        let halfSpan = paddleTrapBarHalfSpan(barEnemyCount: barEnemyCount)
+        let halfGap = paddleTrapBarHalfGap
+        let requestedXInset: CGFloat
+        let requestedYInset: CGFloat
+
+        switch orientation {
+        case .horizontal:
+            requestedXInset = max(configuration.paddleTrapCandidateInset, halfSpan + configuration.enemyRadius)
+            requestedYInset = max(configuration.paddleTrapCandidateInset, halfGap + configuration.enemyRadius)
+        case .vertical:
+            requestedXInset = max(configuration.paddleTrapCandidateInset, halfGap + configuration.enemyRadius)
+            requestedYInset = max(configuration.paddleTrapCandidateInset, halfSpan + configuration.enemyRadius)
+        }
+
+        let maxXInset = max(0, playableRect.width / 2 - configuration.enemyRadius)
+        let maxYInset = max(0, playableRect.height / 2 - configuration.enemyRadius)
+        return playableRect.insetBy(dx: min(requestedXInset, maxXInset), dy: min(requestedYInset, maxYInset))
+    }
+
+    private func paddleTrapLayout(
+        center: CGPoint,
+        orientation: PaddleTrapOrientation,
+        barEnemyCount: Int,
+        dotSpeed: CGFloat
+    ) -> PaddleTrapLayout {
+        let halfSpan = paddleTrapBarHalfSpan(barEnemyCount: barEnemyCount)
+        let halfGap = paddleTrapBarHalfGap
+        let innerHalfGap = max(configuration.enemyRadius, halfGap - configuration.enemyRadius * 2.2)
+        let speed = max(0, dotSpeed) / sqrt(CGFloat(2))
+        let bars = paddleTrapBars(
+            center: center,
+            orientation: orientation,
+            barEnemyCount: barEnemyCount,
+            halfSpan: halfSpan,
+            halfGap: halfGap
+        )
+
+        switch orientation {
+        case .horizontal:
+            let dotBounds = CGRect(
+                x: center.x - halfSpan,
+                y: center.y - innerHalfGap,
+                width: halfSpan * 2,
+                height: innerHalfGap * 2
+            )
+            let bounceSegment = EnemyTelegraphSegment(
+                start: CGPoint(x: center.x, y: dotBounds.minY),
+                end: CGPoint(x: center.x, y: dotBounds.maxY)
+            )
+            return PaddleTrapLayout(
+                barPositions: bars.first + bars.second,
+                dotPosition: center,
+                dotVelocity: CGVector(dx: speed, dy: speed),
+                dotBounds: dotBounds,
+                telegraphSegments: paddleTrapTelegraphSegments(bars: bars, bounceSegment: bounceSegment)
+            )
+        case .vertical:
+            let dotBounds = CGRect(
+                x: center.x - innerHalfGap,
+                y: center.y - halfSpan,
+                width: innerHalfGap * 2,
+                height: halfSpan * 2
+            )
+            let bounceSegment = EnemyTelegraphSegment(
+                start: CGPoint(x: dotBounds.minX, y: center.y),
+                end: CGPoint(x: dotBounds.maxX, y: center.y)
+            )
+            return PaddleTrapLayout(
+                barPositions: bars.first + bars.second,
+                dotPosition: center,
+                dotVelocity: CGVector(dx: speed, dy: -speed),
+                dotBounds: dotBounds,
+                telegraphSegments: paddleTrapTelegraphSegments(bars: bars, bounceSegment: bounceSegment)
+            )
+        }
+    }
+
+    private func paddleTrapBars(
+        center: CGPoint,
+        orientation: PaddleTrapOrientation,
+        barEnemyCount: Int,
+        halfSpan: CGFloat,
+        halfGap: CGFloat
+    ) -> (first: [CGPoint], second: [CGPoint]) {
+        var firstBar: [CGPoint] = []
+        var secondBar: [CGPoint] = []
+
+        for index in 0..<barEnemyCount {
+            let offset = CGFloat(index) * configuration.paddleTrapBarSpacing - halfSpan
+
+            switch orientation {
+            case .horizontal:
+                firstBar.append(CGPoint(x: center.x + offset, y: center.y - halfGap))
+                secondBar.append(CGPoint(x: center.x + offset, y: center.y + halfGap))
+            case .vertical:
+                firstBar.append(CGPoint(x: center.x - halfGap, y: center.y + offset))
+                secondBar.append(CGPoint(x: center.x + halfGap, y: center.y + offset))
+            }
+        }
+
+        return (firstBar, secondBar)
+    }
+
+    private func paddleTrapTelegraphSegments(
+        bars: (first: [CGPoint], second: [CGPoint]),
+        bounceSegment: EnemyTelegraphSegment
+    ) -> [EnemyTelegraphSegment] {
+        [
+            EnemyTelegraphSegment(start: bars.first[0], end: bars.first[bars.first.count - 1]),
+            EnemyTelegraphSegment(start: bars.second[0], end: bars.second[bars.second.count - 1]),
+            bounceSegment
+        ]
+    }
+
+    private func isSafePaddleTrapLayout(
+        _ layout: PaddleTrapLayout,
+        playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        activeEnemies: [ArenaEnemy],
+        pendingTrapPositions: [CGPoint]
+    ) -> Bool {
+        let spawnRect = playableRect.insetBy(dx: configuration.enemyRadius, dy: configuration.enemyRadius)
+
+        for position in layout.componentPositions {
+            guard spawnRect.contains(position),
+                  isSafeSpawn(position, avoiding: playerPosition, pickupCircles: pickupCircles),
+                  isClearOfActiveEnemies(position, activeEnemies: activeEnemies),
+                  isClearOfPendingPaddleTraps(position, pendingTrapPositions: pendingTrapPositions) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private func isClearOfActiveEnemies(
+        _ position: CGPoint,
+        activeEnemies: [ArenaEnemy]
+    ) -> Bool {
+        activeEnemies.allSatisfy { activeEnemy in
+            let baseClearance = activeEnemy.radius + configuration.enemyRadius + configuration.pickupClearance
+            let clearance = activeEnemy.isPaddleTrap ? max(baseClearance, configuration.paddleTrapMinimumSpacing) : baseClearance
+            return squaredDistance(from: position, to: activeEnemy.position) >= clearance * clearance
+        }
+    }
+
+    private func isClearOfPendingPaddleTraps(
+        _ position: CGPoint,
+        pendingTrapPositions: [CGPoint]
+    ) -> Bool {
+        pendingTrapPositions.allSatisfy { pendingPosition in
+            let clearance = configuration.paddleTrapMinimumSpacing
+            return squaredDistance(from: position, to: pendingPosition) >= clearance * clearance
+        }
+    }
+
+    private func paddleTrapComponentCount(tuning: EnemyPhaseTuning) -> Int {
+        let barEnemyCount = max(0, tuning.paddleTrapBarEnemyCount)
+        guard barEnemyCount > 0 else {
+            return 0
+        }
+
+        return barEnemyCount * 2 + 1
+    }
+
+    private func paddleTrapBarHalfSpan(barEnemyCount: Int) -> CGFloat {
+        CGFloat(max(0, barEnemyCount - 1)) * configuration.paddleTrapBarSpacing / 2
+    }
+
+    private var paddleTrapBarHalfGap: CGFloat {
+        max(configuration.enemyRadius * 4, configuration.paddleTrapBarGap / 2)
+    }
+}

--- a/TiltArena/Game/Enemies/EnemySpawnDirector.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector.swift
@@ -51,6 +51,11 @@ struct EnemyPhaseTuning: Equatable {
     var hunterDotSpeed: CGFloat = 0
     var hunterDotPredictionLead: CGFloat = 0
     var maxActiveHunterDots: Int = 0
+    var paddleTrapSpawnInterval: TimeInterval?
+    var maxActivePaddleTraps: Int = 0
+    var paddleTrapLifetime: TimeInterval = 0
+    var paddleTrapBarEnemyCount: Int = 0
+    var paddleTrapDotSpeed: CGFloat = 0
 }
 
 struct EnemySpawnConfiguration: Equatable {
@@ -72,6 +77,11 @@ struct EnemySpawnConfiguration: Equatable {
     var mineDotCandidateInset: CGFloat = 48
     var mineDotMinimumSpacing: CGFloat = 52
     var hunterDotTelegraphDuration: TimeInterval = 0.75
+    var paddleTrapTelegraphDuration: TimeInterval = 1
+    var paddleTrapBarSpacing: CGFloat = 24
+    var paddleTrapBarGap: CGFloat = 96
+    var paddleTrapCandidateInset: CGFloat = 84
+    var paddleTrapMinimumSpacing: CGFloat = 64
     var maxPendingEnemyTelegraphs = 2
     var cullingOutset: CGFloat = 72
     var warmup = EnemyPhaseTuning(
@@ -89,7 +99,12 @@ struct EnemySpawnConfiguration: Equatable {
         hunterDotSpawnInterval: nil,
         hunterDotSpeed: 0,
         hunterDotPredictionLead: 0,
-        maxActiveHunterDots: 0
+        maxActiveHunterDots: 0,
+        paddleTrapSpawnInterval: nil,
+        maxActivePaddleTraps: 0,
+        paddleTrapLifetime: 0,
+        paddleTrapBarEnemyCount: 0,
+        paddleTrapDotSpeed: 0
     )
     var pressure = EnemyPhaseTuning(
         chaserSpawnInterval: 1.05,
@@ -106,7 +121,12 @@ struct EnemySpawnConfiguration: Equatable {
         hunterDotSpawnInterval: nil,
         hunterDotSpeed: 0,
         hunterDotPredictionLead: 0,
-        maxActiveHunterDots: 0
+        maxActiveHunterDots: 0,
+        paddleTrapSpawnInterval: nil,
+        maxActivePaddleTraps: 0,
+        paddleTrapLifetime: 0,
+        paddleTrapBarEnemyCount: 0,
+        paddleTrapDotSpeed: 0
     )
     var chaos = EnemyPhaseTuning(
         chaserSpawnInterval: 0.75,
@@ -123,7 +143,12 @@ struct EnemySpawnConfiguration: Equatable {
         hunterDotSpawnInterval: 18,
         hunterDotSpeed: 108,
         hunterDotPredictionLead: 0.6,
-        maxActiveHunterDots: 2
+        maxActiveHunterDots: 2,
+        paddleTrapSpawnInterval: 24,
+        maxActivePaddleTraps: 1,
+        paddleTrapLifetime: 7,
+        paddleTrapBarEnemyCount: 4,
+        paddleTrapDotSpeed: 145
     )
     var survivalHell = EnemyPhaseTuning(
         chaserSpawnInterval: 0.5,
@@ -140,7 +165,12 @@ struct EnemySpawnConfiguration: Equatable {
         hunterDotSpawnInterval: 13,
         hunterDotSpeed: 132,
         hunterDotPredictionLead: 0.9,
-        maxActiveHunterDots: 3
+        maxActiveHunterDots: 3,
+        paddleTrapSpawnInterval: 18,
+        maxActivePaddleTraps: 2,
+        paddleTrapLifetime: 8,
+        paddleTrapBarEnemyCount: 5,
+        paddleTrapDotSpeed: 170
     )
 
     func tuning(at survivalTime: TimeInterval) -> EnemyPhaseTuning {
@@ -214,7 +244,32 @@ struct EnemySpawnConfiguration: Equatable {
                     to: CGFloat(next?.tuning.maxActiveHunterDots ?? current.tuning.maxActiveHunterDots),
                     progress: progress
                 ))
-            ))
+            )),
+            paddleTrapSpawnInterval: current.tuning.paddleTrapSpawnInterval,
+            maxActivePaddleTraps: max(0, Int(
+                round(interpolate(
+                    from: CGFloat(current.tuning.maxActivePaddleTraps),
+                    to: CGFloat(next?.tuning.maxActivePaddleTraps ?? current.tuning.maxActivePaddleTraps),
+                    progress: progress
+                ))
+            )),
+            paddleTrapLifetime: interpolate(
+                from: current.tuning.paddleTrapLifetime,
+                to: next?.tuning.paddleTrapLifetime ?? current.tuning.paddleTrapLifetime,
+                progress: progress
+            ),
+            paddleTrapBarEnemyCount: max(0, Int(
+                round(interpolate(
+                    from: CGFloat(current.tuning.paddleTrapBarEnemyCount),
+                    to: CGFloat(next?.tuning.paddleTrapBarEnemyCount ?? current.tuning.paddleTrapBarEnemyCount),
+                    progress: progress
+                ))
+            )),
+            paddleTrapDotSpeed: interpolate(
+                from: current.tuning.paddleTrapDotSpeed,
+                to: next?.tuning.paddleTrapDotSpeed ?? current.tuning.paddleTrapDotSpeed,
+                progress: progress
+            )
         )
     }
 
@@ -306,11 +361,15 @@ struct EnemySpawnDirector {
     var nextArrowRushDirectionIndex = 0
     var nextMineDotCandidateIndex = 0
     var nextHunterDotCandidateIndex = 0
+    var nextPaddleTrapCandidateIndex = 0
+    var nextPaddleTrapOrientationIndex = 0
+    var nextPaddleTrapID = 1
     private var timeUntilNextChaser: TimeInterval = 0
     private var timeUntilNextFormation: TimeInterval = 0
     var timeUntilNextArrowRush: TimeInterval = 0
     var timeUntilNextMineDot: TimeInterval = 0
     var timeUntilNextHunterDot: TimeInterval = 0
+    var timeUntilNextPaddleTrap: TimeInterval = 0
     var pendingSpawns: [Int: PendingEnemySpawn] = [:]
 
     var pendingEnemyCount: Int {
@@ -329,6 +388,13 @@ struct EnemySpawnDirector {
         }
     }
 
+    var pendingPaddleTrapCount: Int {
+        let trapIDs = pendingSpawns.values.flatMap { pendingSpawn in
+            pendingSpawn.enemies.compactMap(\.paddleTrapID)
+        }
+        return Set(trapIDs).count
+    }
+
     init(configuration: EnemySpawnConfiguration = EnemySpawnConfiguration()) {
         self.configuration = configuration
     }
@@ -342,11 +408,15 @@ struct EnemySpawnDirector {
         nextArrowRushDirectionIndex = 0
         nextMineDotCandidateIndex = 0
         nextHunterDotCandidateIndex = 0
+        nextPaddleTrapCandidateIndex = 0
+        nextPaddleTrapOrientationIndex = 0
+        nextPaddleTrapID = 1
         timeUntilNextChaser = 0
         timeUntilNextFormation = 0
         timeUntilNextArrowRush = 0
         timeUntilNextMineDot = 0
         timeUntilNextHunterDot = 0
+        timeUntilNextPaddleTrap = 0
         pendingSpawns.removeAll()
     }
 
@@ -411,6 +481,16 @@ struct EnemySpawnDirector {
         )
 
         spawnHunterDotTelegraphIfNeeded(
+            deltaTime: clampedDelta,
+            tuning: tuning,
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            activeEnemies: activeEnemies,
+            frame: &frame
+        )
+
+        spawnPaddleTrapTelegraphIfNeeded(
             deltaTime: clampedDelta,
             tuning: tuning,
             playableRect: playableRect,

--- a/TiltArenaTests/ArenaEnemyTests.swift
+++ b/TiltArenaTests/ArenaEnemyTests.swift
@@ -92,6 +92,63 @@ final class ArenaEnemyTests: XCTestCase {
         XCTAssertTrue(enemy.isHunterDot)
     }
 
+    func testPaddleTrapBarDoesNotMoveAndExpires() {
+        var enemy = ArenaEnemy(
+            id: 1,
+            position: CGPoint(x: 80, y: 120),
+            radius: 8,
+            speed: 0,
+            behavior: .paddleTrapBar(trapID: 7, remainingLifetime: 2)
+        )
+
+        enemy.advance(toward: CGPoint(x: 300, y: 300), deltaTime: 1.5)
+
+        XCTAssertEqual(enemy.position.x, 80, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 120, accuracy: 0.0001)
+        XCTAssertEqual(enemy.paddleTrapID, 7)
+        XCTAssertNil(enemy.formationID)
+        XCTAssertFalse(enemy.isLinearPatternEnemy)
+        XCTAssertTrue(enemy.isPaddleTrap)
+        XCTAssertFalse(enemy.isExpired)
+
+        enemy.advance(toward: CGPoint(x: 300, y: 300), deltaTime: 0.5)
+
+        XCTAssertTrue(enemy.isExpired)
+    }
+
+    func testPaddleTrapDotBouncesInsideBounds() {
+        var enemy = ArenaEnemy(
+            id: 1,
+            position: CGPoint(x: 9, y: 9),
+            radius: 8,
+            speed: 4,
+            behavior: .paddleTrapDot(
+                trapID: 3,
+                velocity: CGVector(dx: 4, dy: 4),
+                bounds: CGRect(x: 0, y: 0, width: 10, height: 10),
+                remainingLifetime: 2
+            )
+        )
+
+        enemy.advance(toward: CGPoint(x: 100, y: 100), deltaTime: 0.5)
+
+        XCTAssertEqual(enemy.position.x, 10, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 10, accuracy: 0.0001)
+        XCTAssertEqual(enemy.paddleTrapID, 3)
+        XCTAssertNil(enemy.formationID)
+        XCTAssertFalse(enemy.isLinearPatternEnemy)
+        XCTAssertTrue(enemy.isPaddleTrap)
+
+        guard case let .paddleTrapDot(_, velocity, _, remainingLifetime) = enemy.behavior else {
+            XCTFail("Expected Paddle Trap dot behavior.")
+            return
+        }
+
+        XCTAssertEqual(velocity.dx, -4, accuracy: 0.0001)
+        XCTAssertEqual(velocity.dy, -4, accuracy: 0.0001)
+        XCTAssertEqual(remainingLifetime, 1.5, accuracy: 0.0001)
+    }
+
     func testCircleCollisionUsesCombinedRadii() {
         let player = CollisionCircle(center: CGPoint(x: 0, y: 0), radius: 9)
         let touchingEnemy = CollisionCircle(center: CGPoint(x: 17, y: 0), radius: 8)

--- a/TiltArenaTests/EnemySpawnDirectorPaddleTrapTests.swift
+++ b/TiltArenaTests/EnemySpawnDirectorPaddleTrapTests.swift
@@ -1,0 +1,424 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class EnemySpawnDirectorPaddleTrapTests: XCTestCase {
+    func testPaddleTrapDoesNotTelegraphBeforeChaos() {
+        var director = EnemySpawnDirector(configuration: paddleTrapTestConfiguration())
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+
+        let pressureFrame = director.update(
+            deltaTime: 100,
+            survivalTime: 89.9,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: CGPoint(x: 150, y: 150),
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(pressureFrame.telegraphsToShow.isEmpty)
+
+        let chaosFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: CGPoint(x: 150, y: 150),
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(chaosFrame.telegraphsToShow.count, 1)
+        XCTAssertTrue(chaosFrame.newEnemies.isEmpty)
+    }
+
+    func testPaddleTrapUsesChaosAndSurvivalHellDefaults() {
+        let configuration = EnemySpawnConfiguration()
+        let chaos = configuration.tuning(at: 90)
+        let survivalHell = configuration.tuning(at: 180)
+
+        XCTAssertEqual(chaos.paddleTrapSpawnInterval, 24)
+        XCTAssertEqual(chaos.maxActivePaddleTraps, 1)
+        XCTAssertEqual(chaos.paddleTrapLifetime, 7, accuracy: 0.0001)
+        XCTAssertEqual(chaos.paddleTrapBarEnemyCount, 4)
+        XCTAssertEqual(chaos.paddleTrapDotSpeed, 145, accuracy: 0.0001)
+        XCTAssertEqual(survivalHell.paddleTrapSpawnInterval, 18)
+        XCTAssertEqual(survivalHell.maxActivePaddleTraps, 2)
+        XCTAssertEqual(survivalHell.paddleTrapLifetime, 8, accuracy: 0.0001)
+        XCTAssertEqual(survivalHell.paddleTrapBarEnemyCount, 5)
+        XCTAssertEqual(survivalHell.paddleTrapDotSpeed, 170, accuracy: 0.0001)
+    }
+
+    func testPaddleTrapTelegraphsBeforeSpawningAndBuildsTrapComponents() throws {
+        var director = EnemySpawnDirector(configuration: paddleTrapTestConfiguration())
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+        XCTAssertEqual(telegraphFrame.telegraphsToShow[0].segments.count, 3)
+        XCTAssertTrue(telegraphFrame.newEnemies.isEmpty)
+
+        let waitingFrame = director.update(
+            deltaTime: 0.5,
+            survivalTime: 90.5,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(waitingFrame.newEnemies.isEmpty)
+        XCTAssertTrue(waitingFrame.telegraphIDsToRemove.isEmpty)
+
+        let spawnFrame = director.update(
+            deltaTime: 0.5,
+            survivalTime: 91,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(spawnFrame.telegraphIDsToRemove, [telegraphFrame.telegraphsToShow[0].id])
+        XCTAssertEqual(spawnFrame.newEnemies.count, 9)
+        XCTAssertEqual(Set(spawnFrame.newEnemies.compactMap(\.paddleTrapID)), [1])
+        XCTAssertEqual(spawnFrame.newEnemies.filter(\.isPaddleTrap).count, 9)
+        XCTAssertEqual(spawnFrame.newEnemies.filter(isPaddleTrapBar).count, 8)
+
+        let dot = try XCTUnwrap(spawnFrame.newEnemies.first(where: isPaddleTrapDot))
+        let velocity = paddleTrapDotVelocity(for: dot)
+        XCTAssertEqual(hypot(velocity.dx, velocity.dy), 145, accuracy: 0.0001)
+        XCTAssertNil(dot.formationID)
+        XCTAssertFalse(dot.isLinearPatternEnemy)
+    }
+
+    func testPendingPaddleTrapComponentsCountAgainstActiveCap() {
+        var configuration = paddleTrapTestConfiguration()
+        configuration.chaos.maxActiveEnemies = 17
+        configuration.chaos.maxActivePaddleTraps = 2
+        configuration.chaos.paddleTrapSpawnInterval = 0.1
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+
+        let cappedFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90.1,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(cappedFrame.newEnemies.isEmpty)
+        XCTAssertTrue(cappedFrame.telegraphsToShow.isEmpty)
+    }
+
+    func testPendingPaddleTrapCountsAgainstTrapSpecificCap() {
+        var configuration = paddleTrapTestConfiguration()
+        configuration.chaos.paddleTrapSpawnInterval = 0.1
+        configuration.chaos.maxActivePaddleTraps = 1
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+
+        let cappedFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90.1,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(cappedFrame.newEnemies.isEmpty)
+        XCTAssertTrue(cappedFrame.telegraphsToShow.isEmpty)
+    }
+
+    func testActivePaddleTrapCountsAgainstTrapSpecificCap() {
+        var configuration = paddleTrapTestConfiguration()
+        configuration.chaos.maxActivePaddleTraps = 1
+        var director = EnemySpawnDirector(configuration: configuration)
+
+        let frame = director.update(
+            deltaTime: 1,
+            survivalTime: 90,
+            activeEnemies: [paddleTrapBarEnemy()],
+            playableRect: CGRect(x: 0, y: 0, width: 300, height: 300),
+            playerPosition: CGPoint(x: 150, y: 150),
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(frame.newEnemies.isEmpty)
+        XCTAssertTrue(frame.telegraphsToShow.isEmpty)
+    }
+
+    func testPaddleTrapPlacementAvoidsPlayerPickupsAndActiveEnemies() {
+        var configuration = paddleTrapTestConfiguration()
+        configuration.playerSafetyRadius = 30
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 117, y: 117)
+        let pickupCircle = CollisionCircle(center: CGPoint(x: 150, y: 117), radius: 16)
+        let activeEnemy = ArenaEnemy(
+            id: 20_000,
+            position: CGPoint(x: 183, y: 117),
+            radius: 8,
+            speed: 0
+        )
+
+        _ = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [activeEnemy],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: [pickupCircle]
+        )
+
+        let spawnFrame = director.update(
+            deltaTime: 1,
+            survivalTime: 91,
+            activeEnemies: [activeEnemy],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: [pickupCircle]
+        )
+
+        XCTAssertEqual(spawnFrame.newEnemies.count, 9)
+
+        for enemy in spawnFrame.newEnemies {
+            XCTAssertTrue(director.isSafeSpawn(
+                enemy.position,
+                avoiding: playerPosition,
+                pickupCircles: [pickupCircle]
+            ))
+            XCTAssertGreaterThan(
+                distance(from: enemy.position, to: activeEnemy.position),
+                activeEnemy.radius + enemy.radius
+            )
+        }
+    }
+
+    func testPendingPaddleTrapSpacingCanBlockNearbyTrap() {
+        var configuration = paddleTrapTestConfiguration()
+        configuration.maxPendingEnemyTelegraphs = 2
+        configuration.paddleTrapMinimumSpacing = 1_000
+        configuration.chaos.maxActiveEnemies = 40
+        configuration.chaos.maxActivePaddleTraps = 2
+        configuration.chaos.paddleTrapSpawnInterval = 0.1
+        var director = EnemySpawnDirector(configuration: configuration)
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let telegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertEqual(telegraphFrame.telegraphsToShow.count, 1)
+
+        let blockedFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90.1,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        XCTAssertTrue(blockedFrame.newEnemies.isEmpty)
+        XCTAssertTrue(blockedFrame.telegraphsToShow.isEmpty)
+    }
+
+    func testResetRestartsPaddleTrapTimersAndIDs() throws {
+        var director = EnemySpawnDirector(configuration: paddleTrapTestConfiguration())
+        let playableRect = CGRect(x: 0, y: 0, width: 300, height: 300)
+        let playerPosition = CGPoint(x: 150, y: 150)
+
+        let firstTelegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+        let firstSpawnFrame = director.update(
+            deltaTime: 1,
+            survivalTime: 91,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        director.reset()
+
+        let resetTelegraphFrame = director.update(
+            deltaTime: 0.1,
+            survivalTime: 90,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+        let resetSpawnFrame = director.update(
+            deltaTime: 1,
+            survivalTime: 91,
+            activeEnemies: [],
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: []
+        )
+
+        let firstEnemy = try XCTUnwrap(firstSpawnFrame.newEnemies.first)
+        let resetEnemy = try XCTUnwrap(resetSpawnFrame.newEnemies.first)
+        XCTAssertEqual(firstTelegraphFrame.telegraphsToShow.first?.id, 1)
+        XCTAssertEqual(resetTelegraphFrame.telegraphsToShow.first?.id, 1)
+        XCTAssertEqual(firstEnemy.id, 1)
+        XCTAssertEqual(resetEnemy.id, 1)
+        XCTAssertEqual(firstEnemy.paddleTrapID, 1)
+        XCTAssertEqual(resetEnemy.paddleTrapID, 1)
+        XCTAssertEqual(firstEnemy.position, resetEnemy.position)
+    }
+
+    private func paddleTrapTestConfiguration() -> EnemySpawnConfiguration {
+        var configuration = EnemySpawnConfiguration()
+        configuration.playerSafetyRadius = 20
+        configuration.paddleTrapTelegraphDuration = 1
+        configuration.paddleTrapMinimumSpacing = 64
+        configuration.warmup = disabledPhaseTuning(maxActiveEnemies: 20)
+        configuration.pressure = disabledPhaseTuning(maxActiveEnemies: 20)
+        configuration.chaos = paddleTrapPhaseTuning(
+            spawnInterval: 24,
+            maxTraps: 1,
+            lifetime: 7,
+            barCount: 4,
+            dotSpeed: 145
+        )
+        configuration.survivalHell = paddleTrapPhaseTuning(
+            spawnInterval: 18,
+            maxTraps: 2,
+            lifetime: 8,
+            barCount: 5,
+            dotSpeed: 170
+        )
+        return configuration
+    }
+
+    private func paddleTrapPhaseTuning(
+        spawnInterval: TimeInterval,
+        maxTraps: Int,
+        lifetime: TimeInterval,
+        barCount: Int,
+        dotSpeed: CGFloat
+    ) -> EnemyPhaseTuning {
+        EnemyPhaseTuning(
+            chaserSpawnInterval: 0,
+            chaserSpeed: 0,
+            maxActiveEnemies: 20,
+            formationSpawnInterval: nil,
+            formationSpeed: 0,
+            formationLaneCount: 5,
+            arrowRushSpawnInterval: nil,
+            arrowRushSpeed: 0,
+            arrowRushEnemyCount: 0,
+            mineDotSpawnInterval: nil,
+            maxActiveMineDots: 0,
+            hunterDotSpawnInterval: nil,
+            hunterDotSpeed: 0,
+            hunterDotPredictionLead: 0,
+            maxActiveHunterDots: 0,
+            paddleTrapSpawnInterval: spawnInterval,
+            maxActivePaddleTraps: maxTraps,
+            paddleTrapLifetime: lifetime,
+            paddleTrapBarEnemyCount: barCount,
+            paddleTrapDotSpeed: dotSpeed
+        )
+    }
+
+    private func disabledPhaseTuning(maxActiveEnemies: Int) -> EnemyPhaseTuning {
+        EnemyPhaseTuning(
+            chaserSpawnInterval: 0,
+            chaserSpeed: 0,
+            maxActiveEnemies: maxActiveEnemies,
+            formationSpawnInterval: nil,
+            formationSpeed: 0,
+            formationLaneCount: 5
+        )
+    }
+
+    private func paddleTrapBarEnemy() -> ArenaEnemy {
+        ArenaEnemy(
+            id: 10_000,
+            position: CGPoint(x: 20, y: 20),
+            radius: 8,
+            speed: 0,
+            behavior: .paddleTrapBar(trapID: 99, remainingLifetime: 7)
+        )
+    }
+
+    private func isPaddleTrapBar(_ enemy: ArenaEnemy) -> Bool {
+        guard case .paddleTrapBar = enemy.behavior else {
+            return false
+        }
+
+        return true
+    }
+
+    private func isPaddleTrapDot(_ enemy: ArenaEnemy) -> Bool {
+        guard case .paddleTrapDot = enemy.behavior else {
+            return false
+        }
+
+        return true
+    }
+
+    private func paddleTrapDotVelocity(for enemy: ArenaEnemy) -> CGVector {
+        guard case let .paddleTrapDot(_, velocity, _, _) = enemy.behavior else {
+            XCTFail("Expected Paddle Trap dot behavior.")
+            return .zero
+        }
+
+        return velocity
+    }
+
+    private func distance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        hypot(lhs.x - rhs.x, lhs.y - rhs.y)
+    }
+}


### PR DESCRIPTION
## Summary
- add Paddle Trap bar and bouncing-dot enemy behaviors
- schedule Paddle Trap telegraphs during Chaos and Survival Hell with total and trap-specific cap handling
- expire trap components without score/combo credit and add focused coverage

## Validation
- xcodegen generate
- swiftlint lint --no-cache
- git diff --check
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test

Parent: #9
Closes #34