### PR TITLE
Lock app orientation to landscape

### DIFF
--- a/TiltArena/App/GameViewController.swift
+++ b/TiltArena/App/GameViewController.swift
@@ -35,7 +35,7 @@ final class GameViewController: UIViewController {
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        .portrait
+        .landscape
     }
 
     override var prefersHomeIndicatorAutoHidden: Bool {

--- a/TiltArena/Resources/Info.plist
+++ b/TiltArena/Resources/Info.plist
@@ -33,7 +33,8 @@
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Restrict supported iPhone app orientations to landscape left and landscape right in `Info.plist`.
- Update `GameViewController` to report landscape-only runtime orientation support.

## Validation
- `xcodegen generate`
- `plutil -lint TiltArena/Resources/Info.plist`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`

Closes #42