### PR TITLE
Add Chain Lightning weapon pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -479,6 +479,14 @@ final class ArenaScene: SKScene {
                 at: playerPosition,
                 enemyIDs: resolution.gravityWellEnemyIDs
             )
+        case .chainLightning:
+            let targetPositions = positions(forEnemyIDs: resolution.chainLightningEnemyIDs)
+            playChainLightningEffect(
+                from: playerPosition,
+                through: targetPositions,
+                accentColor: theme.playerAccentColor,
+                coreColor: theme.playerColor
+            )
         case .novaBomb:
             playNovaBombEffect()
         }
@@ -488,6 +496,11 @@ final class ArenaScene: SKScene {
 
     private func positions(forEnemyIDs enemyIDs: Set<Int>) -> [CGPoint] {
         enemies.compactMap { enemyIDs.contains($0.id) ? $0.position : nil }
+    }
+
+    private func positions(forEnemyIDs enemyIDs: [Int]) -> [CGPoint] {
+        let positionsByID = Dictionary(uniqueKeysWithValues: enemies.map { ($0.id, $0.position) })
+        return enemyIDs.compactMap { positionsByID[$0] }
     }
 
     private func destroyEnemies(ids enemyIDs: Set<Int>, weaponKind: WeaponKind?) {
@@ -868,7 +881,7 @@ private extension ArenaScene {
         guard !shatterIDs.isEmpty else {
             return
         }
-        playFrozenShatterEffect(at: positions(forEnemyIDs: shatterIDs))
+        playFrozenShatterEffect(at: positions(forEnemyIDs: shatterIDs), color: theme.playerColor)
         runController.recordFrozenShatters(count: shatterIDs.count, weaponKind: .freezeBurst)
         removeEnemies(ids: shatterIDs)
     }
@@ -976,23 +989,4 @@ private extension ArenaScene {
         container.run(.sequence([pulse, .removeFromParent()]))
     }
 
-    func playFrozenShatterEffect(at positions: [CGPoint]) {
-        for position in positions {
-            let ring = SKShapeNode(circleOfRadius: 16)
-            ring.position = position
-            ring.strokeColor = theme.playerColor.withAlphaComponent(0.9)
-            ring.fillColor = .clear
-            ring.lineWidth = 1.5
-            ring.glowWidth = 4
-            ring.zPosition = 18
-            ring.setScale(0.35)
-            addChild(ring)
-
-            let burst = SKAction.group([
-                .scale(to: 1.2, duration: 0.1),
-                .fadeOut(withDuration: 0.1)
-            ])
-            ring.run(.sequence([burst, .removeFromParent()]))
-        }
-    }
 }

--- a/TiltArena/Game/Weapons/ChainLightningEffect.swift
+++ b/TiltArena/Game/Weapons/ChainLightningEffect.swift
@@ -1,0 +1,37 @@
+import SpriteKit
+
+extension ArenaScene {
+    func playChainLightningEffect(
+        from origin: CGPoint,
+        through targets: [CGPoint],
+        accentColor: SKColor,
+        coreColor: SKColor
+    ) {
+        guard !targets.isEmpty else {
+            return
+        }
+
+        let path = CGMutablePath()
+        path.move(to: origin)
+        targets.forEach { path.addLine(to: $0) }
+
+        let bolt = SKShapeNode(path: path)
+        bolt.strokeColor = accentColor.withAlphaComponent(0.95)
+        bolt.lineWidth = 2
+        bolt.glowWidth = 5
+        bolt.zPosition = 18
+        addChild(bolt)
+
+        let core = SKShapeNode(path: path)
+        core.strokeColor = coreColor.withAlphaComponent(0.95)
+        core.lineWidth = 0.8
+        core.glowWidth = 1
+        bolt.addChild(core)
+
+        let fade = SKAction.group([
+            .fadeOut(withDuration: 0.14),
+            .scale(to: 0.98, duration: 0.14)
+        ])
+        bolt.run(.sequence([fade, .removeFromParent()]))
+    }
+}

--- a/TiltArena/Game/Weapons/FrozenShatterEffect.swift
+++ b/TiltArena/Game/Weapons/FrozenShatterEffect.swift
@@ -1,0 +1,23 @@
+import SpriteKit
+
+extension ArenaScene {
+    func playFrozenShatterEffect(at positions: [CGPoint], color: SKColor) {
+        for position in positions {
+            let ring = SKShapeNode(circleOfRadius: 16)
+            ring.position = position
+            ring.strokeColor = color.withAlphaComponent(0.9)
+            ring.fillColor = .clear
+            ring.lineWidth = 1.5
+            ring.glowWidth = 4
+            ring.zPosition = 18
+            ring.setScale(0.35)
+            addChild(ring)
+
+            let burst = SKAction.group([
+                .scale(to: 1.2, duration: 0.1),
+                .fadeOut(withDuration: 0.1)
+            ])
+            ring.run(.sequence([burst, .removeFromParent()]))
+        }
+    }
+}

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -11,6 +11,7 @@ struct PickupSpawnConfiguration: Equatable {
         .shockwave,
         .seekerSwarm,
         .razorShield,
+        .chainLightning,
         .freezeBurst,
         .shockwave,
         .seekerSwarm,
@@ -20,6 +21,7 @@ struct PickupSpawnConfiguration: Equatable {
         .seekerSwarm,
         .razorShield,
         .freezeBurst,
+        .chainLightning,
         .novaBomb
     ]
 

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -12,12 +12,16 @@ struct StartingWeaponConfiguration: Equatable {
     var gravityWellRadius: CGFloat = 132
     var gravityWellPullDuration: TimeInterval = 0.85
     var gravityWellClearRadius: CGFloat = 32
+    var chainLightningInitialRange: CGFloat = 128
+    var chainLightningJumpRange: CGFloat = 96
+    var chainLightningTargetLimit: Int = 6
 }
 
 struct WeaponResolution: Equatable {
     var destroyedEnemyIDs: Set<Int> = []
     var frozenEnemyIDs: Set<Int> = []
     var gravityWellEnemyIDs: Set<Int> = []
+    var chainLightningEnemyIDs: [Int] = []
 }
 
 struct StartingWeaponResolver {
@@ -35,6 +39,12 @@ struct StartingWeaponResolver {
             return WeaponResolution(frozenEnemyIDs: freezeBurstTargets(playerPosition: playerPosition, enemies: enemies))
         case .gravityWell:
             return WeaponResolution(gravityWellEnemyIDs: gravityWellTargets(playerPosition: playerPosition, enemies: enemies))
+        case .chainLightning:
+            let targetIDs = chainLightningTargets(playerPosition: playerPosition, enemies: enemies)
+            return WeaponResolution(
+                destroyedEnemyIDs: Set(targetIDs),
+                chainLightningEnemyIDs: targetIDs
+            )
         case .novaBomb:
             return WeaponResolution(destroyedEnemyIDs: Set(enemies.map(\.id)))
         }
@@ -76,6 +86,57 @@ struct StartingWeaponResolver {
     private func gravityWellTargets(playerPosition: CGPoint, enemies: [ArenaEnemy]) -> Set<Int> {
         let wellCircle = CollisionCircle(center: playerPosition, radius: configuration.gravityWellRadius)
         return Set(enemies.filter { !$0.isFrozen && wellCircle.intersects($0.collisionCircle) }.map(\.id))
+    }
+
+    private func chainLightningTargets(playerPosition: CGPoint, enemies: [ArenaEnemy]) -> [Int] {
+        let targetLimit = max(0, configuration.chainLightningTargetLimit)
+
+        guard targetLimit > 0 else {
+            return []
+        }
+
+        var targetIDs: [Int] = []
+        var selectedIDs = Set<Int>()
+        var origin = playerPosition
+        var range = configuration.chainLightningInitialRange
+
+        while targetIDs.count < targetLimit {
+            guard let target = nearestEnemy(
+                from: origin,
+                within: range,
+                excluding: selectedIDs,
+                enemies: enemies
+            ) else {
+                return targetIDs
+            }
+
+            targetIDs.append(target.id)
+            selectedIDs.insert(target.id)
+            origin = target.position
+            range = configuration.chainLightningJumpRange
+        }
+
+        return targetIDs
+    }
+
+    private func nearestEnemy(
+        from origin: CGPoint,
+        within range: CGFloat,
+        excluding selectedIDs: Set<Int>,
+        enemies: [ArenaEnemy]
+    ) -> ArenaEnemy? {
+        let maximumDistance = max(0, range)
+        let maximumSquaredDistance = maximumDistance * maximumDistance
+
+        return enemies
+            .filter { enemy in
+                !selectedIDs.contains(enemy.id)
+                    && squaredDistance(from: enemy.position, to: origin) <= maximumSquaredDistance
+            }
+            .min {
+                squaredDistance(from: $0.position, to: origin)
+                    < squaredDistance(from: $1.position, to: origin)
+            }
     }
 
     private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -4,6 +4,7 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case razorShield
     case freezeBurst
     case gravityWell
+    case chainLightning
     case novaBomb
 
     var displayName: String {
@@ -18,6 +19,8 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
             return "Freeze Burst"
         case .gravityWell:
             return "Gravity Well"
+        case .chainLightning:
+            return "Chain Lightning"
         case .novaBomb:
             return "Nova Bomb"
         }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -48,6 +48,8 @@ final class WeaponPickupNode: SKNode {
             return theme.pickupBlue
         case .gravityWell:
             return theme.pickupViolet
+        case .chainLightning:
+            return theme.pickupBlue
         case .novaBomb:
             return theme.pickupAmber
         }

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -148,7 +148,7 @@ final class PickupSpawnPlannerTests: XCTestCase {
         ])
     }
 
-    func testDefaultKindCycleMakesGravityWellRareAndNovaBombRarest() {
+    func testDefaultKindCycleMakesControlWeaponsRareAndNovaBombRarest() {
         let kinds = spawnKinds(
             count: PickupSpawnConfiguration.defaultWeaponKindCycle.count,
             configuration: PickupSpawnConfiguration()
@@ -157,12 +157,15 @@ final class PickupSpawnPlannerTests: XCTestCase {
         XCTAssertEqual(kinds, PickupSpawnConfiguration.defaultWeaponKindCycle)
         XCTAssertEqual(kinds.filter { $0 == .freezeBurst }.count, 3)
         XCTAssertEqual(kinds.filter { $0 == .gravityWell }.count, 2)
+        XCTAssertEqual(kinds.filter { $0 == .chainLightning }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .novaBomb }.count, 1)
         XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .razorShield }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .gravityWell }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .chainLightning }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .gravityWell }.count, kinds.filter { $0 == .novaBomb }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .chainLightning }.count, kinds.filter { $0 == .novaBomb }.count)
     }
 
     func testEmptyKindCycleDoesNotSpawnPickup() {

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -125,6 +125,91 @@ final class StartingWeaponResolverTests: XCTestCase {
         XCTAssertEqual(resolution.gravityWellEnemyIDs, [])
     }
 
+    func testChainLightningDestroysOrderedChainedTargets() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 100, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 150, y: 0)),
+            enemy(id: 3, position: CGPoint(x: 210, y: 0)),
+            enemy(id: 4, position: CGPoint(x: 60, y: 90))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .chainLightning,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [1, 2, 3])
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [1, 2, 3])
+    }
+
+    func testChainLightningStopsWhenNextTargetIsOutOfJumpRange() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 100, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 210, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .chainLightning,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [1])
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [1])
+    }
+
+    func testChainLightningRespectsTargetLimit() {
+        let resolver = StartingWeaponResolver(
+            configuration: StartingWeaponConfiguration(chainLightningTargetLimit: 2)
+        )
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 80, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 130, y: 0)),
+            enemy(id: 3, position: CGPoint(x: 180, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .chainLightning,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [1, 2])
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [1, 2])
+    }
+
+    func testChainLightningRequiresFirstTargetInsideInitialRange() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 129, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .chainLightning,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [])
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+    }
+
+    func testChainLightningHandlesEmptyArena() {
+        let resolver = StartingWeaponResolver()
+
+        let resolution = resolver.resolve(
+            kind: .chainLightning,
+            playerPosition: .zero,
+            enemies: []
+        )
+
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [])
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+    }
+
     func testNovaBombClearsAllEnemies() {
         let resolver = StartingWeaponResolver()
         let enemies = [


### PR DESCRIPTION
Closes #44. Summary: Adds Chain Lightning with ordered jump targeting, cyan-white fast-fading effect, default pickup-cycle frequency, and resolver/pickup tests. Validation: xcodegen generate; plutil -lint TiltArena/Resources/Info.plist; swiftlint lint --no-cache; xcodebuild Debug simulator build; xcodebuild build-for-testing.