### PR TITLE
Add Flame Trail weapon pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -1,19 +1,19 @@
 import SpriteKit
 
 final class ArenaScene: SKScene {
-    private let theme = ArenaTheme.darkTacticalRadar
+    let theme = ArenaTheme.darkTacticalRadar
     private let tiltSettingsStore = TiltSettingsStore()
     private let runProfileStore = RunProfileStore()
     private var arenaRoot = SKNode()
     private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
-    private var movementController = PlayerMovementController()
+    var movementController = PlayerMovementController()
     private var runController = ClassicRunController()
     private var runProfile = RunProfile()
     private var hasPersistedFinalRun = false
     private var spawnDirector = EnemySpawnDirector()
     private let pickupSpawnConfiguration = PickupSpawnConfiguration()
     private var pickupPlanner = PickupSpawnPlanner()
-    private let weaponResolver = StartingWeaponResolver()
+    let weaponResolver = StartingWeaponResolver()
     private var enemies: [ArenaEnemy] = []
     private var enemyNodes: [Int: EnemyNode] = [:]
     private var enemyTelegraphNodes: [Int: EnemyTelegraphNode] = [:]
@@ -25,8 +25,10 @@ final class ArenaScene: SKScene {
     private var razorShieldTimeRemaining: TimeInterval = 0
     private var razorShieldNode: SKShapeNode?
     private var frozenCrasherTimeRemaining: TimeInterval = 0
+    private var flameTrailState = FlameTrailState()
+    private lazy var flameTrailEffectNode = FlameTrailEffectNode(theme: theme)
     private var gravityWellState: GravityWellState?
-    private var gravityWellEffectNode: SKNode?
+    var gravityWellEffectNode: SKNode?
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let centerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let detailLabel = SKLabelNode(fontNamed: "Menlo")
@@ -51,6 +53,7 @@ final class ArenaScene: SKScene {
     override func didMove(to view: SKView) {
         runProfile = runProfileStore.profile
         rebuildArena()
+        if flameTrailEffectNode.parent == nil { addChild(flameTrailEffectNode) }
         configureLabels()
         configurePauseControl()
         placePlayer(resetPosition: true)
@@ -295,6 +298,8 @@ final class ArenaScene: SKScene {
         pickupPlanner.reset(configuration: pickupSpawnConfiguration)
         deactivateRazorShield()
         frozenCrasherTimeRemaining = 0
+        flameTrailState.reset()
+        flameTrailEffectNode.reset()
         deactivateGravityWell()
     }
 
@@ -316,6 +321,7 @@ final class ArenaScene: SKScene {
         updateRazorShield(deltaTime: deltaTime, playerPosition: playerPosition)
         shatterFrozenContactEnemies(playerPosition: playerPosition)
         updateFrozenCrasher(deltaTime: deltaTime)
+        updateFlameTrail(deltaTime: deltaTime, playerPosition: playerPosition)
         recordNearMisses(playerPosition: playerPosition)
         detectPlayerCollision(playerPosition: playerPosition)
         updateRunDisplay()
@@ -495,6 +501,9 @@ final class ArenaScene: SKScene {
                 accentColor: theme.playerAccentColor,
                 coreColor: theme.playerColor
             )
+        case .flameTrail:
+            flameTrailState.activate(at: playerPosition)
+            flameTrailEffectNode.apply(segments: flameTrailState.segments)
         case .novaBomb:
             playNovaBombEffect()
         }
@@ -600,6 +609,12 @@ final class ArenaScene: SKScene {
         razorShieldTimeRemaining = 0
         razorShieldNode?.removeFromParent()
         razorShieldNode = nil
+    }
+
+    private func updateFlameTrail(deltaTime: TimeInterval, playerPosition: CGPoint) {
+        let frame = flameTrailState.update(deltaTime: deltaTime, playerPosition: playerPosition, enemies: enemies)
+        destroyEnemies(ids: frame.burnedEnemyIDs, weaponKind: .flameTrail)
+        flameTrailEffectNode.apply(segments: frame.segments)
     }
 
     private func detectPlayerCollision(playerPosition: CGPoint) {
@@ -892,109 +907,6 @@ private extension ArenaScene {
         playFrozenShatterEffect(at: positions(forEnemyIDs: shatterIDs), color: theme.playerColor)
         runController.recordFrozenShatters(count: shatterIDs.count, weaponKind: .freezeBurst)
         removeEnemies(ids: shatterIDs)
-    }
-
-    func playShockwaveEffect(at position: CGPoint) {
-        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.shockwaveRadius)
-        ring.position = position
-        ring.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
-        ring.fillColor = .clear
-        ring.lineWidth = 2
-        ring.glowWidth = 5
-        ring.zPosition = 18
-        ring.setScale(0.2)
-        addChild(ring)
-        let expand = SKAction.group([
-            .scale(to: 1.0, duration: 0.16),
-            .fadeOut(withDuration: 0.16)
-        ])
-        ring.run(.sequence([expand, .removeFromParent()]))
-    }
-
-    func playNovaBombEffect() {
-        let playableRect = movementController.configuration.playableRect(in: size)
-
-        guard playableRect.width > 0, playableRect.height > 0 else {
-            return
-        }
-
-        let center = CGPoint(x: playableRect.midX, y: playableRect.midY)
-        let radius = hypot(playableRect.width, playableRect.height) / 2
-        let ring = SKShapeNode(circleOfRadius: radius)
-        ring.position = center
-        ring.strokeColor = theme.pickupAmber.withAlphaComponent(0.85)
-        ring.fillColor = .clear
-        ring.lineWidth = 2
-        ring.glowWidth = 6
-        ring.zPosition = 18
-        ring.setScale(0.05)
-        addChild(ring)
-
-        let clearPulse = SKAction.group([
-            .scale(to: 1.0, duration: 0.22),
-            .fadeOut(withDuration: 0.22)
-        ])
-        ring.run(.sequence([clearPulse, .removeFromParent()]))
-    }
-
-    func playSeekerSwarmEffect(from origin: CGPoint, to targets: [CGPoint]) {
-        for target in targets {
-            let path = CGMutablePath()
-            path.move(to: origin)
-            path.addLine(to: target)
-
-            let streak = SKShapeNode(path: path)
-            streak.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
-            streak.lineWidth = 1.5
-            streak.glowWidth = 3
-            streak.zPosition = 18
-            addChild(streak)
-
-            let fade = SKAction.group([
-                .fadeOut(withDuration: 0.12),
-                .scale(to: 0.9, duration: 0.12)
-            ])
-            streak.run(.sequence([fade, .removeFromParent()]))
-        }
-    }
-
-    func playFreezeBurstEffect(at position: CGPoint) {
-        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.freezeBurstRadius)
-        ring.position = position
-        ring.strokeColor = theme.pickupBlue.withAlphaComponent(0.85)
-        ring.fillColor = .clear
-        ring.lineWidth = 2
-        ring.glowWidth = 5
-        ring.zPosition = 18
-        ring.setScale(0.18)
-        addChild(ring)
-
-        let expand = SKAction.group([
-            .scale(to: 1.0, duration: 0.18),
-            .fadeOut(withDuration: 0.18)
-        ])
-        ring.run(.sequence([expand, .removeFromParent()]))
-    }
-
-    func playGravityWellEffect(at position: CGPoint) {
-        gravityWellEffectNode?.removeFromParent()
-        let container = SKNode()
-        container.position = position
-        container.zPosition = 18
-        addChild(container)
-        gravityWellEffectNode = container
-        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.gravityWellRadius)
-        ring.strokeColor = theme.pickupViolet.withAlphaComponent(0.7)
-        ring.fillColor = theme.pickupBlue.withAlphaComponent(0.08)
-        ring.lineWidth = 1.8
-        ring.glowWidth = 5
-        container.addChild(ring)
-        let duration = max(0.12, weaponResolver.configuration.gravityWellPullDuration)
-        let pulse = SKAction.group([
-            .scale(to: 0.25, duration: duration),
-            .fadeOut(withDuration: duration)
-        ])
-        container.run(.sequence([pulse, .removeFromParent()]))
     }
 
 }

--- a/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
+++ b/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
@@ -1,0 +1,106 @@
+import SpriteKit
+
+extension ArenaScene {
+    func playShockwaveEffect(at position: CGPoint) {
+        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.shockwaveRadius)
+        ring.position = position
+        ring.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 5
+        ring.zPosition = 18
+        ring.setScale(0.2)
+        addChild(ring)
+        let expand = SKAction.group([
+            .scale(to: 1.0, duration: 0.16),
+            .fadeOut(withDuration: 0.16)
+        ])
+        ring.run(.sequence([expand, .removeFromParent()]))
+    }
+
+    func playNovaBombEffect() {
+        let playableRect = movementController.configuration.playableRect(in: size)
+
+        guard playableRect.width > 0, playableRect.height > 0 else {
+            return
+        }
+
+        let center = CGPoint(x: playableRect.midX, y: playableRect.midY)
+        let radius = hypot(playableRect.width, playableRect.height) / 2
+        let ring = SKShapeNode(circleOfRadius: radius)
+        ring.position = center
+        ring.strokeColor = theme.pickupAmber.withAlphaComponent(0.85)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 6
+        ring.zPosition = 18
+        ring.setScale(0.05)
+        addChild(ring)
+
+        let clearPulse = SKAction.group([
+            .scale(to: 1.0, duration: 0.22),
+            .fadeOut(withDuration: 0.22)
+        ])
+        ring.run(.sequence([clearPulse, .removeFromParent()]))
+    }
+
+    func playSeekerSwarmEffect(from origin: CGPoint, to targets: [CGPoint]) {
+        for target in targets {
+            let path = CGMutablePath()
+            path.move(to: origin)
+            path.addLine(to: target)
+
+            let streak = SKShapeNode(path: path)
+            streak.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
+            streak.lineWidth = 1.5
+            streak.glowWidth = 3
+            streak.zPosition = 18
+            addChild(streak)
+
+            let fade = SKAction.group([
+                .fadeOut(withDuration: 0.12),
+                .scale(to: 0.9, duration: 0.12)
+            ])
+            streak.run(.sequence([fade, .removeFromParent()]))
+        }
+    }
+
+    func playFreezeBurstEffect(at position: CGPoint) {
+        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.freezeBurstRadius)
+        ring.position = position
+        ring.strokeColor = theme.pickupBlue.withAlphaComponent(0.85)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 5
+        ring.zPosition = 18
+        ring.setScale(0.18)
+        addChild(ring)
+
+        let expand = SKAction.group([
+            .scale(to: 1.0, duration: 0.18),
+            .fadeOut(withDuration: 0.18)
+        ])
+        ring.run(.sequence([expand, .removeFromParent()]))
+    }
+
+    func playGravityWellEffect(at position: CGPoint) {
+        gravityWellEffectNode?.removeFromParent()
+        let container = SKNode()
+        container.position = position
+        container.zPosition = 18
+        addChild(container)
+        gravityWellEffectNode = container
+        let ring = SKShapeNode(circleOfRadius: weaponResolver.configuration.gravityWellRadius)
+        ring.strokeColor = theme.pickupViolet.withAlphaComponent(0.7)
+        ring.fillColor = theme.pickupBlue.withAlphaComponent(0.08)
+        ring.lineWidth = 1.8
+        ring.glowWidth = 5
+        container.addChild(ring)
+        let duration = max(0.12, weaponResolver.configuration.gravityWellPullDuration)
+        let pulse = SKAction.group([
+            .scale(to: 0.25, duration: duration),
+            .fadeOut(withDuration: duration)
+        ])
+        container.run(.sequence([pulse, .removeFromParent()]))
+    }
+}

