### PR TITLE
Add Warp Dash weapon pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -43,6 +43,8 @@ final class ArenaScene: SKScene {
     private lazy var flameTrailEffectNode = FlameTrailEffectNode(theme: theme)
     private var gravityWellState: GravityWellState?
     var gravityWellEffectNode: SKNode?
+    private var warpDashState = WarpDashState()
+    private var warpDashInvulnerabilityTimeRemaining: TimeInterval = 0
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let bestMarkerLabel = SKLabelNode(fontNamed: "Menlo")
     private let comboLabel = SKLabelNode(fontNamed: "Menlo-Bold")
@@ -302,6 +304,7 @@ final class ArenaScene: SKScene {
         }
 
         let input = tiltInputController.update(deltaTime: deltaTime)
+        warpDashState.record(input: input)
         let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
         applyPlayerState(state, resetTrail: false)
         updateActiveRun(deltaTime: deltaTime, playerPosition: state.position)
@@ -373,6 +376,8 @@ final class ArenaScene: SKScene {
         flameTrailState.reset()
         flameTrailEffectNode.reset()
         deactivateGravityWell()
+        warpDashState.reset()
+        warpDashInvulnerabilityTimeRemaining = 0
     }
 
     private func resetPlayerFeedback() {
@@ -381,11 +386,14 @@ final class ArenaScene: SKScene {
         playerNode?.setScale(1)
     }
 
-    private func updateActiveRun(deltaTime: TimeInterval, playerPosition: CGPoint) {
+    private func updateActiveRun(deltaTime: TimeInterval, playerPosition initialPlayerPosition: CGPoint) {
+        var playerPosition = initialPlayerPosition
+
         runController.update(deltaTime: deltaTime)
+        updateWarpDashInvulnerability(deltaTime: deltaTime)
         spawnEnemiesIfNeeded(deltaTime: deltaTime, playerPosition: playerPosition)
         spawnPickupIfNeeded(deltaTime: deltaTime, playerPosition: playerPosition)
-        collectPickups(playerPosition: playerPosition)
+        playerPosition = collectPickups(playerPosition: playerPosition)
         advanceEnemies(deltaTime: deltaTime, playerPosition: playerPosition)
         updateGravityWell(deltaTime: deltaTime)
         removeExpiredEnemies()
@@ -512,7 +520,8 @@ final class ArenaScene: SKScene {
         }
     }
 
-    private func collectPickups(playerPosition: CGPoint) {
+    private func collectPickups(playerPosition: CGPoint) -> CGPoint {
+        var currentPlayerPosition = playerPosition
         let playerCircle = CollisionCircle(
             center: playerPosition,
             radius: movementController.configuration.visualRadius
@@ -520,7 +529,7 @@ final class ArenaScene: SKScene {
         let collectedPickups = pickups.filter { playerCircle.intersects($0.collisionCircle) }
 
         guard !collectedPickups.isEmpty else {
-            return
+            return currentPlayerPosition
         }
 
         for pickup in collectedPickups {
@@ -529,8 +538,11 @@ final class ArenaScene: SKScene {
             }
 
             removePickup(id: pickup.id)
-            applyWeapon(pickup.kind, playerPosition: playerPosition)
+            applyWeapon(pickup.kind, playerPosition: currentPlayerPosition)
+            currentPlayerPosition = movementController.state.position
         }
+
+        return currentPlayerPosition
     }
 
     private func removePickup(id: Int) {
@@ -576,6 +588,8 @@ final class ArenaScene: SKScene {
         case .flameTrail:
             flameTrailState.activate(at: playerPosition)
             flameTrailEffectNode.apply(segments: flameTrailState.segments)
+        case .warpDash:
+            performWarpDash(from: playerPosition)
         case .novaBomb:
             playNovaBombEffect()
         }
@@ -689,7 +703,43 @@ final class ArenaScene: SKScene {
         flameTrailEffectNode.apply(segments: frame.segments)
     }
 
+    private func performWarpDash(from startPosition: CGPoint) {
+        let state = movementController.dash(
+            direction: warpDashState.resolvedDirection(),
+            distance: warpDashDistance(),
+            arenaSize: size
+        )
+
+        applyPlayerState(state, resetTrail: false)
+        warpDashInvulnerabilityTimeRemaining = max(
+            warpDashInvulnerabilityTimeRemaining,
+            weaponResolver.configuration.warpDashInvulnerabilityDuration
+        )
+        playWarpDashEffect(from: startPosition, to: state.position)
+    }
+
+    private func warpDashDistance() -> CGFloat {
+        let playableRect = movementController.configuration.playableRect(in: size)
+        return min(playableRect.width, playableRect.height)
+            * max(0, weaponResolver.configuration.warpDashDistanceFractionOfShortSide)
+    }
+
+    private func updateWarpDashInvulnerability(deltaTime: TimeInterval) {
+        guard warpDashInvulnerabilityTimeRemaining > 0 else {
+            return
+        }
+
+        warpDashInvulnerabilityTimeRemaining = max(
+            0,
+            warpDashInvulnerabilityTimeRemaining - max(0, deltaTime)
+        )
+    }
+
     private func detectPlayerCollision(playerPosition: CGPoint) {
+        guard warpDashInvulnerabilityTimeRemaining == 0 else {
+            return
+        }
+
         let playerCircle = CollisionCircle(
             center: playerPosition,
             radius: runController.configuration.playerHitRadius

--- a/TiltArena/Game/Player/PlayerMovementController.swift
+++ b/TiltArena/Game/Player/PlayerMovementController.swift
@@ -57,6 +57,34 @@ struct PlayerMovementController {
         return state
     }
 
+    mutating func dash(direction: CGVector, distance: CGFloat, arenaSize: CGSize) -> PlayerMovementState {
+        guard direction.length > 0 else {
+            return state
+        }
+
+        let clampedDistance = max(0, distance)
+        guard clampedDistance > 0 else {
+            return state
+        }
+
+        let dashDirection = direction.normalized
+        let proposedPosition = CGPoint(
+            x: state.position.x + dashDirection.dx * clampedDistance,
+            y: state.position.y + dashDirection.dy * clampedDistance
+        )
+        let maximumSpeed = configuration.maximumSpeed(in: arenaSize)
+
+        state = PlayerMovementState(
+            position: clampedPosition(proposedPosition, in: arenaSize),
+            velocity: CGVector(
+                dx: dashDirection.dx * maximumSpeed,
+                dy: dashDirection.dy * maximumSpeed
+            )
+        )
+
+        return state
+    }
+
     mutating func clampToArena(_ arenaSize: CGSize) -> PlayerMovementState {
         state = PlayerMovementState(
             position: clampedPosition(state.position, in: arenaSize),

--- a/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
+++ b/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
@@ -103,4 +103,39 @@ extension ArenaScene {
         ])
         container.run(.sequence([pulse, .removeFromParent()]))
     }
+
+    func playWarpDashEffect(from startPosition: CGPoint, to endPosition: CGPoint) {
+        let path = CGMutablePath()
+        path.move(to: startPosition)
+        path.addLine(to: endPosition)
+
+        let streak = SKShapeNode(path: path)
+        streak.strokeColor = theme.playerAccentColor.withAlphaComponent(0.9)
+        streak.lineWidth = 2
+        streak.glowWidth = 5
+        streak.zPosition = 18
+        addChild(streak)
+
+        let endpoint = SKShapeNode(circleOfRadius: movementController.configuration.visualRadius * 1.4)
+        endpoint.position = endPosition
+        endpoint.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
+        endpoint.fillColor = .clear
+        endpoint.lineWidth = 1.4
+        endpoint.glowWidth = 4
+        endpoint.zPosition = 18
+        endpoint.setScale(0.35)
+        addChild(endpoint)
+
+        let fade = SKAction.group([
+            .fadeOut(withDuration: 0.14),
+            .scale(to: 0.96, duration: 0.14)
+        ])
+        streak.run(.sequence([fade, .removeFromParent()]))
+
+        let pulse = SKAction.group([
+            .scale(to: 1.0, duration: 0.14),
+            .fadeOut(withDuration: 0.14)
+        ])
+        endpoint.run(.sequence([pulse, .removeFromParent()]))
+    }
 }

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -17,6 +17,7 @@ struct PickupSpawnConfiguration: Equatable {
         .seekerSwarm,
         .razorShield,
         .flameTrail,
+        .warpDash,
         .gravityWell,
         .shockwave,
         .seekerSwarm,
@@ -24,6 +25,7 @@ struct PickupSpawnConfiguration: Equatable {
         .freezeBurst,
         .chainLightning,
         .flameTrail,
+        .warpDash,
         .novaBomb
     ]
 

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -15,6 +15,8 @@ struct StartingWeaponConfiguration: Equatable {
     var chainLightningInitialRange: CGFloat = 128
     var chainLightningJumpRange: CGFloat = 96
     var chainLightningTargetLimit: Int = 6
+    var warpDashDistanceFractionOfShortSide: CGFloat = 0.33
+    var warpDashInvulnerabilityDuration: TimeInterval = 0.35
 }
 
 struct WeaponResolution: Equatable {
@@ -45,7 +47,7 @@ struct StartingWeaponResolver {
                 destroyedEnemyIDs: Set(targetIDs),
                 chainLightningEnemyIDs: targetIDs
             )
-        case .flameTrail:
+        case .flameTrail, .warpDash:
             return WeaponResolution()
         case .novaBomb:
             return WeaponResolution(destroyedEnemyIDs: Set(enemies.map(\.id)))

--- a/TiltArena/Game/Weapons/WarpDashState.swift
+++ b/TiltArena/Game/Weapons/WarpDashState.swift
@@ -1,0 +1,26 @@
+import CoreGraphics
+
+struct WarpDashState {
+    private let minimumDirectionMagnitude: CGFloat = 0.05
+    private(set) var lastDirection = CGVector(dx: 0, dy: 1)
+
+    mutating func reset() {
+        lastDirection = CGVector(dx: 0, dy: 1)
+    }
+
+    mutating func record(input: CGVector) {
+        guard input.length >= minimumDirectionMagnitude else {
+            return
+        }
+
+        lastDirection = input.normalized
+    }
+
+    func resolvedDirection() -> CGVector {
+        guard lastDirection.length > 0 else {
+            return CGVector(dx: 0, dy: 1)
+        }
+
+        return lastDirection.normalized
+    }
+}

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -6,6 +6,7 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case gravityWell
     case chainLightning
     case flameTrail
+    case warpDash
     case novaBomb
 
     var displayName: String {
@@ -24,6 +25,8 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
             return "Chain Lightning"
         case .flameTrail:
             return "Flame Trail"
+        case .warpDash:
+            return "Warp Dash"
         case .novaBomb:
             return "Nova Bomb"
         }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -52,6 +52,8 @@ final class WeaponPickupNode: SKNode {
             return theme.pickupBlue
         case .flameTrail:
             return theme.pickupAmber
+        case .warpDash:
+            return theme.pickupViolet
         case .novaBomb:
             return theme.pickupAmber
         }

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -159,6 +159,7 @@ final class PickupSpawnPlannerTests: XCTestCase {
         XCTAssertEqual(kinds.filter { $0 == .gravityWell }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .chainLightning }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .flameTrail }.count, 2)
+        XCTAssertEqual(kinds.filter { $0 == .warpDash }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .novaBomb }.count, 1)
         XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, kinds.filter { $0 == .freezeBurst }.count)
@@ -166,9 +167,11 @@ final class PickupSpawnPlannerTests: XCTestCase {
         XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .gravityWell }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .chainLightning }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .flameTrail }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .freezeBurst }.count, kinds.filter { $0 == .warpDash }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .gravityWell }.count, kinds.filter { $0 == .novaBomb }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .chainLightning }.count, kinds.filter { $0 == .novaBomb }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .flameTrail }.count, kinds.filter { $0 == .novaBomb }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .warpDash }.count, kinds.filter { $0 == .novaBomb }.count)
     }
 
     func testEmptyKindCycleDoesNotSpawnPickup() {

--- a/TiltArenaTests/PlayerMovementControllerTests.swift
+++ b/TiltArenaTests/PlayerMovementControllerTests.swift
@@ -34,4 +34,52 @@ final class PlayerMovementControllerTests: XCTestCase {
         XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)
         XCTAssertEqual(state.position.y, playableRect.maxY, accuracy: 0.0001)
     }
