### PR TITLE
Build landscape UI scene shell

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -1,15 +1,29 @@
+// swiftlint:disable file_length
 import SpriteKit
 
+// swiftlint:disable:next type_body_length
 final class ArenaScene: SKScene {
     let theme = ArenaTheme.darkTacticalRadar
     private let tiltSettingsStore = TiltSettingsStore()
     private let runProfileStore = RunProfileStore()
+    private let localOptionsStore = ArenaLocalOptionsStore()
     private var arenaRoot = SKNode()
+    private let uiRoot = SKNode()
     private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
     var movementController = PlayerMovementController()
     private var runController = ClassicRunController()
     private var runProfile = RunProfile()
+    private var localOptions = ArenaLocalOptions()
+    private var uiState: ArenaUISceneState = .home
+    private var optionsReturnState: ArenaUISceneState = .home
+    private var selectedMode: ArenaModeKind = .classic
+    private var previousBestScore = 0
+    private var resetDataArmed = false
     private var hasPersistedFinalRun = false
+    private var readyHoldController = ReadyStartHoldController()
+    private var readyStartPoint = CGPoint.zero
+    private var readyProgressRing: SKShapeNode?
+    private var readyStatusLabel: SKLabelNode?
     private var spawnDirector = EnemySpawnDirector()
     private let pickupSpawnConfiguration = PickupSpawnConfiguration()
     private var pickupPlanner = PickupSpawnPlanner()
@@ -30,14 +44,13 @@ final class ArenaScene: SKScene {
     private var gravityWellState: GravityWellState?
     var gravityWellEffectNode: SKNode?
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
-    private let centerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
-    private let detailLabel = SKLabelNode(fontNamed: "Menlo")
+    private let bestMarkerLabel = SKLabelNode(fontNamed: "Menlo")
     private let comboLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let pauseControlNode = SKNode()
     private let pauseIconNode = SKNode()
-    private let resumeIconNode = SKShapeNode()
     private let hudMargin: CGFloat = 24
     private let pauseControlSize = CGSize(width: 48, height: 48)
+    private var uiHitTargets: [ArenaControlHitTarget] = []
     private var lastUpdateTime: TimeInterval?
 
     override init(size: CGSize) {
@@ -52,20 +65,28 @@ final class ArenaScene: SKScene {
 
     override func didMove(to view: SKView) {
         runProfile = runProfileStore.profile
+        localOptions = localOptionsStore.options
         rebuildArena()
         if flameTrailEffectNode.parent == nil { addChild(flameTrailEffectNode) }
         configureLabels()
         configurePauseControl()
+        configureUIRoot()
         placePlayer(resetPosition: true)
         updateRunDisplay()
+        rebuildUI()
         tiltInputController.start()
     }
 
     override func didChangeSize(_ oldSize: CGSize) {
         rebuildArena()
-        placePlayer(resetPosition: playerNode == nil)
+        placePlayer(resetPosition: playerNode == nil || uiState == .home)
+        if uiState == .preRun {
+            readyStartPoint = movementController.state.position
+            readyHoldController.reset()
+        }
         layoutLabels()
         layoutPauseControl()
+        rebuildUI()
     }
 
     override func willMove(from view: SKView) {
@@ -87,23 +108,26 @@ final class ArenaScene: SKScene {
             return
         }
 
-        guard runController.phase == .active else {
-            return
+        switch uiState {
+        case .preRun:
+            updatePreRun(deltaTime: deltaTime)
+        case .activeGameplay:
+            updateGameplay(deltaTime: deltaTime)
+        case .home, .modeSelect, .awards, .options, .pause, .postRun:
+            break
         }
-
-        let input = tiltInputController.update(deltaTime: deltaTime)
-        let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
-        applyPlayerState(state, resetTrail: false)
-        updateActiveRun(deltaTime: deltaTime, playerPosition: state.position)
     }
 
     func recalibrateTiltControls() {
         tiltInputController.recalibrateToCurrentAttitude()
+        updateRunDisplay()
+        rebuildUI()
     }
 
     func refreshSafeAreaLayout() {
         layoutLabels()
         layoutPauseControl()
+        rebuildUI()
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -111,18 +135,17 @@ final class ArenaScene: SKScene {
             return
         }
 
-        if touches.contains(where: isPauseControlTouch) {
-            togglePauseControl()
+        if uiState == .activeGameplay, touches.contains(where: isPauseControlTouch) {
+            pauseRun()
             return
         }
 
-        switch runController.phase {
-        case .preRun:
-            startRun()
-        case .gameOver:
-            restartRun()
-        case .active, .paused:
-            break
+        for touch in touches {
+            let location = touch.location(in: self)
+            if let target = uiHitTargets.reversed().first(where: { $0.frame.contains(location) }) {
+                perform(target.action)
+                return
+            }
         }
     }
 
@@ -130,6 +153,15 @@ final class ArenaScene: SKScene {
         arenaRoot.removeFromParent()
         arenaRoot = ArenaThemeRenderer(theme: theme).makeArenaBackground(size: size)
         addChild(arenaRoot)
+    }
+
+    private func configureUIRoot() {
+        guard uiRoot.parent == nil else {
+            return
+        }
+
+        uiRoot.zPosition = 70
+        addChild(uiRoot)
     }
 
     private func placePlayer(resetPosition: Bool) {
@@ -179,19 +211,15 @@ final class ArenaScene: SKScene {
         timerLabel.horizontalAlignmentMode = .left
         timerLabel.verticalAlignmentMode = .top
 
-        configureLabel(centerLabel, fontSize: 22, color: theme.playerColor)
-        centerLabel.horizontalAlignmentMode = .center
-        centerLabel.verticalAlignmentMode = .center
-
-        configureLabel(detailLabel, fontSize: 14, color: theme.borderColor)
-        detailLabel.horizontalAlignmentMode = .center
-        detailLabel.verticalAlignmentMode = .center
+        configureLabel(bestMarkerLabel, fontSize: 12, color: theme.borderColor)
+        bestMarkerLabel.horizontalAlignmentMode = .right
+        bestMarkerLabel.verticalAlignmentMode = .center
 
         configureLabel(comboLabel, fontSize: 14, color: theme.playerAccentColor)
         comboLabel.horizontalAlignmentMode = .center
         comboLabel.verticalAlignmentMode = .bottom
 
-        [timerLabel, centerLabel, detailLabel, comboLabel].forEach { label in
+        [timerLabel, bestMarkerLabel, comboLabel].forEach { label in
             if label.parent == nil {
                 addChild(label)
             }
@@ -208,7 +236,6 @@ final class ArenaScene: SKScene {
         pauseControlNode.zPosition = 60
         addPauseControlBackground()
         configurePauseIcon()
-        configureResumeIcon()
         addChild(pauseControlNode)
         layoutPauseControl()
         updatePauseControl()
@@ -224,8 +251,10 @@ final class ArenaScene: SKScene {
         let layout = currentHUDLayout()
 
         timerLabel.position = layout.timerPosition
-        centerLabel.position = layout.centerPosition
-        detailLabel.position = layout.detailPosition
+        bestMarkerLabel.position = CGPoint(
+            x: layout.pauseControlPosition.x - pauseControlSize.width,
+            y: layout.pauseControlPosition.y
+        )
         comboLabel.position = layout.comboPosition
     }
 
@@ -242,37 +271,80 @@ final class ArenaScene: SKScene {
         )
     }
 
+    private func currentLandscapeLayout() -> ArenaLandscapeUILayout {
+        ArenaLandscapeUILayout(
+            sceneSize: size,
+            safeAreaInsets: view?.safeAreaInsets ?? .zero,
+            margin: hudMargin
+        )
+    }
+
+    private func updatePreRun(deltaTime: TimeInterval) {
+        let input = tiltInputController.update(deltaTime: deltaTime)
+        let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
+        applyPlayerState(state, resetTrail: false)
+
+        let holdState = readyHoldController.update(
+            playerPosition: state.position,
+            startPoint: readyStartPoint,
+            deltaTime: deltaTime
+        )
+        updateReadyProgressDisplay(holdState)
+
+        if holdState.didComplete {
+            startRun()
+        }
+    }
+
+    private func updateGameplay(deltaTime: TimeInterval) {
+        guard runController.phase == .active else {
+            return
+        }
+
+        let input = tiltInputController.update(deltaTime: deltaTime)
+        let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
+        applyPlayerState(state, resetTrail: false)
+        updateActiveRun(deltaTime: deltaTime, playerPosition: state.position)
+    }
+
+    private func preparePreRun() {
+        runController = ClassicRunController(configuration: runController.configuration)
+        hasPersistedFinalRun = false
+        resetGameplayObjects()
+        readyHoldController.reset()
+        placePlayer(resetPosition: true)
+        readyStartPoint = movementController.state.position
+        resetPlayerFeedback()
+        show(.preRun)
+    }
+
     private func startRun() {
         runController.start()
+        readyHoldController.reset()
         resetActiveRun()
-    }
-
-    private func restartRun() {
-        runController.restart()
-        resetActiveRun()
-    }
-
-    private func togglePauseControl() {
-        switch runController.phase {
-        case .active:
-            pauseRun()
-        case .paused:
-            resumeRun()
-        case .preRun, .gameOver:
-            break
-        }
+        show(.activeGameplay)
     }
 
     private func pauseRun() {
         runController.pause()
         tiltInputController.resetSmoothedInput()
-        updateRunDisplay()
+        show(.pause)
     }
 
     private func resumeRun() {
         tiltInputController.resetSmoothedInput()
         runController.resume()
-        updateRunDisplay()
+        show(.activeGameplay)
+    }
+
+    private func finishRun(playFeedback: Bool = true) {
+        previousBestScore = runProfile.bestScore
+        runController.endRun()
+        persistFinalRunIfNeeded()
+        if playFeedback {
+            playDeathFeedback()
+        }
+        show(.postRun)
     }
 
     private func resetActiveRun() {
@@ -630,13 +702,6 @@ final class ArenaScene: SKScene {
         finishRun()
     }
 
-    private func finishRun() {
-        runController.endRun()
-        persistFinalRunIfNeeded()
-        playDeathFeedback()
-        updateRunDisplay()
-    }
-
     private func playDeathFeedback() {
         let pulse = SKAction.group([
             .scale(to: 1.45, duration: 0.08),
@@ -648,34 +713,38 @@ final class ArenaScene: SKScene {
     }
 
     private func updateRunDisplay() {
-        switch runController.phase {
-        case .preRun:
-            timerLabel.text = "BEST \(runProfile.bestScore)"
-            centerLabel.text = "TAP TO START"
-            detailLabel.text = "CLASSIC SURVIVAL"
-            comboLabel.text = ""
-        case .active:
-            timerLabel.text = "SCORE \(runController.score)  \(formatSurvivalTime(runController.survivalTime))"
-            centerLabel.text = ""
-            detailLabel.text = ""
-            comboLabel.text = formatCombo()
-        case .paused:
-            timerLabel.text = "SCORE \(runController.score)  \(formatSurvivalTime(runController.survivalTime))"
-            centerLabel.text = "PAUSED"
-            detailLabel.text = ""
-            comboLabel.text = formatCombo()
-        case .gameOver:
-            timerLabel.text = "BEST \(runProfile.bestScore)"
+        timerLabel.alpha = uiState == .pause || uiState == .postRun ? 0.55 : 1
 
-            if let summary = runController.finalizedSummary {
-                centerLabel.text = "GAME OVER  \(summary.score)"
-                detailLabel.text = "TIME \(formatSurvivalTime(summary.survivalTime))  MAX COMBO \(summary.maxCombo)  PLAY AGAIN"
-                comboLabel.text = "KILLS \(summary.enemiesDestroyed)  WEAPON \(formatWeapon(summary.bestWeapon))"
-            } else {
-                centerLabel.text = "GAME OVER"
-                detailLabel.text = "\(formatSurvivalTime(runController.survivalTime))  PLAY AGAIN"
-                comboLabel.text = ""
-            }
+        switch uiState {
+        case .home, .modeSelect, .awards, .options:
+            timerLabel.isHidden = true
+            bestMarkerLabel.isHidden = true
+            comboLabel.isHidden = true
+        case .preRun:
+            timerLabel.isHidden = false
+            bestMarkerLabel.isHidden = false
+            comboLabel.isHidden = true
+            timerLabel.text = "BEST \(runProfile.bestScore)"
+            bestMarkerLabel.text = "\(selectedMode.displayName) READY"
+        case .activeGameplay:
+            timerLabel.isHidden = false
+            bestMarkerLabel.isHidden = false
+            comboLabel.isHidden = false
+            timerLabel.text = "SCORE \(runController.score)  \(formatSurvivalTime(runController.survivalTime))"
+            bestMarkerLabel.text = "BEST \(runProfile.bestScore)"
+            comboLabel.text = formatCombo()
+        case .pause:
+            timerLabel.isHidden = false
+            bestMarkerLabel.isHidden = false
+            comboLabel.isHidden = false
+            timerLabel.text = "SCORE \(runController.score)  \(formatSurvivalTime(runController.survivalTime))"
+            bestMarkerLabel.text = "PAUSED"
+            comboLabel.text = formatCombo()
+        case .postRun:
+            timerLabel.isHidden = false
+            bestMarkerLabel.isHidden = true
+            comboLabel.isHidden = true
+            timerLabel.text = "BEST \(runProfile.bestScore)"
         }
 
         updatePauseControl()
@@ -698,17 +767,8 @@ final class ArenaScene: SKScene {
         )
     }
 
-    private func formatWeapon(_ weaponKind: WeaponKind?) -> String {
-        weaponKind?.displayName.uppercased() ?? "NONE"
-    }
-
     private func isPauseControlTouch(_ touch: UITouch) -> Bool {
-        switch runController.phase {
-        case .active, .paused:
-            return pauseControlFrame.contains(touch.location(in: self))
-        case .preRun, .gameOver:
-            return false
-        }
+        pauseControlFrame.contains(touch.location(in: self))
     }
 
     private var pauseControlFrame: CGRect {
@@ -721,18 +781,7 @@ final class ArenaScene: SKScene {
     }
 
     private func updatePauseControl() {
-        switch runController.phase {
-        case .active:
-            pauseControlNode.isHidden = false
-            pauseIconNode.isHidden = false
-            resumeIconNode.isHidden = true
-        case .paused:
-            pauseControlNode.isHidden = false
-            pauseIconNode.isHidden = true
-            resumeIconNode.isHidden = false
-        case .preRun, .gameOver:
-            pauseControlNode.isHidden = true
-        }
+        pauseControlNode.isHidden = uiState != .activeGameplay || runController.phase != .active
     }
 
     private func recordNearMisses(playerPosition: CGPoint) {
@@ -797,18 +846,789 @@ final class ArenaScene: SKScene {
 
         pauseControlNode.addChild(pauseIconNode)
     }
+}
 
-    private func configureResumeIcon() {
-        let path = CGMutablePath()
-        path.move(to: CGPoint(x: -5, y: -10))
-        path.addLine(to: CGPoint(x: -5, y: 10))
-        path.addLine(to: CGPoint(x: 10, y: 0))
-        path.closeSubpath()
+private extension ArenaScene {
+    func show(_ state: ArenaUISceneState) {
+        if state != .options {
+            resetDataArmed = false
+        }
 
-        resumeIconNode.path = path
-        resumeIconNode.fillColor = theme.playerColor
-        resumeIconNode.strokeColor = theme.playerColor
-        pauseControlNode.addChild(resumeIconNode)
+        uiState = state
+        updateRunDisplay()
+        rebuildUI()
+    }
+
+    func rebuildUI() {
+        uiRoot.removeAllChildren()
+        uiHitTargets.removeAll()
+        readyProgressRing = nil
+        readyStatusLabel = nil
+
+        switch uiState {
+        case .home:
+            renderHome()
+        case .modeSelect:
+            renderModeSelect()
+        case .awards:
+            renderAwards()
+        case .options:
+            renderOptions()
+        case .preRun:
+            renderPreRun()
+        case .activeGameplay:
+            break
+        case .pause:
+            renderPause()
+        case .postRun:
+            renderPostRun()
+        }
+
+        updateRunDisplay()
+    }
+
+    func renderHome() {
+        let layout = currentLandscapeLayout()
+        addTitle("TILT ARENA", at: layout.titlePosition)
+        addSmallLabel(
+            "CLASSIC SURVIVAL",
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 34),
+            color: theme.borderColor,
+            alignment: .left
+        )
+        addSmallLabel(
+            "BEST \(runProfile.bestScore)",
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 56),
+            color: theme.playerAccentColor,
+            alignment: .left
+        )
+        addPreviewThreats(in: layout.safeRect)
+        addButton(
+            "PLAY",
+            frame: layout.lowerRightButtonFrame,
+            action: .play,
+            style: .primary
+        )
+
+        let buttonSize = CGSize(width: 108, height: 38)
+        addButton(
+            "MODES",
+            frame: layout.bottomButtonFrame(index: 0, count: 3, buttonSize: buttonSize),
+            action: .openModes,
+            style: .secondary
+        )
+        addButton(
+            "AWARDS",
+            frame: layout.bottomButtonFrame(index: 1, count: 3, buttonSize: buttonSize),
+            action: .openAwards,
+            style: .secondary
+        )
+        addButton(
+            "OPTIONS",
+            frame: layout.bottomButtonFrame(index: 2, count: 3, buttonSize: buttonSize),
+            action: .openOptions,
+            style: .secondary
+        )
+    }
+
+    func renderModeSelect() {
+        let layout = currentLandscapeLayout()
+        addBackButton(layout: layout)
+        addTitle("MODES", at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 48))
+
+        let rows = ArenaMenuContent.modeRows(profile: runProfile, selectedMode: selectedMode)
+        let rowWidth = layout.safeRect.width * 0.62
+        let rowHeight: CGFloat = 58
+        let rowStartY = layout.safeRect.maxY - 118
+
+        for (index, row) in rows.enumerated() {
+            let frame = CGRect(
+                x: layout.safeRect.minX,
+                y: rowStartY - CGFloat(index) * (rowHeight + 14),
+                width: rowWidth,
+                height: rowHeight
+            )
+            addModeRow(row, frame: frame)
+        }
+
+        addButton(
+            "PLAY",
+            frame: layout.lowerRightButtonFrame,
+            action: .play,
+            style: .primary
+        )
+        addSmallLabel(
+            "LOCAL ONLY",
+            at: CGPoint(x: layout.safeRect.maxX, y: layout.lowerRightButtonFrame.maxY + 20),
+            color: theme.borderColor,
+            alignment: .right
+        )
+    }
+
+    func renderAwards() {
+        let layout = currentLandscapeLayout()
+        addBackButton(layout: layout)
+        addTitle("AWARDS", at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 48))
+
+        let rows = ArenaMenuContent.awardRows(profile: runProfile)
+        let columnWidth = layout.safeRect.width * 0.34
+        let rowHeight: CGFloat = 48
+        let leftX = layout.safeRect.minX
+        let rightX = leftX + columnWidth + 18
+        let startY = layout.safeRect.maxY - 118
+
+        for (index, row) in rows.enumerated() {
+            let column = index / 3
+            let rowIndex = index % 3
+            let x = column == 0 ? leftX : rightX
+            let frame = CGRect(
+                x: x,
+                y: startY - CGFloat(rowIndex) * (rowHeight + 14),
+                width: columnWidth,
+                height: rowHeight
+            )
+            addAwardRow(row, frame: frame)
+        }
+
+        let highlightFrame = layout.rightColumnFrame(width: 190)
+        addPanel(frame: highlightFrame, stroke: theme.playerAccentColor.withAlphaComponent(0.42))
+        addSmallLabel(
+            "ACTIVE UNLOCK",
+            at: CGPoint(x: highlightFrame.minX + 14, y: highlightFrame.maxY - 24),
+            color: theme.borderColor,
+            alignment: .left
+        )
+        addLabel(
+            ArenaMenuContent.activeUnlockText(profile: runProfile),
+            at: CGPoint(x: highlightFrame.minX + 14, y: highlightFrame.maxY - 54),
+            fontSize: 15,
+            color: theme.playerAccentColor,
+            alignment: .left
+        )
+        addSmallLabel(
+            "LOCAL PROGRESS ONLY",
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.minY + 16),
+            color: theme.borderColor,
+            alignment: .left
+        )
+    }
+
+    func renderOptions() {
+        let layout = currentLandscapeLayout()
+        addBackButton(layout: layout)
+        addTitle("OPTIONS", at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 48))
+
+        let left = layout.leftColumnFrame(width: 270)
+        let right = layout.rightColumnFrame(width: 270)
+        addPanel(frame: left)
+        addPanel(frame: right)
+
+        addButton(
+            "CALIBRATE",
+            frame: CGRect(x: left.minX + 14, y: left.maxY - 62, width: 148, height: 40),
+            action: .calibrate,
+            style: .primary
+        )
+        let settings = tiltSettingsStore.settings
+        addSmallLabel(
+            "SENSITIVITY \(String(format: "%.1f", settings.clampedSensitivity))",
+            at: CGPoint(x: left.minX + 14, y: left.maxY - 90),
+            color: theme.borderColor,
+            alignment: .left
+        )
+        addButton(
+            "-",
+            frame: CGRect(x: left.minX + 14, y: left.maxY - 140, width: 44, height: 36),
+            action: .sensitivityDown,
+            style: .secondary
+        )
+        addButton(
+            "+",
+            frame: CGRect(x: left.minX + 70, y: left.maxY - 140, width: 44, height: 36),
+            action: .sensitivityUp,
+            style: .secondary
+        )
+
+        let presetY = left.maxY - 196
+        for (index, preset) in [TiltCalibrationPreset.standard, .flatTable, .reclined].enumerated() {
+            let frame = CGRect(
+                x: left.minX + 14 + CGFloat(index) * 82,
+                y: presetY,
+                width: 74,
+                height: 34
+            )
+            addButton(
+                presetTitle(preset),
+                frame: frame,
+                action: .preset(preset),
+                style: settings.calibration.preset == preset ? .primary : .secondary
+            )
+        }
+
+        addToggle(
+            title: "AUDIO",
+            isOn: localOptions.audioEnabled,
+            frame: CGRect(x: right.minX + 14, y: right.maxY - 62, width: 132, height: 38),
+            action: .toggleAudio
+        )
+        addToggle(
+            title: "HAPTICS",
+            isOn: localOptions.hapticsEnabled,
+            frame: CGRect(x: right.minX + 14, y: right.maxY - 112, width: 132, height: 38),
+            action: .toggleHaptics
+        )
+        addToggle(
+            title: "EFFECTS",
+            isOn: !localOptions.reducedEffects,
+            frame: CGRect(x: right.minX + 14, y: right.maxY - 162, width: 132, height: 38),
+            action: .toggleEffects
+        )
+        addButton(
+            resetDataArmed ? "CONFIRM RESET" : "RESET DATA",
+            frame: CGRect(x: right.minX + 14, y: right.minY + 12, width: 156, height: 34),
+            action: .resetData,
+            style: .danger
+        )
+    }
+
+    func renderPreRun() {
+        let layout = currentLandscapeLayout()
+        addButton(
+            "CAL",
+            frame: CGRect(x: layout.safeRect.maxX - 112, y: layout.safeRect.maxY - 40, width: 48, height: 36),
+            action: .calibrate,
+            style: .secondary
+        )
+        addButton(
+            "OPT",
+            frame: CGRect(x: layout.safeRect.maxX - 54, y: layout.safeRect.maxY - 40, width: 54, height: 36),
+            action: .openOptions,
+            style: .secondary
+        )
+        addReadyStartCircle(at: readyStartPoint)
+        addLabel(
+            "HOLD 3s TO START",
+            at: CGPoint(x: layout.safeRect.midX, y: layout.safeRect.midY - 92),
+            fontSize: 15,
+            color: theme.playerColor,
+            alignment: .center
+        )
+        addSmallLabel(
+            selectedMode.displayName,
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.minY + 16),
+            color: theme.borderColor,
+            alignment: .left
+        )
+        addSmallLabel(
+            calibrationText,
+            at: CGPoint(x: layout.safeRect.maxX, y: layout.safeRect.minY + 16),
+            color: theme.borderColor,
+            alignment: .right
+        )
+        updateReadyProgressDisplay(readyHoldController.state)
+    }
+
+    func renderPause() {
+        let layout = currentLandscapeLayout()
+        addScrim(alpha: 0.58)
+        addLabel(
+            "PAUSED",
+            at: CGPoint(x: layout.safeRect.midX, y: layout.safeRect.midY + 54),
+            fontSize: 26,
+            color: theme.playerColor,
+            alignment: .center
+        )
+        addButton(
+            "RESUME",
+            frame: CGRect(x: layout.safeRect.midX - 82, y: layout.safeRect.midY - 20, width: 164, height: 50),
+            action: .resume,
+            style: .primary
+        )
+        addButton(
+            "CALIBRATE",
+            frame: CGRect(x: layout.safeRect.maxX - 150, y: layout.safeRect.midY + 12, width: 150, height: 38),
+            action: .calibrate,
+            style: .secondary
+        )
+        addButton(
+            "OPTIONS",
+            frame: CGRect(x: layout.safeRect.maxX - 150, y: layout.safeRect.midY - 38, width: 150, height: 38),
+            action: .openOptions,
+            style: .secondary
+        )
+        addButton(
+            "END RUN",
+            frame: CGRect(x: layout.safeRect.minX, y: layout.safeRect.minY, width: 132, height: 36),
+            action: .endRun,
+            style: .danger
+        )
+    }
+
+    func renderPostRun() {
+        let layout = currentLandscapeLayout()
+        addScrim(alpha: 0.62)
+        let summary = runController.finalizedSummary
+
+        addLabel(
+            "GAME OVER",
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 52),
+            fontSize: 24,
+            color: theme.enemyColor,
+            alignment: .left
+        )
+        addLabel(
+            "\(summary?.score ?? runController.score)",
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 86),
+            fontSize: 30,
+            color: theme.playerColor,
+            alignment: .left
+        )
+        addSmallLabel(
+            summary?.score ?? 0 > previousBestScore ? "NEW BEST" : "BEST \(runProfile.bestScore)",
+            at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 112),
+            color: theme.playerAccentColor,
+            alignment: .left
+        )
+        addDeathClarityMarker(at: movementController.state.position)
+
+        let right = layout.rightColumnFrame(width: 230)
+        addPanel(frame: right)
+        let highlights = ArenaMenuContent.postRunHighlights(
+            summary: summary,
+            profile: runProfile,
+            previousBestScore: previousBestScore
+        )
+        for (index, text) in highlights.enumerated() {
+            addSmallLabel(
+                text,
+                at: CGPoint(x: right.minX + 14, y: right.maxY - 28 - CGFloat(index) * 26),
+                color: index == 0 ? theme.playerAccentColor : theme.borderColor,
+                alignment: .left
+            )
+        }
+
+        addButton(
+            "PLAY AGAIN",
+            frame: layout.lowerRightButtonFrame,
+            action: .playAgain,
+            style: .primary
+        )
+        let buttonSize = CGSize(width: 112, height: 36)
+        addButton(
+            "MODES",
+            frame: layout.bottomButtonFrame(index: 0, count: 2, buttonSize: buttonSize),
+            action: .openModes,
+            style: .secondary
+        )
+        addButton(
+            "HOME",
+            frame: layout.bottomButtonFrame(index: 1, count: 2, buttonSize: buttonSize),
+            action: .home,
+            style: .secondary
+        )
+    }
+
+    func perform(_ action: ArenaControlAction) {
+        switch action {
+        case .play:
+            if selectedModeIsAvailable {
+                preparePreRun()
+            }
+        case .playAgain:
+            preparePreRun()
+        case .openModes:
+            resetMenuPreviewIfNeeded()
+            show(.modeSelect)
+        case .openAwards:
+            show(.awards)
+        case .openOptions:
+            optionsReturnState = uiState
+            show(.options)
+        case .home:
+            resetMenuPreviewIfNeeded()
+            show(.home)
+        case .back:
+            show(uiState == .options ? optionsReturnState : .home)
+        case let .selectMode(mode):
+            guard modeRowsByKind[mode]?.isAvailable == true else {
+                return
+            }
+
+            selectedMode = mode
+            rebuildUI()
+        case .resume:
+            resumeRun()
+        case .calibrate:
+            recalibrateTiltControls()
+        case .endRun:
+            finishRun(playFeedback: false)
+        case .sensitivityDown:
+            tiltSettingsStore.updateSensitivity(tiltSettingsStore.settings.clampedSensitivity - 0.1)
+            rebuildUI()
+        case .sensitivityUp:
+            tiltSettingsStore.updateSensitivity(tiltSettingsStore.settings.clampedSensitivity + 0.1)
+            rebuildUI()
+        case let .preset(preset):
+            tiltSettingsStore.selectPreset(preset)
+            rebuildUI()
+        case .toggleAudio:
+            localOptions.audioEnabled.toggle()
+            localOptionsStore.options = localOptions
+            rebuildUI()
+        case .toggleHaptics:
+            localOptions.hapticsEnabled.toggle()
+            localOptionsStore.options = localOptions
+            rebuildUI()
+        case .toggleEffects:
+            localOptions.reducedEffects.toggle()
+            localOptionsStore.options = localOptions
+            rebuildUI()
+        case .resetData:
+            resetLocalDataOrArmConfirmation()
+        }
+    }
+
+    func resetMenuPreviewIfNeeded() {
+        guard uiState == .postRun || runController.phase == .gameOver else {
+            return
+        }
+
+        runController = ClassicRunController(configuration: runController.configuration)
+        resetGameplayObjects()
+        readyHoldController.reset()
+        placePlayer(resetPosition: true)
+        resetPlayerFeedback()
+    }
+
+    var selectedModeIsAvailable: Bool {
+        modeRowsByKind[selectedMode]?.isAvailable == true
+    }
+
+    var modeRowsByKind: [ArenaModeKind: ArenaModeRow] {
+        Dictionary(
+            uniqueKeysWithValues: ArenaMenuContent
+                .modeRows(profile: runProfile, selectedMode: selectedMode)
+                .map { ($0.kind, $0) }
+        )
+    }
+
+    var calibrationText: String {
+        "CAL \(tiltSettingsStore.settings.calibration.preset.rawValue.uppercased())"
+    }
+
+    func resetLocalDataOrArmConfirmation() {
+        guard resetDataArmed else {
+            resetDataArmed = true
+            rebuildUI()
+            return
+        }
+
+        runProfileStore.reset()
+        tiltSettingsStore.reset()
+        localOptionsStore.reset()
+        runProfile = RunProfile()
+        localOptions = .defaults
+        selectedMode = .classic
+        resetDataArmed = false
+        rebuildUI()
+        updateRunDisplay()
+    }
+
+    func addReadyStartCircle(at point: CGPoint) {
+        let radius = readyHoldController.configuration.startCircleRadius
+        let circle = SKShapeNode(circleOfRadius: radius)
+        circle.position = point
+        circle.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
+        circle.fillColor = theme.playerAccentColor.withAlphaComponent(0.06)
+        circle.lineWidth = 2
+        circle.glowWidth = 5
+        uiRoot.addChild(circle)
+
+        let progress = SKShapeNode(circleOfRadius: radius + 8)
+        progress.position = point
+        progress.strokeColor = theme.playerColor.withAlphaComponent(0.85)
+        progress.fillColor = .clear
+        progress.lineWidth = 2
+        progress.glowWidth = 3
+        uiRoot.addChild(progress)
+        readyProgressRing = progress
+
+        let label = SKLabelNode(fontNamed: "Menlo-Bold")
+        label.fontSize = 18
+        label.fontColor = theme.playerColor
+        label.horizontalAlignmentMode = .center
+        label.verticalAlignmentMode = .center
+        label.position = point
+        uiRoot.addChild(label)
+        readyStatusLabel = label
+
+        for angle in stride(from: 0.0, to: Double.pi * 2, by: Double.pi / 2) {
+            let tick = SKShapeNode(rectOf: CGSize(width: 3, height: 12), cornerRadius: 1)
+            tick.position = CGPoint(
+                x: point.x + cos(angle) * (radius + 16),
+                y: point.y + sin(angle) * (radius + 16)
+            )
+            tick.zRotation = angle
+            tick.fillColor = theme.borderColor.withAlphaComponent(0.75)
+            tick.strokeColor = .clear
+            uiRoot.addChild(tick)
+        }
+    }
+
+    func updateReadyProgressDisplay(_ state: ReadyStartHoldState) {
+        let progress = state.progressFraction(requiredDuration: readyHoldController.configuration.requiredDuration)
+        readyProgressRing?.setScale(0.55 + CGFloat(progress) * 0.45)
+        readyProgressRing?.alpha = 0.35 + CGFloat(progress) * 0.65
+
+        if state.isInsideCircle {
+            let remaining = max(0, readyHoldController.configuration.requiredDuration - state.elapsed)
+            readyStatusLabel?.text = String(format: "%.1f", remaining)
+        } else {
+            readyStatusLabel?.text = "CENTER"
+        }
+    }
+
+    func addPreviewThreats(in rect: CGRect) {
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let offsets = [
+            CGPoint(x: -120, y: 52),
+            CGPoint(x: 104, y: 42),
+            CGPoint(x: 142, y: -58),
+            CGPoint(x: -92, y: -74)
+        ]
+
+        for offset in offsets {
+            let dot = SKShapeNode(circleOfRadius: 6)
+            dot.position = CGPoint(x: center.x + offset.x, y: center.y + offset.y)
+            dot.fillColor = theme.enemyColor.withAlphaComponent(0.5)
+            dot.strokeColor = theme.enemyColor.withAlphaComponent(0.75)
+            dot.lineWidth = 1
+            uiRoot.addChild(dot)
+        }
+
+        let pickup = SKShapeNode(circleOfRadius: 9)
+        pickup.position = CGPoint(x: center.x + 52, y: center.y - 36)
+        pickup.fillColor = theme.pickupAmber.withAlphaComponent(0.25)
+        pickup.strokeColor = theme.pickupAmber
+        pickup.lineWidth = 2
+        uiRoot.addChild(pickup)
+    }
+
+    func addDeathClarityMarker(at position: CGPoint) {
+        let ring = SKShapeNode(circleOfRadius: 30)
+        ring.position = position
+        ring.strokeColor = theme.enemyColor.withAlphaComponent(0.9)
+        ring.fillColor = .clear
+        ring.lineWidth = 2
+        ring.glowWidth = 4
+        uiRoot.addChild(ring)
+
+        let crossPath = CGMutablePath()
+        crossPath.move(to: CGPoint(x: position.x - 22, y: position.y))
+        crossPath.addLine(to: CGPoint(x: position.x + 22, y: position.y))
+        crossPath.move(to: CGPoint(x: position.x, y: position.y - 22))
+        crossPath.addLine(to: CGPoint(x: position.x, y: position.y + 22))
+        let cross = SKShapeNode(path: crossPath)
+        cross.strokeColor = theme.enemyColor
+        cross.lineWidth = 1.5
+        uiRoot.addChild(cross)
+    }
+
+    func addModeRow(_ row: ArenaModeRow, frame: CGRect) {
+        let selected = row.kind == selectedMode
+        addPanel(
+            frame: frame,
+            stroke: selected ? theme.playerAccentColor.withAlphaComponent(0.85) : theme.borderColor.withAlphaComponent(0.35),
+            fill: selected ? theme.playerAccentColor.withAlphaComponent(0.09) : theme.backgroundColor.withAlphaComponent(0.55)
+        )
+        addLabel(
+            row.title,
+            at: CGPoint(x: frame.minX + 14, y: frame.maxY - 22),
+            fontSize: 17,
+            color: row.isAvailable ? theme.playerColor : theme.borderColor.withAlphaComponent(0.75),
+            alignment: .left
+        )
+        addSmallLabel(
+            row.subtitle,
+            at: CGPoint(x: frame.minX + 14, y: frame.minY + 17),
+            color: theme.borderColor,
+            alignment: .left
+        )
+        addSmallLabel(
+            row.statusText,
+            at: CGPoint(x: frame.maxX - 14, y: frame.maxY - 22),
+            color: row.isAvailable ? theme.playerAccentColor : theme.borderColor,
+            alignment: .right
+        )
+        addSmallLabel(
+            row.progressText,
+            at: CGPoint(x: frame.maxX - 14, y: frame.minY + 17),
+            color: theme.borderColor,
+            alignment: .right
+        )
+        uiHitTargets.append(ArenaControlHitTarget(action: .selectMode(row.kind), frame: frame))
+    }
+
+    func addAwardRow(_ row: ArenaAwardRow, frame: CGRect) {
+        addPanel(frame: frame, stroke: row.isComplete ? theme.playerAccentColor : theme.borderColor.withAlphaComponent(0.35))
+        addSmallLabel(
+            row.title,
+            at: CGPoint(x: frame.minX + 12, y: frame.maxY - 17),
+            color: row.isComplete ? theme.playerAccentColor : theme.playerColor,
+            alignment: .left
+        )
+        addSmallLabel(
+            row.progressText,
+            at: CGPoint(x: frame.maxX - 12, y: frame.maxY - 17),
+            color: theme.borderColor,
+            alignment: .right
+        )
+        addProgressBar(
+            frame: CGRect(x: frame.minX + 12, y: frame.minY + 9, width: frame.width - 24, height: 5),
+            fraction: row.progressFraction,
+            placeholder: row.isPlaceholderProgress
+        )
+    }
+
+    func addToggle(title: String, isOn: Bool, frame: CGRect, action: ArenaControlAction) {
+        addButton(
+            "\(title) \(isOn ? "ON" : "OFF")",
+            frame: frame,
+            action: action,
+            style: isOn ? .primary : .secondary
+        )
+    }
+
+    func addBackButton(layout: ArenaLandscapeUILayout) {
+        addButton(
+            "<",
+            frame: CGRect(x: layout.safeRect.minX, y: layout.safeRect.maxY - 38, width: 42, height: 34),
+            action: .back,
+            style: .secondary
+        )
+    }
+
+    func addScrim(alpha: CGFloat) {
+        let scrim = SKShapeNode(rect: CGRect(origin: .zero, size: size))
+        scrim.fillColor = SKColor.black.withAlphaComponent(alpha)
+        scrim.strokeColor = .clear
+        uiRoot.addChild(scrim)
+    }
+
+    func addPanel(
+        frame: CGRect,
+        stroke: SKColor = SKColor(red: 0.37, green: 0.66, blue: 0.78, alpha: 0.35),
+        fill: SKColor = SKColor(red: 0.03, green: 0.07, blue: 0.11, alpha: 0.62)
+    ) {
+        let panel = SKShapeNode(rect: frame, cornerRadius: 8)
+        panel.fillColor = fill
+        panel.strokeColor = stroke
+        panel.lineWidth = 1
+        uiRoot.addChild(panel)
+    }
+
+    func addProgressBar(frame: CGRect, fraction: Double, placeholder: Bool) {
+        let background = SKShapeNode(rect: frame, cornerRadius: 2)
+        background.fillColor = theme.borderColor.withAlphaComponent(0.18)
+        background.strokeColor = .clear
+        uiRoot.addChild(background)
+
+        let fillWidth = max(0, frame.width * CGFloat(min(1, max(0, fraction))))
+        guard fillWidth > 0 else {
+            return
+        }
+
+        let fill = SKShapeNode(
+            rect: CGRect(x: frame.minX, y: frame.minY, width: fillWidth, height: frame.height),
+            cornerRadius: 2
+        )
+        fill.fillColor = (placeholder ? theme.pickupAmber : theme.playerAccentColor).withAlphaComponent(0.85)
+        fill.strokeColor = .clear
+        uiRoot.addChild(fill)
+    }
+
+    func addButton(
+        _ title: String,
+        frame: CGRect,
+        action: ArenaControlAction,
+        style: ArenaButtonStyle
+    ) {
+        let fill: SKColor
+        let stroke: SKColor
+        let text: SKColor
+
+        switch style {
+        case .primary:
+            fill = theme.playerAccentColor.withAlphaComponent(0.16)
+            stroke = theme.playerAccentColor.withAlphaComponent(0.95)
+            text = theme.playerColor
+        case .secondary:
+            fill = theme.borderColor.withAlphaComponent(0.09)
+            stroke = theme.borderColor.withAlphaComponent(0.55)
+            text = theme.borderColor
+        case .danger:
+            fill = theme.enemyColor.withAlphaComponent(0.08)
+            stroke = theme.enemyColor.withAlphaComponent(0.55)
+            text = theme.enemyColor.withAlphaComponent(0.9)
+        }
+
+        let button = SKShapeNode(rect: frame, cornerRadius: 7)
+        button.fillColor = fill
+        button.strokeColor = stroke
+        button.lineWidth = 1
+        uiRoot.addChild(button)
+
+        addLabel(
+            title,
+            at: CGPoint(x: frame.midX, y: frame.midY - 1),
+            fontSize: 14,
+            color: text,
+            alignment: .center
+        )
+        uiHitTargets.append(ArenaControlHitTarget(action: action, frame: frame))
+    }
+
+    func addTitle(_ text: String, at position: CGPoint) {
+        addLabel(text, at: position, fontSize: 22, color: theme.playerColor, alignment: .left)
+    }
+
+    func addSmallLabel(
+        _ text: String,
+        at position: CGPoint,
+        color: SKColor,
+        alignment: SKLabelHorizontalAlignmentMode
+    ) {
+        addLabel(text, at: position, fontSize: 12, color: color, alignment: alignment)
+    }
+
+    func addLabel(
+        _ text: String,
+        at position: CGPoint,
+        fontSize: CGFloat,
+        color: SKColor,
+        alignment: SKLabelHorizontalAlignmentMode
+    ) {
+        let label = SKLabelNode(fontNamed: fontSize >= 16 ? "Menlo-Bold" : "Menlo")
+        label.text = text
+        label.fontSize = fontSize
+        label.fontColor = color
+        label.horizontalAlignmentMode = alignment
+        label.verticalAlignmentMode = .center
+        label.position = position
+        uiRoot.addChild(label)
+    }
+
+    func presetTitle(_ preset: TiltCalibrationPreset) -> String {
+        switch preset {
+        case .standard:
+            return "STD"
+        case .flatTable:
+            return "FLAT"
+        case .reclined:
+            return "RECL"
+        case .custom:
+            return "CUSTOM"
+        }
     }
 }
 
@@ -908,5 +1728,36 @@ private extension ArenaScene {
         runController.recordFrozenShatters(count: shatterIDs.count, weaponKind: .freezeBurst)
         removeEnemies(ids: shatterIDs)
     }
+}
 
+private struct ArenaControlHitTarget {
+    let action: ArenaControlAction
+    let frame: CGRect
+}
+
+private enum ArenaControlAction: Equatable {
+    case play
+    case playAgain
+    case openModes
+    case openAwards
+    case openOptions
+    case home
+    case back
+    case selectMode(ArenaModeKind)
+    case resume
+    case calibrate
+    case endRun
+    case sensitivityDown
+    case sensitivityUp
+    case preset(TiltCalibrationPreset)
+    case toggleAudio
+    case toggleHaptics
+    case toggleEffects
+    case resetData
+}
+
+private enum ArenaButtonStyle {
+    case primary
+    case secondary
+    case danger
 }

--- a/TiltArena/Game/Input/TiltSettingsStore.swift
+++ b/TiltArena/Game/Input/TiltSettingsStore.swift
@@ -63,4 +63,9 @@ final class TiltSettingsStore {
         )
         settings = currentSettings
     }
+
+    func reset() {
+        defaults.removeObject(forKey: settingsKey)
+        defaults.removeObject(forKey: initialCalibrationKey)
+    }
 }

--- a/TiltArena/Game/Run/RunProfileStore.swift
+++ b/TiltArena/Game/Run/RunProfileStore.swift
@@ -55,4 +55,8 @@ final class RunProfileStore {
         profile = updatedProfile
         return updatedProfile
     }
+
+    func reset() {
+        defaults.removeObject(forKey: profileKey)
+    }
 }

--- a/TiltArena/Game/UI/ArenaLandscapeUILayout.swift
+++ b/TiltArena/Game/UI/ArenaLandscapeUILayout.swift
@@ -1,0 +1,81 @@
+import UIKit
+
+struct ArenaLandscapeUILayout: Equatable {
+    let sceneSize: CGSize
+    let safeAreaInsets: UIEdgeInsets
+    let margin: CGFloat
+
+    var safeRect: CGRect {
+        Self.safeRect(sceneSize: sceneSize, safeAreaInsets: safeAreaInsets, margin: margin)
+    }
+
+    var titlePosition: CGPoint {
+        CGPoint(x: safeRect.minX, y: safeRect.maxY)
+    }
+
+    var topRightControlPosition: CGPoint {
+        CGPoint(x: safeRect.maxX, y: safeRect.maxY)
+    }
+
+    var bottomCenterPosition: CGPoint {
+        CGPoint(x: safeRect.midX, y: safeRect.minY)
+    }
+
+    var lowerRightButtonFrame: CGRect {
+        CGRect(x: safeRect.maxX - 156, y: safeRect.minY, width: 156, height: 48)
+    }
+
+    var centerPoint: CGPoint {
+        CGPoint(x: safeRect.midX, y: safeRect.midY)
+    }
+
+    func leftColumnFrame(width: CGFloat) -> CGRect {
+        CGRect(
+            x: safeRect.minX,
+            y: safeRect.minY + 56,
+            width: min(width, safeRect.width * 0.46),
+            height: max(0, safeRect.height - 96)
+        )
+    }
+
+    func rightColumnFrame(width: CGFloat) -> CGRect {
+        let resolvedWidth = min(width, safeRect.width * 0.42)
+        return CGRect(
+            x: safeRect.maxX - resolvedWidth,
+            y: safeRect.minY + 56,
+            width: resolvedWidth,
+            height: max(0, safeRect.height - 96)
+        )
+    }
+
+    func bottomButtonFrame(index: Int, count: Int, buttonSize: CGSize) -> CGRect {
+        let spacing: CGFloat = 12
+        let totalWidth = CGFloat(count) * buttonSize.width + CGFloat(max(0, count - 1)) * spacing
+        let minX = safeRect.midX - totalWidth / 2
+        return CGRect(
+            x: minX + CGFloat(index) * (buttonSize.width + spacing),
+            y: safeRect.minY,
+            width: buttonSize.width,
+            height: buttonSize.height
+        )
+    }
+
+    static func safeRect(
+        sceneSize: CGSize,
+        safeAreaInsets: UIEdgeInsets,
+        margin: CGFloat
+    ) -> CGRect {
+        let width = max(0, sceneSize.width)
+        let height = max(0, sceneSize.height)
+        let leftInset = max(0, min(safeAreaInsets.left, width))
+        let rightInset = max(0, min(safeAreaInsets.right, width - leftInset))
+        let bottomInset = max(0, min(safeAreaInsets.bottom, height))
+        let topInset = max(0, min(safeAreaInsets.top, height - bottomInset))
+        let minX = leftInset + margin
+        let maxX = max(minX, width - rightInset - margin)
+        let minY = bottomInset + margin
+        let maxY = max(minY, height - topInset - margin)
+
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+}

--- a/TiltArena/Game/UI/ArenaLocalOptionsStore.swift
+++ b/TiltArena/Game/UI/ArenaLocalOptionsStore.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct ArenaLocalOptions: Codable, Equatable {
+    var audioEnabled = true
+    var hapticsEnabled = true
+    var reducedEffects = false
+
+    static let defaults = ArenaLocalOptions()
+}
+
+final class ArenaLocalOptionsStore {
+    private let defaults: UserDefaults
+    private let optionsKey = "tiltArena.localOptions"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var options: ArenaLocalOptions {
+        get {
+            guard
+                let data = defaults.data(forKey: optionsKey),
+                let options = try? JSONDecoder().decode(ArenaLocalOptions.self, from: data)
+            else {
+                return .defaults
+            }
+
+            return options
+        }
+        set {
+            guard let data = try? JSONEncoder().encode(newValue) else {
+                return
+            }
+
+            defaults.set(data, forKey: optionsKey)
+        }
+    }
+
+    func reset() {
+        defaults.removeObject(forKey: optionsKey)
+    }
+}

--- a/TiltArena/Game/UI/ArenaMenuModels.swift
+++ b/TiltArena/Game/UI/ArenaMenuModels.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+struct ArenaModeRow: Equatable {
+    let kind: ArenaModeKind
+    let title: String
+    let subtitle: String
+    let statusText: String
+    let progressText: String
+    let isAvailable: Bool
+}
+
+struct ArenaAwardRow: Equatable {
+    let title: String
+    let progressText: String
+    let detailText: String
+    let progressFraction: Double
+    let isComplete: Bool
+    let isPlaceholderProgress: Bool
+}
+
+struct ArenaMenuContent {
+    static func modeRows(profile: RunProfile, selectedMode: ArenaModeKind) -> [ArenaModeRow] {
+        let redlineAvailable = profile.bestScore >= 5_000
+        let dailyAvailable = profile.totalEnemiesDestroyed >= 400
+
+        return [
+            ArenaModeRow(
+                kind: .classic,
+                title: ArenaModeKind.classic.displayName,
+                subtitle: "Classic Survival",
+                statusText: selectedMode == .classic ? "SELECTED" : "AVAILABLE",
+                progressText: "BEST \(profile.bestScore)",
+                isAvailable: true
+            ),
+            ArenaModeRow(
+                kind: .redline,
+                title: ArenaModeKind.redline.displayName,
+                subtitle: "Faster pressure curve",
+                statusText: modeStatus(kind: .redline, selectedMode: selectedMode, isAvailable: redlineAvailable),
+                progressText: "\(min(profile.bestScore, 5_000))/5000 CLASSIC BEST",
+                isAvailable: redlineAvailable
+            ),
+            ArenaModeRow(
+                kind: .daily,
+                title: ArenaModeKind.daily.displayName,
+                subtitle: "Local fixed-seed arena",
+                statusText: modeStatus(kind: .daily, selectedMode: selectedMode, isAvailable: dailyAvailable),
+                progressText: "\(min(profile.totalEnemiesDestroyed, 400))/400 UNLOCK TRACK",
+                isAvailable: dailyAvailable
+            )
+        ]
+    }
+
+    static func awardRows(profile: RunProfile) -> [ArenaAwardRow] {
+        [
+            award(
+                title: "COMBO SPARK",
+                progress: profile.highestCombo,
+                target: 10,
+                detail: "Reach a 10 combo",
+                placeholder: false
+            ),
+            award(
+                title: "SCORE CREST",
+                progress: profile.bestScore,
+                target: 5_000,
+                detail: "Score 5000 in Classic",
+                placeholder: false
+            ),
+            award(
+                title: "FREEZE SHATTER",
+                progress: min(profile.totalEnemiesDestroyed, 25),
+                target: 25,
+                detail: "Shatter frozen enemies",
+                placeholder: true
+            ),
+            award(
+                title: "DANGER GRAB",
+                progress: min(profile.totalRuns, 5),
+                target: 5,
+                detail: "Take risky weapon pickups",
+                placeholder: true
+            ),
+            award(
+                title: "WEAPON MASTER",
+                progress: profile.totalEnemiesDestroyed,
+                target: 250,
+                detail: "Destroy enemies with weapons",
+                placeholder: true
+            ),
+            award(
+                title: "SURVIVOR",
+                progress: Int(profile.longestSurvivalTime),
+                target: 120,
+                detail: "Survive for 120 seconds",
+                placeholder: false
+            )
+        ]
+    }
+
+    static func activeUnlockText(profile: RunProfile) -> String {
+        if profile.bestScore < 5_000 {
+            return "REDLINE \(min(profile.bestScore, 5_000))/5000"
+        }
+
+        if profile.totalEnemiesDestroyed < 400 {
+            return "DAILY \(min(profile.totalEnemiesDestroyed, 400))/400"
+        }
+
+        return "ALL LOCAL MODES READY"
+    }
+
+    static func postRunHighlights(
+        summary: RunSummary?,
+        profile: RunProfile,
+        previousBestScore: Int
+    ) -> [String] {
+        guard let summary else {
+            return ["NO RUN SUMMARY"]
+        }
+
+        let bestText = summary.score > previousBestScore ? "NEW BEST" : "BEST \(profile.bestScore)"
+        return [
+            bestText,
+            "TIME \(formatTime(summary.survivalTime))",
+            "MAX COMBO \(summary.maxCombo)",
+            "KILLS \(summary.enemiesDestroyed)",
+            "WEAPON \(summary.bestWeapon?.displayName.uppercased() ?? "NONE")",
+            activeUnlockText(profile: profile)
+        ]
+    }
+
+    private static func award(
+        title: String,
+        progress: Int,
+        target: Int,
+        detail: String,
+        placeholder: Bool
+    ) -> ArenaAwardRow {
+        let clampedTarget = max(1, target)
+        let clampedProgress = max(0, min(progress, clampedTarget))
+        return ArenaAwardRow(
+            title: title,
+            progressText: "\(clampedProgress)/\(clampedTarget)",
+            detailText: detail,
+            progressFraction: Double(clampedProgress) / Double(clampedTarget),
+            isComplete: clampedProgress >= clampedTarget,
+            isPlaceholderProgress: placeholder
+        )
+    }
+
+    private static func modeStatus(
+        kind: ArenaModeKind,
+        selectedMode: ArenaModeKind,
+        isAvailable: Bool
+    ) -> String {
+        guard isAvailable else {
+            return "LOCKED"
+        }
+
+        return kind == selectedMode ? "SELECTED" : "AVAILABLE"
+    }
+
+    private static func formatTime(_ time: TimeInterval) -> String {
+        String(format: "%.1fs", time)
+    }
+}

--- a/TiltArena/Game/UI/ArenaUISceneState.swift
+++ b/TiltArena/Game/UI/ArenaUISceneState.swift
@@ -1,0 +1,27 @@
+enum ArenaUISceneState: Equatable {
+    case home
+    case modeSelect
+    case awards
+    case options
+    case preRun
+    case activeGameplay
+    case pause
+    case postRun
+}
+
+enum ArenaModeKind: String, CaseIterable, Equatable {
+    case classic
+    case redline
+    case daily
+
+    var displayName: String {
+        switch self {
+        case .classic:
+            return "CLASSIC"
+        case .redline:
+            return "REDLINE"
+        case .daily:
+            return "DAILY"
+        }
+    }
+}

--- a/TiltArena/Game/UI/ReadyStartHoldController.swift
+++ b/TiltArena/Game/UI/ReadyStartHoldController.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+import Foundation
+
+struct ReadyStartHoldConfiguration: Equatable {
+    var requiredDuration: TimeInterval = 3
+    var startCircleRadius: CGFloat = 58
+}
+
+struct ReadyStartHoldState: Equatable {
+    var elapsed: TimeInterval = 0
+    var isInsideCircle = false
+    var didComplete = false
+
+    func progressFraction(requiredDuration: TimeInterval) -> Double {
+        guard requiredDuration > 0 else {
+            return 1
+        }
+
+        return min(1, max(0, elapsed / requiredDuration))
+    }
+}
+
+struct ReadyStartHoldController: Equatable {
+    var configuration = ReadyStartHoldConfiguration()
+    private(set) var state = ReadyStartHoldState()
+
+    mutating func reset() {
+        state = ReadyStartHoldState()
+    }
+
+    @discardableResult
+    mutating func update(
+        playerPosition: CGPoint,
+        startPoint: CGPoint,
+        deltaTime: TimeInterval
+    ) -> ReadyStartHoldState {
+        let radius = max(0, configuration.startCircleRadius)
+        let dx = playerPosition.x - startPoint.x
+        let dy = playerPosition.y - startPoint.y
+        let isInside = dx * dx + dy * dy <= radius * radius
+
+        guard isInside else {
+            state = ReadyStartHoldState(elapsed: 0, isInsideCircle: false, didComplete: false)
+            return state
+        }
+
+        let elapsed = state.elapsed + max(0, deltaTime)
+        state = ReadyStartHoldState(
+            elapsed: elapsed,
+            isInsideCircle: true,
+            didComplete: elapsed >= max(0, configuration.requiredDuration)
+        )
+        return state
+    }
+}

--- a/TiltArenaTests/ArenaLandscapeUILayoutTests.swift
+++ b/TiltArenaTests/ArenaLandscapeUILayoutTests.swift
@@ -1,0 +1,39 @@
+import UIKit
+import XCTest
+@testable import TiltArena
+
+final class ArenaLandscapeUILayoutTests: XCTestCase {
+    func testSafeRectHonorsLandscapeInsetsAndMargin() {
+        let layout = ArenaLandscapeUILayout(
+            sceneSize: CGSize(width: 852, height: 393),
+            safeAreaInsets: UIEdgeInsets(top: 0, left: 59, bottom: 21, right: 59),
+            margin: 24
+        )
+
+        XCTAssertEqual(layout.safeRect, CGRect(x: 83, y: 45, width: 686, height: 324))
+        XCTAssertEqual(layout.titlePosition, CGPoint(x: 83, y: 369))
+        XCTAssertEqual(layout.bottomCenterPosition, CGPoint(x: 426, y: 45))
+    }
+
+    func testBottomButtonsRemainCenteredInLandscapeSafeRect() {
+        let layout = ArenaLandscapeUILayout(
+            sceneSize: CGSize(width: 800, height: 360),
+            safeAreaInsets: .zero,
+            margin: 24
+        )
+
+        let first = layout.bottomButtonFrame(
+            index: 0,
+            count: 3,
+            buttonSize: CGSize(width: 100, height: 40)
+        )
+        let last = layout.bottomButtonFrame(
+            index: 2,
+            count: 3,
+            buttonSize: CGSize(width: 100, height: 40)
+        )
+
+        XCTAssertEqual(first.minX, 238)
+        XCTAssertEqual(last.maxX, 562)
+    }
+}

--- a/TiltArenaTests/ArenaLocalOptionsStoreTests.swift
+++ b/TiltArenaTests/ArenaLocalOptionsStoreTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import TiltArena
+
+final class ArenaLocalOptionsStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ArenaLocalOptionsStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testOptionsPersistAndReset() {
+        let store = ArenaLocalOptionsStore(defaults: defaults)
+        store.options = ArenaLocalOptions(audioEnabled: false, hapticsEnabled: false, reducedEffects: true)
+
+        XCTAssertEqual(
+            ArenaLocalOptionsStore(defaults: defaults).options,
+            ArenaLocalOptions(audioEnabled: false, hapticsEnabled: false, reducedEffects: true)
+        )
+
+        store.reset()
+
+        XCTAssertEqual(store.options, .defaults)
+    }
+}

--- a/TiltArenaTests/ArenaMenuContentTests.swift
+++ b/TiltArenaTests/ArenaMenuContentTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import TiltArena
+
+final class ArenaMenuContentTests: XCTestCase {
+    func testModeRowsKeepClassicAvailableAndGateMockModesFromProfile() {
+        var profile = RunProfile()
+
+        var rows = ArenaMenuContent.modeRows(profile: profile, selectedMode: .classic)
+        XCTAssertEqual(rows.map(\.kind), [.classic, .redline, .daily])
+        XCTAssertTrue(rows[0].isAvailable)
+        XCTAssertFalse(rows[1].isAvailable)
+        XCTAssertFalse(rows[2].isAvailable)
+
+        profile.bestScore = 5_000
+        profile.totalEnemiesDestroyed = 400
+        rows = ArenaMenuContent.modeRows(profile: profile, selectedMode: .classic)
+
+        XCTAssertTrue(rows[1].isAvailable)
+        XCTAssertEqual(rows[1].statusText, "AVAILABLE")
+        XCTAssertTrue(rows[2].isAvailable)
+        XCTAssertEqual(rows[2].statusText, "AVAILABLE")
+    }
+
+    func testAwardRowsUseProfileDataAndMarkPlaceholderProgress() {
+        var profile = RunProfile()
+        profile.bestScore = 2_500
+        profile.highestCombo = 8
+        profile.totalEnemiesDestroyed = 30
+
+        let rows = ArenaMenuContent.awardRows(profile: profile)
+
+        XCTAssertEqual(rows.first?.title, "COMBO SPARK")
+        XCTAssertEqual(rows.first?.progressText, "8/10")
+        XCTAssertEqual(rows[1].progressText, "2500/5000")
+        XCTAssertTrue(rows.contains(where: \.isPlaceholderProgress))
+    }
+
+    func testPostRunHighlightsReportNewBestAgainstPreviousBest() {
+        let summary = RunSummary(
+            score: 600,
+            survivalTime: 12.5,
+            maxCombo: 7,
+            enemiesDestroyed: 9,
+            bestWeapon: .shockwave,
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        var profile = RunProfile()
+        profile.record(summary)
+
+        let highlights = ArenaMenuContent.postRunHighlights(
+            summary: summary,
+            profile: profile,
+            previousBestScore: 500
+        )
+
+        XCTAssertEqual(highlights.first, "NEW BEST")
+        XCTAssertTrue(highlights.contains("WEAPON SHOCKWAVE"))
+    }
+}

--- a/TiltArenaTests/GameViewControllerTests.swift
+++ b/TiltArenaTests/GameViewControllerTests.swift
@@ -1,0 +1,12 @@
+import UIKit
+import XCTest
+@testable import TiltArena
+
+final class GameViewControllerTests: XCTestCase {
+    @MainActor
+    func testSupportedOrientationsAreLandscapeOnly() {
+        let controller = GameViewController()
+
+        XCTAssertEqual(controller.supportedInterfaceOrientations, .landscape)
+    }
+}

--- a/TiltArenaTests/ReadyStartHoldControllerTests.swift
+++ b/TiltArenaTests/ReadyStartHoldControllerTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import TiltArena
+
+final class ReadyStartHoldControllerTests: XCTestCase {
+    func testHoldCompletesOnlyAfterRequiredTimeInsideCircle() {
+        var controller = ReadyStartHoldController(
+            configuration: ReadyStartHoldConfiguration(requiredDuration: 3, startCircleRadius: 10)
+        )
+        let startPoint = CGPoint(x: 100, y: 100)
+
+        var state = controller.update(
+            playerPosition: CGPoint(x: 105, y: 100),
+            startPoint: startPoint,
+            deltaTime: 1.5
+        )
+        XCTAssertTrue(state.isInsideCircle)
+        XCTAssertFalse(state.didComplete)
+        XCTAssertEqual(state.progressFraction(requiredDuration: 3), 0.5, accuracy: 0.0001)
+
+        state = controller.update(
+            playerPosition: CGPoint(x: 100, y: 100),
+            startPoint: startPoint,
+            deltaTime: 1.5
+        )
+        XCTAssertTrue(state.didComplete)
+        XCTAssertEqual(state.progressFraction(requiredDuration: 3), 1, accuracy: 0.0001)
+    }
+
+    func testLeavingCircleResetsCountdown() {
+        var controller = ReadyStartHoldController(
+            configuration: ReadyStartHoldConfiguration(requiredDuration: 3, startCircleRadius: 10)
+        )
+        let startPoint = CGPoint(x: 100, y: 100)
+
+        controller.update(playerPosition: startPoint, startPoint: startPoint, deltaTime: 2)
+        let state = controller.update(
+            playerPosition: CGPoint(x: 111, y: 100),
+            startPoint: startPoint,
+            deltaTime: 1
+        )
+
+        XCTAssertFalse(state.isInsideCircle)
+        XCTAssertFalse(state.didComplete)
+        XCTAssertEqual(state.elapsed, 0)
+    }
+}

--- a/TiltArenaTests/RunProfileStoreTests.swift
+++ b/TiltArenaTests/RunProfileStoreTests.swift
@@ -56,4 +56,22 @@ final class RunProfileStoreTests: XCTestCase {
 
         XCTAssertEqual(store.profile, RunProfile())
     }
+
+    func testResetClearsPersistedProfile() {
+        let store = RunProfileStore(defaults: defaults)
+        store.record(
+            RunSummary(
+                score: 100,
+                survivalTime: 5,
+                maxCombo: 2,
+                enemiesDestroyed: 3,
+                bestWeapon: .shockwave,
+                timestamp: Date(timeIntervalSince1970: 1)
+            )
+        )
+
+        store.reset()
+
+        XCTAssertEqual(store.profile, RunProfile())
+    }
 }

--- a/TiltArenaTests/TiltSettingsStoreTests.swift
+++ b/TiltArenaTests/TiltSettingsStoreTests.swift
@@ -50,4 +50,15 @@ final class TiltSettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.needsInitialCalibration)
         XCTAssertEqual(store.settings.calibration, .defaultCalibration(for: .flatTable))
     }
+
+    func testResetRestoresDefaultSettingsAndInitialCalibrationNeed() {
+        let store = TiltSettingsStore(defaults: defaults)
+        store.selectPreset(.reclined)
+        store.updateSensitivity(1.3)
+
+        store.reset()
+
+        XCTAssertTrue(store.needsInitialCalibration)
+        XCTAssertEqual(store.settings, .defaults)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds the first landscape SpriteKit UI scene shell for Home, Mode Select, Awards, Options, Pre-run, Active Gameplay, Pause, and Post-run.
- Changes pre-run start to a hold-position countdown and wires pause, resume, calibrate, options, end-run, and play-again flows.
- Adds local/mock mode and award projections plus persisted audio, haptics, and reduced-effects options while #12 remains open.

Closes #13

## Validation
- xcodegen generate
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination "generic/platform=iOS Simulator" -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination "generic/platform=iOS Simulator" -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing
- swiftlint lint --no-cache
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,id=7211F793-06FA-4695-B8CD-6E6A600CFCAE" -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test

Note: an earlier retry on iPhone 17 Pro failed because the simulator device was busy; the clean iPhone 17 run passed 120 tests with 0 failures.