--- a/TiltArena/Game/Weapons/FlameTrailEffectNode.swift
+++ b/TiltArena/Game/Weapons/FlameTrailEffectNode.swift
@@ -1,0 +1,53 @@
+import SpriteKit
+
+@MainActor
+final class FlameTrailEffectNode: SKNode {
+    private let theme: ArenaTheme
+    private var segmentNodes: [Int: SKShapeNode] = [:]
+
+    init(theme: ArenaTheme) {
+        self.theme = theme
+        super.init()
+        zPosition = 12
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("FlameTrailEffectNode does not support storyboard initialization.")
+    }
+
+    func apply(segments: [FlameTrailSegment]) {
+        let activeIDs = Set(segments.map(\.id))
+
+        for id in Array(segmentNodes.keys) where !activeIDs.contains(id) {
+            segmentNodes.removeValue(forKey: id)?.removeFromParent()
+        }
+
+        for segment in segments {
+            let node = segmentNodes[segment.id] ?? makeSegmentNode(radius: segment.radius)
+            segmentNodes[segment.id] = node
+
+            if node.parent == nil {
+                addChild(node)
+            }
+
+            node.position = segment.position
+            node.alpha = 0.2 + 0.55 * segment.remainingFraction
+            node.setScale(0.75 + 0.25 * segment.remainingFraction)
+        }
+    }
+
+    func reset() {
+        segmentNodes.removeAll()
+        removeAllChildren()
+    }
+
+    private func makeSegmentNode(radius: CGFloat) -> SKShapeNode {
+        let node = SKShapeNode(circleOfRadius: radius)
+        let orangeFill = SKColor(red: 1.0, green: 0.46, blue: 0.12, alpha: 0.24)
+        node.fillColor = orangeFill
+        node.strokeColor = theme.pickupAmber.withAlphaComponent(0.9)
+        node.lineWidth = 1.4
+        node.glowWidth = 2
+        return node
+    }
+}