+
+    func testDashMovesAlongDirectionByDistance() {
+        let arenaSize = CGSize(width: 390, height: 844)
+        var controller = PlayerMovementController()
+        let startState = controller.reset(in: arenaSize)
+        let distance: CGFloat = 99
+
+        let state = controller.dash(
+            direction: CGVector(dx: 3, dy: 4),
+            distance: distance,
+            arenaSize: arenaSize
+        )
+
+        XCTAssertEqual(state.position.x, startState.position.x + distance * 0.6, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, startState.position.y + distance * 0.8, accuracy: 0.0001)
+        XCTAssertGreaterThan(state.velocity.length, 2)
+    }
+
+    func testDashClampsToPlayableBounds() {
+        let arenaSize = CGSize(width: 390, height: 844)
+        var controller = PlayerMovementController()
+        _ = controller.reset(in: arenaSize)
+        let playableRect = controller.configuration.playableRect(in: arenaSize)
+
+        let state = controller.dash(
+            direction: CGVector(dx: 1, dy: 1),
+            distance: 10_000,
+            arenaSize: arenaSize
+        )
+
+        XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, playableRect.maxY, accuracy: 0.0001)
+    }
+
+    func testDashIgnoresZeroDirectionAndInvalidDistance() {
+        let arenaSize = CGSize(width: 390, height: 844)
+        var controller = PlayerMovementController()
+        let startState = controller.reset(in: arenaSize)
+
+        XCTAssertEqual(
+            controller.dash(direction: .zero, distance: 100, arenaSize: arenaSize),
+            startState
+        )
+        XCTAssertEqual(
+            controller.dash(direction: CGVector(dx: 1, dy: 0), distance: 0, arenaSize: arenaSize),
+            startState
+        )
+    }
 }

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -243,6 +243,24 @@ final class StartingWeaponResolverTests: XCTestCase {
         XCTAssertEqual(resolution.frozenEnemyIDs, [])
     }
 
