### PR TITLE
Add Gravity Well weapon pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -1,5 +1,11 @@
 import SpriteKit
 
+private struct GravityWellState {
+    let center: CGPoint
+    let enemyIDs: Set<Int>
+    var timeRemaining: TimeInterval
+}
+
 final class ArenaScene: SKScene {
     private let theme = ArenaTheme.darkTacticalRadar
     private let tiltSettingsStore = TiltSettingsStore()
@@ -25,6 +31,8 @@ final class ArenaScene: SKScene {
     private var razorShieldTimeRemaining: TimeInterval = 0
     private var razorShieldNode: SKShapeNode?
     private var frozenCrasherTimeRemaining: TimeInterval = 0
+    private var gravityWellState: GravityWellState?
+    private var gravityWellEffectNode: SKNode?
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let centerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let detailLabel = SKLabelNode(fontNamed: "Menlo")
@@ -279,6 +287,7 @@ final class ArenaScene: SKScene {
         pickupPlanner.reset(configuration: pickupSpawnConfiguration)
         deactivateRazorShield()
         frozenCrasherTimeRemaining = 0
+        deactivateGravityWell()
     }
 
     private func resetPlayerFeedback() {
@@ -293,6 +302,7 @@ final class ArenaScene: SKScene {
         spawnPickupIfNeeded(deltaTime: deltaTime, playerPosition: playerPosition)
         collectPickups(playerPosition: playerPosition)
         advanceEnemies(deltaTime: deltaTime, playerPosition: playerPosition)
+        updateGravityWell(deltaTime: deltaTime)
         removeExpiredEnemies()
         cullExitedLinearPatternEnemies()
         updateRazorShield(deltaTime: deltaTime, playerPosition: playerPosition)
@@ -464,6 +474,11 @@ final class ArenaScene: SKScene {
                 weaponResolver.configuration.frozenCrasherDuration
             )
             playFreezeBurstEffect(at: playerPosition)
+        case .gravityWell:
+            activateGravityWell(
+                at: playerPosition,
+                enemyIDs: resolution.gravityWellEnemyIDs
+            )
         case .novaBomb:
             playNovaBombEffect()
         }
@@ -564,71 +579,6 @@ final class ArenaScene: SKScene {
         razorShieldTimeRemaining = 0
         razorShieldNode?.removeFromParent()
         razorShieldNode = nil
-    }
-
-    private func playShockwaveEffect(at position: CGPoint) {
-        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.shockwaveRadius)
-        ring.position = position
-        ring.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
-        ring.fillColor = .clear
-        ring.lineWidth = 2
-        ring.glowWidth = 5
-        ring.zPosition = 18
-        ring.setScale(0.2)
-        addChild(ring)
-
-        let expand = SKAction.group([
-            .scale(to: 1.0, duration: 0.16),
-            .fadeOut(withDuration: 0.16)
-        ])
-        ring.run(.sequence([expand, .removeFromParent()]))
-    }
-
-    private func playNovaBombEffect() {
-        let playableRect = movementController.configuration.playableRect(in: size)
-
-        guard playableRect.width > 0, playableRect.height > 0 else {
-            return
-        }
-
-        let center = CGPoint(x: playableRect.midX, y: playableRect.midY)
-        let radius = hypot(playableRect.width, playableRect.height) / 2
-        let ring = SKShapeNode(circleOfRadius: radius)
-        ring.position = center
-        ring.strokeColor = theme.pickupAmber.withAlphaComponent(0.85)
-        ring.fillColor = .clear
-        ring.lineWidth = 2
-        ring.glowWidth = 6
-        ring.zPosition = 18
-        ring.setScale(0.05)
-        addChild(ring)
-
-        let clearPulse = SKAction.group([
-            .scale(to: 1.0, duration: 0.22),
-            .fadeOut(withDuration: 0.22)
-        ])
-        ring.run(.sequence([clearPulse, .removeFromParent()]))
-    }
-
-    private func playSeekerSwarmEffect(from origin: CGPoint, to targets: [CGPoint]) {
-        for target in targets {
-            let path = CGMutablePath()
-            path.move(to: origin)
-            path.addLine(to: target)
-
-            let streak = SKShapeNode(path: path)
-            streak.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
-            streak.lineWidth = 1.5
-            streak.glowWidth = 3
-            streak.zPosition = 18
-            addChild(streak)
-
-            let fade = SKAction.group([
-                .fadeOut(withDuration: 0.12),
-                .scale(to: 0.9, duration: 0.12)
-            ])
-            streak.run(.sequence([fade, .removeFromParent()]))
-        }
     }
 
     private func detectPlayerCollision(playerPosition: CGPoint) {
@@ -827,11 +777,66 @@ final class ArenaScene: SKScene {
 }
 
 private extension ArenaScene {
+    func activateGravityWell(at center: CGPoint, enemyIDs: Set<Int>) {
+        gravityWellState = GravityWellState(
+            center: center,
+            enemyIDs: enemyIDs,
+            timeRemaining: weaponResolver.configuration.gravityWellPullDuration
+        )
+        playGravityWellEffect(at: center)
+    }
+
+    func updateGravityWell(deltaTime: TimeInterval) {
+        guard var state = gravityWellState else {
+            return
+        }
+
+        let clampedDelta = max(0, deltaTime)
+        let pullDuration = max(weaponResolver.configuration.gravityWellPullDuration, 0.001)
+        let pullDistance = weaponResolver.configuration.gravityWellRadius / CGFloat(pullDuration) * CGFloat(clampedDelta)
+
+        for index in enemies.indices where state.enemyIDs.contains(enemies[index].id) {
+            enemies[index].pullToward(state.center, distance: pullDistance)
+            enemyNodes[enemies[index].id]?.apply(enemies[index])
+        }
+
+        state.timeRemaining = max(0, state.timeRemaining - clampedDelta)
+
+        guard state.timeRemaining == 0 else {
+            gravityWellState = state
+            return
+        }
+
+        completeGravityWell(state)
+    }
+
+    func completeGravityWell(_ state: GravityWellState) {
+        gravityWellState = nil
+        gravityWellEffectNode?.removeFromParent()
+        gravityWellEffectNode = nil
+
+        let clearCircle = CollisionCircle(
+            center: state.center,
+            radius: weaponResolver.configuration.gravityWellClearRadius
+        )
+        let destroyedIDs = Set(
+            enemies
+                .filter { state.enemyIDs.contains($0.id) && !$0.isFrozen && clearCircle.intersects($0.collisionCircle) }
+                .map(\.id)
+        )
+        destroyEnemies(ids: destroyedIDs, weaponKind: .gravityWell)
+    }
+
+    func deactivateGravityWell() {
+        gravityWellState = nil
+        gravityWellEffectNode?.removeFromParent()
+        gravityWellEffectNode = nil
+    }
+
     func freezeEnemies(ids enemyIDs: Set<Int>, duration: TimeInterval) {
         guard !enemyIDs.isEmpty, duration > 0 else {
             return
         }
-
         for index in enemies.indices where enemyIDs.contains(enemies[index].id) {
             enemies[index].freeze(duration: duration)
             enemyNodes[enemies[index].id]?.apply(enemies[index])
@@ -850,7 +855,6 @@ private extension ArenaScene {
         guard frozenCrasherTimeRemaining > 0 else {
             return
         }
-
         let playerCircle = CollisionCircle(
             center: playerPosition,
             radius: runController.configuration.playerHitRadius
@@ -864,10 +868,73 @@ private extension ArenaScene {
         guard !shatterIDs.isEmpty else {
             return
         }
-
         playFrozenShatterEffect(at: positions(forEnemyIDs: shatterIDs))
         runController.recordFrozenShatters(count: shatterIDs.count, weaponKind: .freezeBurst)
         removeEnemies(ids: shatterIDs)
+    }
+
+    func playShockwaveEffect(at position: CGPoint) {
+        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.shockwaveRadius)
+        ring.position = position
+        ring.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 5
+        ring.zPosition = 18
+        ring.setScale(0.2)
+        addChild(ring)
+        let expand = SKAction.group([
+            .scale(to: 1.0, duration: 0.16),
+            .fadeOut(withDuration: 0.16)
+        ])
+        ring.run(.sequence([expand, .removeFromParent()]))
+    }
+
+    func playNovaBombEffect() {
+        let playableRect = movementController.configuration.playableRect(in: size)
+
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return
+        }
+
+        let center = CGPoint(x: playableRect.midX, y: playableRect.midY)
+        let radius = hypot(playableRect.width, playableRect.height) / 2
+        let ring = SKShapeNode(circleOfRadius: radius)
+        ring.position = center
+        ring.strokeColor = theme.pickupAmber.withAlphaComponent(0.85)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 6
+        ring.zPosition = 18
+        ring.setScale(0.05)
+        addChild(ring)
+
+        let clearPulse = SKAction.group([
+            .scale(to: 1.0, duration: 0.22),
+            .fadeOut(withDuration: 0.22)
+        ])
+        ring.run(.sequence([clearPulse, .removeFromParent()]))
+    }
+
+    func playSeekerSwarmEffect(from origin: CGPoint, to targets: [CGPoint]) {
+        for target in targets {
+            let path = CGMutablePath()
+            path.move(to: origin)
+            path.addLine(to: target)
+
+            let streak = SKShapeNode(path: path)
+            streak.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
+            streak.lineWidth = 1.5
+            streak.glowWidth = 3
+            streak.zPosition = 18
+            addChild(streak)
+
+            let fade = SKAction.group([
+                .fadeOut(withDuration: 0.12),
+                .scale(to: 0.9, duration: 0.12)
+            ])
+            streak.run(.sequence([fade, .removeFromParent()]))
+        }
     }
 
     func playFreezeBurstEffect(at position: CGPoint) {
@@ -886,6 +953,27 @@ private extension ArenaScene {
             .fadeOut(withDuration: 0.18)
         ])
         ring.run(.sequence([expand, .removeFromParent()]))
+    }
+
+    func playGravityWellEffect(at position: CGPoint) {
+        gravityWellEffectNode?.removeFromParent()
+        let container = SKNode()
+        container.position = position
+        container.zPosition = 18
+        addChild(container)
+        gravityWellEffectNode = container
+        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.gravityWellRadius)
+        ring.strokeColor = theme.pickupViolet.withAlphaComponent(0.7)
+        ring.fillColor = theme.pickupBlue.withAlphaComponent(0.08)
+        ring.lineWidth = 1.8
+        ring.glowWidth = 5
+        container.addChild(ring)
+        let duration = max(0.12, weaponResolver.configuration.gravityWellPullDuration)
+        let pulse = SKAction.group([
+            .scale(to: 0.25, duration: duration),
+            .fadeOut(withDuration: duration)
+        ])
+        container.run(.sequence([pulse, .removeFromParent()]))
     }
 
     func playFrozenShatterEffect(at positions: [CGPoint]) {

--- a/TiltArena/Game/Enemies/ArenaEnemy.swift
+++ b/TiltArena/Game/Enemies/ArenaEnemy.swift
@@ -83,6 +83,26 @@ struct ArenaEnemy: Equatable, Identifiable {
         frozenTimeRemaining = max(frozenTimeRemaining, max(0, duration))
     }
 
+    mutating func pullToward(_ target: CGPoint, distance: CGFloat) {
+        guard !isFrozen else {
+            return
+        }
+
+        let dx = target.x - position.x
+        let dy = target.y - position.y
+        let targetDistance = hypot(dx, dy)
+        let clampedDistance = min(max(0, distance), targetDistance)
+
+        guard targetDistance > 0, clampedDistance > 0 else {
+            return
+        }
+
+        position = CGPoint(
+            x: position.x + dx / targetDistance * clampedDistance,
+            y: position.y + dy / targetDistance * clampedDistance
+        )
+    }
+
     mutating func advance(toward target: CGPoint, deltaTime: TimeInterval) {
         let clampedTime = max(0, deltaTime)
         let clampedDelta = CGFloat(clampedTime)

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -7,6 +7,7 @@ struct PickupSpawnConfiguration: Equatable {
         .seekerSwarm,
         .razorShield,
         .freezeBurst,
+        .gravityWell,
         .shockwave,
         .seekerSwarm,
         .razorShield,
@@ -14,6 +15,11 @@ struct PickupSpawnConfiguration: Equatable {
         .shockwave,
         .seekerSwarm,
         .razorShield,
+        .gravityWell,
+        .shockwave,
+        .seekerSwarm,
+        .razorShield,
+        .freezeBurst,
         .novaBomb
     ]
 

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -9,11 +9,15 @@ struct StartingWeaponConfiguration: Equatable {
     var freezeBurstRadius: CGFloat = 112
     var freezeDuration: TimeInterval = 4
     var frozenCrasherDuration: TimeInterval = 2.4
+    var gravityWellRadius: CGFloat = 132
+    var gravityWellPullDuration: TimeInterval = 0.85
+    var gravityWellClearRadius: CGFloat = 32
 }
 
 struct WeaponResolution: Equatable {
     var destroyedEnemyIDs: Set<Int> = []
     var frozenEnemyIDs: Set<Int> = []
+    var gravityWellEnemyIDs: Set<Int> = []
 }
 
 struct StartingWeaponResolver {
@@ -29,6 +33,8 @@ struct StartingWeaponResolver {
             return WeaponResolution()
         case .freezeBurst:
             return WeaponResolution(frozenEnemyIDs: freezeBurstTargets(playerPosition: playerPosition, enemies: enemies))
+        case .gravityWell:
+            return WeaponResolution(gravityWellEnemyIDs: gravityWellTargets(playerPosition: playerPosition, enemies: enemies))
         case .novaBomb:
             return WeaponResolution(destroyedEnemyIDs: Set(enemies.map(\.id)))
         }
@@ -65,6 +71,11 @@ struct StartingWeaponResolver {
     private func freezeBurstTargets(playerPosition: CGPoint, enemies: [ArenaEnemy]) -> Set<Int> {
         let freezeCircle = CollisionCircle(center: playerPosition, radius: configuration.freezeBurstRadius)
         return Set(enemies.filter { freezeCircle.intersects($0.collisionCircle) }.map(\.id))
+    }
+
+    private func gravityWellTargets(playerPosition: CGPoint, enemies: [ArenaEnemy]) -> Set<Int> {
+        let wellCircle = CollisionCircle(center: playerPosition, radius: configuration.gravityWellRadius)
+        return Set(enemies.filter { !$0.isFrozen && wellCircle.intersects($0.collisionCircle) }.map(\.id))
     }
 
     private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -3,6 +3,7 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case seekerSwarm
     case razorShield
     case freezeBurst
+    case gravityWell
     case novaBomb
 
     var displayName: String {
@@ -15,6 +16,8 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
             return "Razor Shield"
         case .freezeBurst:
             return "Freeze Burst"
+        case .gravityWell:
+            return "Gravity Well"
         case .novaBomb:
             return "Nova Bomb"
         }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -46,6 +46,8 @@ final class WeaponPickupNode: SKNode {
             return theme.pickupBlue
         case .freezeBurst:
             return theme.pickupBlue
+        case .gravityWell:
+            return theme.pickupViolet
         case .novaBomb:
             return theme.pickupAmber
         }

--- a/TiltArenaTests/ArenaEnemyTests.swift
+++ b/TiltArenaTests/ArenaEnemyTests.swift
@@ -115,6 +115,26 @@ final class ArenaEnemyTests: XCTestCase {
         XCTAssertEqual(enemy.formationID, 4)
     }
 
+    func testGravityPullMovesTowardTargetWithoutOvershootingOrMovingFrozenEnemies() {
+        var enemy = ArenaEnemy(id: 1, position: CGPoint(x: 0, y: 0), radius: 8, speed: 0)
+
+        enemy.pullToward(CGPoint(x: 30, y: 40), distance: 25)
+
+        XCTAssertEqual(enemy.position.x, 15, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 20, accuracy: 0.0001)
+
+        enemy.pullToward(CGPoint(x: 30, y: 40), distance: 100)
+
+        XCTAssertEqual(enemy.position.x, 30, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 40, accuracy: 0.0001)
+
+        enemy.freeze(duration: 1)
+        enemy.pullToward(.zero, distance: 100)
+
+        XCTAssertEqual(enemy.position.x, 30, accuracy: 0.0001)
+        XCTAssertEqual(enemy.position.y, 40, accuracy: 0.0001)
+    }
+
     func testHunterDotUsesPredictedPlayerPosition() {
         var enemy = ArenaEnemy(
             id: 1,

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -148,19 +148,21 @@ final class PickupSpawnPlannerTests: XCTestCase {
         ])
     }
 
-    func testDefaultKindCycleMakesFreezeMidRarityAndNovaBombRare() {
+    func testDefaultKindCycleMakesGravityWellRareAndNovaBombRarest() {
         let kinds = spawnKinds(
             count: PickupSpawnConfiguration.defaultWeaponKindCycle.count,
             configuration: PickupSpawnConfiguration()
         )
 
         XCTAssertEqual(kinds, PickupSpawnConfiguration.defaultWeaponKindCycle)
-        XCTAssertEqual(kinds.filter { $0 == .freezeBurst }.count, 2)
+        XCTAssertEqual(kinds.filter { $0 == .freezeBurst }.count, 3)
+        XCTAssertEqual(kinds.filter { $0 == .gravityWell }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .novaBomb }.count, 1)
-        XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, 2)
-        XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, 2)
-        XCTAssertGreaterThan(kinds.filter { $0 == .razorShield }.count, 2)
-        XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .novaBomb }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, kinds.filter { $0 == .freezeBurst }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, kinds.filter { $0 == .freezeBurst }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .razorShield }.count, kinds.filter { $0 == .freezeBurst }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .gravityWell }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .gravityWell }.count, kinds.filter { $0 == .novaBomb }.count)
     }
 
     func testEmptyKindCycleDoesNotSpawnPickup() {

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -90,6 +90,41 @@ final class StartingWeaponResolverTests: XCTestCase {
         XCTAssertEqual(resolution.frozenEnemyIDs, [])
     }
 
+    func testGravityWellTargetsUnfrozenEnemiesInsideRadiusWithoutDestroyingThem() {
+        let resolver = StartingWeaponResolver(
+            configuration: StartingWeaponConfiguration(gravityWellRadius: 50)
+        )
+        var frozenEnemy = enemy(id: 3, position: CGPoint(x: 20, y: 0))
+        frozenEnemy.freeze(duration: 1)
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 20, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 80, y: 0)),
+            frozenEnemy
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .gravityWell,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+        XCTAssertEqual(resolution.gravityWellEnemyIDs, [1])
+    }
+
+    func testGravityWellHandlesEmptyArena() {
+        let resolver = StartingWeaponResolver()
+
+        let resolution = resolver.resolve(
+            kind: .gravityWell,
+            playerPosition: .zero,
+            enemies: []
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+        XCTAssertEqual(resolution.gravityWellEnemyIDs, [])
+    }
+
     func testNovaBombClearsAllEnemies() {
         let resolver = StartingWeaponResolver()
         let enemies = [


### PR DESCRIPTION
## Summary
- Add Gravity Well as a violet control pickup with rare pickup cadence.
- Pull captured non-frozen enemies toward the pickup center, then clear enemies still inside the completion radius through existing scoring paths.
- Add focused resolver, enemy movement, pickup cadence, and model tests while preserving existing weapon behavior.

## Validation
- xcodegen generate
- swiftlint lint --no-cache
- git diff --check
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test

Parent: #10
Closes #40