--- a/TiltArena/Game/Weapons/FlameTrailState.swift
+++ b/TiltArena/Game/Weapons/FlameTrailState.swift
@@ -1,0 +1,161 @@
+import CoreGraphics
+import Foundation
+
+struct FlameTrailConfiguration: Equatable {
+    var duration: TimeInterval = 4.0
+    var segmentLifetime: TimeInterval = 1.2
+    var segmentRadius: CGFloat = 18
+    var segmentSpacing: CGFloat = 14
+    var maxSegments: Int = 24
+    var frozenMeltDelay: TimeInterval = 0.3
+}
+
+struct FlameTrailSegment: Equatable, Identifiable {
+    let id: Int
+    let position: CGPoint
+    let radius: CGFloat
+    var timeRemaining: TimeInterval
+    let lifetime: TimeInterval
+
+    var remainingFraction: CGFloat {
+        guard lifetime > 0 else {
+            return 0
+        }
+        return CGFloat(max(0, min(1, timeRemaining / lifetime)))
+    }
+
+    var collisionCircle: CollisionCircle {
+        CollisionCircle(center: position, radius: radius)
+    }
+}
+
+struct FlameTrailFrame: Equatable {
+    var burnedEnemyIDs: Set<Int> = []
+    var segments: [FlameTrailSegment] = []
+}
+
+struct FlameTrailState {
+    var configuration = FlameTrailConfiguration()
+    private(set) var timeRemaining: TimeInterval = 0
+    private(set) var segments: [FlameTrailSegment] = []
+    private var nextSegmentID = 1
+    private var frozenMeltDurations: [Int: TimeInterval] = [:]
+
+    init(configuration: FlameTrailConfiguration = FlameTrailConfiguration()) {
+        self.configuration = configuration
+    }
+
+    mutating func activate(at position: CGPoint) {
+        reset()
+        timeRemaining = max(0, configuration.duration)
+
+        if timeRemaining > 0 {
+            appendSegment(at: position)
+        }
+    }
+
+    mutating func reset() {
+        timeRemaining = 0
+        segments.removeAll()
+        nextSegmentID = 1
+        frozenMeltDurations.removeAll()
+    }
+
+    mutating func update(
+        deltaTime: TimeInterval,
+        playerPosition: CGPoint,
+        enemies: [ArenaEnemy]
+    ) -> FlameTrailFrame {
+        let clampedDelta = max(0, deltaTime)
+        timeRemaining = max(0, timeRemaining - clampedDelta)
+        expireSegments(deltaTime: clampedDelta)
+
+        if timeRemaining > 0 {
+            appendSegmentIfNeeded(at: playerPosition)
+        }
+
+        let burnedEnemyIDs = burnTargets(enemies: enemies, deltaTime: clampedDelta)
+        return FlameTrailFrame(burnedEnemyIDs: burnedEnemyIDs, segments: segments)
+    }
+
+    private mutating func expireSegments(deltaTime: TimeInterval) {
+        guard deltaTime > 0 else {
+            return
+        }
+
+        for index in segments.indices {
+            segments[index].timeRemaining = max(0, segments[index].timeRemaining - deltaTime)
+        }
+        segments.removeAll { $0.timeRemaining == 0 }
+    }
+
+    private mutating func appendSegmentIfNeeded(at position: CGPoint) {
+        guard let lastSegment = segments.last else {
+            appendSegment(at: position)
+            return
+        }
+
+        let spacing = max(0, configuration.segmentSpacing)
+        guard spacing == 0 || squaredDistance(from: lastSegment.position, to: position) >= spacing * spacing else {
+            return
+        }
+
+        appendSegment(at: position)
+    }
+
+    private mutating func appendSegment(at position: CGPoint) {
+        let lifetime = max(0, configuration.segmentLifetime)
+        guard lifetime > 0, configuration.maxSegments > 0 else {
+            return
+        }
+
+        segments.append(FlameTrailSegment(
+            id: nextSegmentID,
+            position: position,
+            radius: max(0, configuration.segmentRadius),
+            timeRemaining: lifetime,
+            lifetime: lifetime
+        ))
+        nextSegmentID += 1
+
+        if segments.count > configuration.maxSegments {
+            segments.removeFirst(segments.count - configuration.maxSegments)
+        }
+    }
+
+    private mutating func burnTargets(enemies: [ArenaEnemy], deltaTime: TimeInterval) -> Set<Int> {
+        guard !segments.isEmpty else {
+            frozenMeltDurations.removeAll()
+            return []
+        }
+
+        var burnedEnemyIDs = Set<Int>()
+        var contactingFrozenEnemyIDs = Set<Int>()
+
+        for enemy in enemies where segments.contains(where: { $0.collisionCircle.intersects(enemy.collisionCircle) }) {
+            if enemy.isFrozen {
+                contactingFrozenEnemyIDs.insert(enemy.id)
+                let meltDuration = frozenMeltDurations[enemy.id, default: 0] + deltaTime
+
+                if meltDuration >= max(0, configuration.frozenMeltDelay) {
+                    burnedEnemyIDs.insert(enemy.id)
+                } else {
+                    frozenMeltDurations[enemy.id] = meltDuration
+                }
+            } else {
+                burnedEnemyIDs.insert(enemy.id)
+            }
+        }
+
+        frozenMeltDurations = frozenMeltDurations.filter { enemyID, _ in
+            contactingFrozenEnemyIDs.contains(enemyID) && !burnedEnemyIDs.contains(enemyID)
+        }
+        return burnedEnemyIDs
+    }
+
+    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy
+    }
+}

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -16,12 +16,14 @@ struct PickupSpawnConfiguration: Equatable {
         .shockwave,
         .seekerSwarm,
         .razorShield,
+        .flameTrail,
         .gravityWell,
         .shockwave,
         .seekerSwarm,
         .razorShield,
         .freezeBurst,
         .chainLightning,
+        .flameTrail,
         .novaBomb
     ]
 

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -45,6 +45,8 @@ struct StartingWeaponResolver {
                 destroyedEnemyIDs: Set(targetIDs),
                 chainLightningEnemyIDs: targetIDs
             )
