### PR TITLE
Add Nova Bomb weapon pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -453,6 +453,8 @@ final class ArenaScene: SKScene {
             playSeekerSwarmEffect(from: playerPosition, to: targetPositions)
         case .razorShield:
             activateRazorShield(at: playerPosition)
+        case .novaBomb:
+            playNovaBombEffect()
         }
 
         destroyEnemies(ids: resolution.destroyedEnemyIDs, weaponKind: kind)
@@ -565,6 +567,32 @@ final class ArenaScene: SKScene {
             .fadeOut(withDuration: 0.16)
         ])
         ring.run(.sequence([expand, .removeFromParent()]))
+    }
+
+    private func playNovaBombEffect() {
+        let playableRect = movementController.configuration.playableRect(in: size)
+
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return
+        }
+
+        let center = CGPoint(x: playableRect.midX, y: playableRect.midY)
+        let radius = hypot(playableRect.width, playableRect.height) / 2
+        let ring = SKShapeNode(circleOfRadius: radius)
+        ring.position = center
+        ring.strokeColor = theme.pickupAmber.withAlphaComponent(0.85)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 6
+        ring.zPosition = 18
+        ring.setScale(0.05)
+        addChild(ring)
+
+        let clearPulse = SKAction.group([
+            .scale(to: 1.0, duration: 0.22),
+            .fadeOut(withDuration: 0.22)
+        ])
+        ring.run(.sequence([clearPulse, .removeFromParent()]))
     }
 
     private func playSeekerSwarmEffect(from origin: CGPoint, to targets: [CGPoint]) {

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -2,6 +2,16 @@ import CoreGraphics
 import Foundation
 
 struct PickupSpawnConfiguration: Equatable {
+    static let defaultWeaponKindCycle: [WeaponKind] = [
+        .shockwave,
+        .seekerSwarm,
+        .razorShield,
+        .shockwave,
+        .seekerSwarm,
+        .razorShield,
+        .novaBomb
+    ]
+
     var initialSpawnDelay: TimeInterval = 4.5
     var spawnInterval: TimeInterval = 4.5
     var maxActivePickups: Int = 2
@@ -9,6 +19,7 @@ struct PickupSpawnConfiguration: Equatable {
     var edgeInset: CGFloat = 44
     var playerClearance: CGFloat = 84
     var enemyClearance: CGFloat = 8
+    var weaponKindCycle: [WeaponKind] = PickupSpawnConfiguration.defaultWeaponKindCycle
 }
 
 struct PickupSpawnPlanner {
@@ -96,6 +107,10 @@ struct PickupSpawnPlanner {
             return nil
         }
 
+        guard !configuration.weaponKindCycle.isEmpty else {
+            return nil
+        }
+
         for _ in 0..<Self.candidatePositions.count {
             let position = candidatePosition(in: spawnRect, index: nextCandidateIndex)
             nextCandidateIndex += 1
@@ -111,7 +126,7 @@ struct PickupSpawnPlanner {
 
             let pickup = WeaponPickup(
                 id: nextPickupID,
-                kind: nextKind(),
+                kind: nextKind(configuration: configuration),
                 position: position,
                 radius: configuration.pickupRadius
             )
@@ -139,9 +154,8 @@ struct PickupSpawnPlanner {
         }
     }
 
-    private mutating func nextKind() -> WeaponKind {
-        let kinds = WeaponKind.allCases
-        let kind = kinds[nextKindIndex % kinds.count]
+    private mutating func nextKind(configuration: PickupSpawnConfiguration) -> WeaponKind {
+        let kind = configuration.weaponKindCycle[nextKindIndex % configuration.weaponKindCycle.count]
         nextKindIndex += 1
         return kind
     }

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -23,6 +23,8 @@ struct StartingWeaponResolver {
             return WeaponResolution(destroyedEnemyIDs: seekerTargets(playerPosition: playerPosition, enemies: enemies))
         case .razorShield:
             return WeaponResolution()
+        case .novaBomb:
+            return WeaponResolution(destroyedEnemyIDs: Set(enemies.map(\.id)))
         }
     }
 

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -2,6 +2,7 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case shockwave
     case seekerSwarm
     case razorShield
+    case novaBomb
 
     var displayName: String {
         switch self {
@@ -11,6 +12,8 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
             return "Seeker Swarm"
         case .razorShield:
             return "Razor Shield"
+        case .novaBomb:
+            return "Nova Bomb"
         }
     }
 }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -44,6 +44,8 @@ final class WeaponPickupNode: SKNode {
             return theme.pickupViolet
         case .razorShield:
             return theme.pickupBlue
+        case .novaBomb:
+            return theme.pickupAmber
         }
     }
 

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -106,7 +106,10 @@ final class PickupSpawnPlannerTests: XCTestCase {
     }
 
     func testResetRestartsPickupIDsAndKindCycle() {
-        let configuration = PickupSpawnConfiguration(initialSpawnDelay: 0)
+        let configuration = PickupSpawnConfiguration(
+            initialSpawnDelay: 0,
+            weaponKindCycle: [.seekerSwarm, .novaBomb]
+        )
         var planner = PickupSpawnPlanner(configuration: configuration)
         let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
         let playerPosition = CGPoint(x: 160, y: 320)
@@ -126,8 +129,65 @@ final class PickupSpawnPlannerTests: XCTestCase {
         )
 
         XCTAssertEqual(first?.id, 1)
-        XCTAssertEqual(first?.kind, .shockwave)
+        XCTAssertEqual(first?.kind, .seekerSwarm)
         XCTAssertEqual(resetFirst?.id, 1)
-        XCTAssertEqual(resetFirst?.kind, .shockwave)
+        XCTAssertEqual(resetFirst?.kind, .seekerSwarm)
+    }
+
+    func testConfiguredKindCycleControlsPickupOrder() {
+        let configuration = PickupSpawnConfiguration(
+            initialSpawnDelay: 0,
+            weaponKindCycle: [.razorShield, .novaBomb]
+        )
+
+        XCTAssertEqual(spawnKinds(count: 4, configuration: configuration), [
+            .razorShield,
+            .novaBomb,
+            .razorShield,
+            .novaBomb
+        ])
+    }
+
+    func testDefaultKindCycleMakesNovaBombRare() {
+        let kinds = spawnKinds(
+            count: PickupSpawnConfiguration.defaultWeaponKindCycle.count,
+            configuration: PickupSpawnConfiguration()
+        )
+
+        XCTAssertEqual(kinds, PickupSpawnConfiguration.defaultWeaponKindCycle)
+        XCTAssertEqual(kinds.filter { $0 == .novaBomb }.count, 1)
+        XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, 1)
+        XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, 1)
+        XCTAssertGreaterThan(kinds.filter { $0 == .razorShield }.count, 1)
+    }
+
+    func testEmptyKindCycleDoesNotSpawnPickup() {
+        let configuration = PickupSpawnConfiguration(
+            initialSpawnDelay: 0,
+            weaponKindCycle: []
+        )
+        var planner = PickupSpawnPlanner(configuration: configuration)
+
+        XCTAssertNil(planner.spawnPickup(
+            in: CGRect(x: 0, y: 0, width: 320, height: 640),
+            avoiding: CGPoint(x: -1_000, y: -1_000),
+            enemyCircles: [],
+            configuration: configuration
+        ))
+    }
+
+    private func spawnKinds(count: Int, configuration: PickupSpawnConfiguration) -> [WeaponKind] {
+        var planner = PickupSpawnPlanner(configuration: configuration)
+        let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let playerPosition = CGPoint(x: -1_000, y: -1_000)
+
+        return (0..<count).compactMap { _ in
+            planner.spawnPickup(
+                in: rect,
+                avoiding: playerPosition,
+                enemyCircles: [],
+                configuration: configuration
+            )?.kind
+        }
     }
 }

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -58,6 +58,35 @@ final class StartingWeaponResolverTests: XCTestCase {
         XCTAssertEqual(resolver.shieldTargets(playerPosition: .zero, enemies: enemies), [1])
     }
 
+    func testNovaBombClearsAllEnemies() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 200, y: 0)),
+            enemy(id: 2, position: CGPoint(x: -40, y: 70)),
+            enemy(id: 3, position: CGPoint(x: 0, y: -120))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .novaBomb,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [1, 2, 3])
+    }
+
+    func testNovaBombHandlesEmptyArena() {
+        let resolver = StartingWeaponResolver()
+
+        let resolution = resolver.resolve(
+            kind: .novaBomb,
+            playerPosition: .zero,
+            enemies: []
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+    }
+
     private func enemy(id: Int, position: CGPoint) -> ArenaEnemy {
         ArenaEnemy(id: id, position: position, radius: 8, speed: 0)
     }


### PR DESCRIPTION
## Summary
- Add Nova Bomb as a rare high-impact weapon pickup.
- Route Nova Bomb through the existing resolver and enemy destruction path so score, combo, best-weapon, and formation completion behavior stay shared.
- Add a minimal arena-wide pulse effect and configurable pickup kind cycle so Nova Bomb can be rare without relying on `WeaponKind.allCases` order.

## Validation
- xcodegen generate
- swiftlint lint --no-cache
- git diff --check
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test

Parent: #10
Closes #36