+    func testWarpDashDoesNotInstantlyResolveTargets() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 10, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .warpDash,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+        XCTAssertEqual(resolution.frozenEnemyIDs, [])
+        XCTAssertEqual(resolution.gravityWellEnemyIDs, [])
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [])
+    }
+
     func testNovaBombHandlesEmptyArena() {
         let resolver = StartingWeaponResolver()
 

--- a/TiltArenaTests/WarpDashStateTests.swift
+++ b/TiltArenaTests/WarpDashStateTests.swift
@@ -1,0 +1,39 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class WarpDashStateTests: XCTestCase {
+    func testDefaultsToUpwardDirectionBeforeMovement() {
+        let state = WarpDashState()
+
+        XCTAssertEqual(state.resolvedDirection().dx, 0, accuracy: 0.0001)
+        XCTAssertEqual(state.resolvedDirection().dy, 1, accuracy: 0.0001)
+    }
+
+    func testRecordsNormalizedMovementDirection() {
+        var state = WarpDashState()
+
+        state.record(input: CGVector(dx: 3, dy: 4))
+
+        XCTAssertEqual(state.resolvedDirection().dx, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(state.resolvedDirection().dy, 0.8, accuracy: 0.0001)
+    }
+
+    func testNeutralInputKeepsLastMovementDirection() {
+        var state = WarpDashState()
+        state.record(input: CGVector(dx: -1, dy: 0))
+        state.record(input: CGVector(dx: 0.01, dy: 0))
+
+        XCTAssertEqual(state.resolvedDirection().dx, -1, accuracy: 0.0001)
+        XCTAssertEqual(state.resolvedDirection().dy, 0, accuracy: 0.0001)
+    }
+
+    func testResetRestoresUpwardFallback() {
+        var state = WarpDashState()
+        state.record(input: CGVector(dx: 1, dy: 0))
+        state.reset()
+
+        XCTAssertEqual(state.resolvedDirection().dx, 0, accuracy: 0.0001)
+        XCTAssertEqual(state.resolvedDirection().dy, 1, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- Add Warp Dash to the weapon roster and pickup cycle.
- Dash the player in the current or last tilt direction with arena clamping and brief invulnerability.
- Add the Warp Dash visual effect and focused unit coverage for movement, fallback direction, resolver, and pickup-cycle behavior.

## Validation
- `plutil -lint TiltArena/Resources/Info.plist`
- `xcodegen generate`
- `swiftlint lint --no-cache` (warning-level existing violations only, 0 serious)
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- `xcrun simctl list devices available` blocked locally: CoreSimulatorService connection invalid, so simulator execution was not available.

Closes #53