+        case .flameTrail:
+            return WeaponResolution()
         case .novaBomb:
             return WeaponResolution(destroyedEnemyIDs: Set(enemies.map(\.id)))
         }

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -5,6 +5,7 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case freezeBurst
     case gravityWell
     case chainLightning
+    case flameTrail
     case novaBomb
 
     var displayName: String {
@@ -21,6 +22,8 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
             return "Gravity Well"
         case .chainLightning:
             return "Chain Lightning"
+        case .flameTrail:
+            return "Flame Trail"
         case .novaBomb:
             return "Nova Bomb"
         }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -50,6 +50,8 @@ final class WeaponPickupNode: SKNode {
             return theme.pickupViolet
         case .chainLightning:
             return theme.pickupBlue
+        case .flameTrail:
+            return theme.pickupAmber
         case .novaBomb:
             return theme.pickupAmber
         }

--- a/TiltArenaTests/FlameTrailStateTests.swift
+++ b/TiltArenaTests/FlameTrailStateTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import TiltArena
+
+final class FlameTrailStateTests: XCTestCase {
+    func testActiveEnemiesBurnImmediatelyOnContact() {
+        var state = FlameTrailState(configuration: FlameTrailConfiguration(segmentRadius: 12))
+        state.activate(at: .zero)
+
+        let frame = state.update(
+            deltaTime: 0.1,
+            playerPosition: .zero,
+            enemies: [
+                enemy(id: 1, position: CGPoint(x: 10, y: 0)),
+                enemy(id: 2, position: CGPoint(x: 40, y: 0))
+            ]
+        )
+
+        XCTAssertEqual(frame.burnedEnemyIDs, [1])
+    }
+
+    func testFrozenEnemiesBurnAfterContinuousMeltDelay() {
+        var state = FlameTrailState(configuration: FlameTrailConfiguration(segmentRadius: 12, frozenMeltDelay: 0.3))
+        state.activate(at: .zero)
+        let frozen = frozenEnemy(id: 1, position: CGPoint(x: 10, y: 0))
+
+        var frame = state.update(deltaTime: 0.2, playerPosition: .zero, enemies: [frozen])
+        XCTAssertEqual(frame.burnedEnemyIDs, [])
+
+        frame = state.update(deltaTime: 0.1, playerPosition: .zero, enemies: [frozen])
+        XCTAssertEqual(frame.burnedEnemyIDs, [1])
+    }
+
+    func testFrozenMeltCancelsWhenContactEnds() {
+        var state = FlameTrailState(configuration: FlameTrailConfiguration(segmentRadius: 12, frozenMeltDelay: 0.3))
+        state.activate(at: .zero)
+        let frozenInContact = frozenEnemy(id: 1, position: CGPoint(x: 10, y: 0))
+        let frozenAway = frozenEnemy(id: 1, position: CGPoint(x: 80, y: 0))
+
+        XCTAssertEqual(
+            state.update(deltaTime: 0.2, playerPosition: .zero, enemies: [frozenInContact]).burnedEnemyIDs,
+            []
+        )
+        XCTAssertEqual(
+            state.update(deltaTime: 0.1, playerPosition: .zero, enemies: [frozenAway]).burnedEnemyIDs,
+            []
+        )
+        XCTAssertEqual(
+            state.update(deltaTime: 0.1, playerPosition: .zero, enemies: [frozenInContact]).burnedEnemyIDs,
+            []
+        )
+        XCTAssertEqual(
+            state.update(deltaTime: 0.2, playerPosition: .zero, enemies: [frozenInContact]).burnedEnemyIDs,
+            [1]
+        )
+    }
+
+    func testSegmentsExpireAfterLifetimeWhenTrailStopsGenerating() {
+        var state = FlameTrailState(configuration: FlameTrailConfiguration(
+            duration: 0.1,
+            segmentLifetime: 0.2
+        ))
+        state.activate(at: .zero)
+
+        XCTAssertEqual(state.update(deltaTime: 0.1, playerPosition: .zero, enemies: []).segments.count, 1)
+        XCTAssertEqual(state.update(deltaTime: 0.11, playerPosition: .zero, enemies: []).segments.count, 0)
+    }
+
+    func testSegmentSpacingControlsWhenNewSegmentsAreRecorded() {
+        var state = FlameTrailState(configuration: FlameTrailConfiguration(segmentSpacing: 14))
+        state.activate(at: .zero)
+
+        XCTAssertEqual(
+            state.update(deltaTime: 0.1, playerPosition: CGPoint(x: 13, y: 0), enemies: []).segments.count,
+            1
+        )
+        XCTAssertEqual(
+            state.update(deltaTime: 0.1, playerPosition: CGPoint(x: 14, y: 0), enemies: []).segments.count,
+            2
+        )
+    }
+
+    func testMaxSegmentsCapsOldestSegments() {
+        var state = FlameTrailState(configuration: FlameTrailConfiguration(
+            duration: 10,
+            segmentLifetime: 10,
+            segmentSpacing: 1,
+            maxSegments: 3
+        ))
+        state.activate(at: .zero)
+
+        for x in 1...4 {
+            _ = state.update(deltaTime: 0.1, playerPosition: CGPoint(x: x, y: 0), enemies: [])
+        }
+
+        XCTAssertEqual(state.segments.count, 3)
+        XCTAssertEqual(state.segments.map(\.position.x), [2, 3, 4])
+    }
+
+    private func enemy(id: Int, position: CGPoint) -> ArenaEnemy {
+        ArenaEnemy(id: id, position: position, radius: 8, speed: 0)
+    }
+
+    private func frozenEnemy(id: Int, position: CGPoint) -> ArenaEnemy {
+        var frozen = enemy(id: id, position: position)
+        frozen.freeze(duration: 1)
+        return frozen
+    }
+}

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -158,14 +158,17 @@ final class PickupSpawnPlannerTests: XCTestCase {
         XCTAssertEqual(kinds.filter { $0 == .freezeBurst }.count, 3)
         XCTAssertEqual(kinds.filter { $0 == .gravityWell }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .chainLightning }.count, 2)
+        XCTAssertEqual(kinds.filter { $0 == .flameTrail }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .novaBomb }.count, 1)
         XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .razorShield }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .gravityWell }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .chainLightning }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .flameTrail }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .gravityWell }.count, kinds.filter { $0 == .novaBomb }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .chainLightning }.count, kinds.filter { $0 == .novaBomb }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .flameTrail }.count, kinds.filter { $0 == .novaBomb }.count)
     }
 
     func testEmptyKindCycleDoesNotSpawnPickup() {

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -227,6 +227,22 @@ final class StartingWeaponResolverTests: XCTestCase {
         XCTAssertEqual(resolution.destroyedEnemyIDs, [1, 2, 3])
     }
 
+    func testFlameTrailDoesNotInstantlyResolveTargets() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 10, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .flameTrail,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+        XCTAssertEqual(resolution.frozenEnemyIDs, [])
+    }
+
     func testNovaBombHandlesEmptyArena() {
         let resolver = StartingWeaponResolver()
 


### PR DESCRIPTION
## Summary
- Adds Flame Trail as a focused weapon-roster slice under #10.
- Adds pure Swift Flame Trail state for segment spacing, expiry, immediate burns, and frozen-enemy melt delay.
- Renders an amber/orange trail effect and wires Flame Trail into pickup spawning and score/combo kill tracking.

Closes #48

Parent: #10 remains open for the rest of the weapon roster.

## Validation
- xcodegen generate
- swiftlint lint --no-cache
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,id=F9038B9B-519B-49B6-9531-99DAA4F64D6C,arch=arm64" -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test