### PR TITLE
Clean up duplicated gameplay helpers

### DIFF
--- a/TiltArena/Game/ArenaGeometry.swift
+++ b/TiltArena/Game/ArenaGeometry.swift
@@ -1,0 +1,29 @@
+import CoreGraphics
+import UIKit
+
+enum ArenaGeometry {
+    static func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy
+    }
+
+    static func safeRect(
+        sceneSize: CGSize,
+        safeAreaInsets: UIEdgeInsets,
+        margin: CGFloat
+    ) -> CGRect {
+        let width = max(0, sceneSize.width)
+        let height = max(0, sceneSize.height)
+        let leftInset = max(0, min(safeAreaInsets.left, width))
+        let rightInset = max(0, min(safeAreaInsets.right, width - leftInset))
+        let bottomInset = max(0, min(safeAreaInsets.bottom, height))
+        let topInset = max(0, min(safeAreaInsets.top, height - bottomInset))
+        let minX = leftInset + margin
+        let maxX = max(minX, width - rightInset - margin)
+        let minY = bottomInset + margin
+        let maxY = max(minY, height - topInset - margin)
+
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+}

--- a/TiltArena/Game/ArenaHUDLayout.swift
+++ b/TiltArena/Game/ArenaHUDLayout.swift
@@ -2,8 +2,6 @@ import UIKit
 
 struct ArenaHUDLayout: Equatable {
     let timerPosition: CGPoint
-    let centerPosition: CGPoint
-    let detailPosition: CGPoint
     let comboPosition: CGPoint
     let pauseControlPosition: CGPoint
 
@@ -13,7 +11,7 @@ struct ArenaHUDLayout: Equatable {
         margin: CGFloat,
         pauseControlSize: CGSize
     ) {
-        let safeRect = Self.safeRect(
+        let safeRect = ArenaGeometry.safeRect(
             sceneSize: sceneSize,
             safeAreaInsets: safeAreaInsets,
             margin: margin
@@ -22,31 +20,10 @@ struct ArenaHUDLayout: Equatable {
         let halfPauseHeight = pauseControlSize.height / 2
 
         timerPosition = CGPoint(x: safeRect.minX, y: safeRect.maxY)
-        centerPosition = CGPoint(x: safeRect.midX, y: safeRect.midY + 24)
-        detailPosition = CGPoint(x: safeRect.midX, y: safeRect.midY - 12)
         comboPosition = CGPoint(x: safeRect.midX, y: safeRect.minY)
         pauseControlPosition = CGPoint(
             x: max(safeRect.minX + halfPauseWidth, safeRect.maxX - halfPauseWidth),
             y: max(safeRect.minY + halfPauseHeight, safeRect.maxY - halfPauseHeight)
         )
-    }
-
-    private static func safeRect(
-        sceneSize: CGSize,
-        safeAreaInsets: UIEdgeInsets,
-        margin: CGFloat
-    ) -> CGRect {
-        let width = max(0, sceneSize.width)
-        let height = max(0, sceneSize.height)
-        let leftInset = max(0, min(safeAreaInsets.left, width))
-        let rightInset = max(0, min(safeAreaInsets.right, width - leftInset))
-        let bottomInset = max(0, min(safeAreaInsets.bottom, height))
-        let topInset = max(0, min(safeAreaInsets.top, height - bottomInset))
-        let minX = leftInset + margin
-        let maxX = max(minX, width - rightInset - margin)
-        let minY = bottomInset + margin
-        let maxY = max(minY, height - topInset - margin)
-
-        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 }

--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -858,14 +858,8 @@ final class ArenaScene: SKScene {
             let dangerDistance = runController.configuration.dangerGrabEnemyDistance
                 + pickup.radius
                 + enemy.radius
-            return squaredDistance(from: pickup.position, to: enemy.position) <= dangerDistance * dangerDistance
+            return ArenaGeometry.squaredDistance(from: pickup.position, to: enemy.position) <= dangerDistance * dangerDistance
         }
-    }
-
-    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
-        let dx = lhs.x - rhs.x
-        let dy = lhs.y - rhs.y
-        return dx * dx + dy * dy
     }
 
     private func persistFinalRunIfNeeded() {
@@ -1073,69 +1067,76 @@ private extension ArenaScene {
         addPanel(frame: left)
         addPanel(frame: right)
 
+        renderTiltOptions(in: left)
+        renderLocalOptions(in: right)
+    }
+
+    func renderTiltOptions(in frame: CGRect) {
         addButton(
             "CALIBRATE",
-            frame: CGRect(x: left.minX + 14, y: left.maxY - 62, width: 148, height: 40),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 62, width: 148, height: 40),
             action: .calibrate,
             style: .primary
         )
         let settings = tiltSettingsStore.settings
         addSmallLabel(
             "SENSITIVITY \(String(format: "%.1f", settings.clampedSensitivity))",
-            at: CGPoint(x: left.minX + 14, y: left.maxY - 90),
+            at: CGPoint(x: frame.minX + 14, y: frame.maxY - 90),
             color: theme.borderColor,
             alignment: .left
         )
         addButton(
             "-",
-            frame: CGRect(x: left.minX + 14, y: left.maxY - 140, width: 44, height: 36),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 140, width: 44, height: 36),
             action: .sensitivityDown,
             style: .secondary
         )
         addButton(
             "+",
-            frame: CGRect(x: left.minX + 70, y: left.maxY - 140, width: 44, height: 36),
+            frame: CGRect(x: frame.minX + 70, y: frame.maxY - 140, width: 44, height: 36),
             action: .sensitivityUp,
             style: .secondary
         )
 
-        let presetY = left.maxY - 196
+        let presetY = frame.maxY - 196
         for (index, preset) in [TiltCalibrationPreset.standard, .flatTable, .reclined].enumerated() {
-            let frame = CGRect(
-                x: left.minX + 14 + CGFloat(index) * 82,
+            let buttonFrame = CGRect(
+                x: frame.minX + 14 + CGFloat(index) * 82,
                 y: presetY,
                 width: 74,
                 height: 34
             )
             addButton(
                 presetTitle(preset),
-                frame: frame,
+                frame: buttonFrame,
                 action: .preset(preset),
                 style: settings.calibration.preset == preset ? .primary : .secondary
             )
         }
+    }
 
+    func renderLocalOptions(in frame: CGRect) {
         addToggle(
             title: "AUDIO",
             isOn: localOptions.audioEnabled,
-            frame: CGRect(x: right.minX + 14, y: right.maxY - 62, width: 132, height: 38),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 62, width: 132, height: 38),
             action: .toggleAudio
         )
         addToggle(
             title: "HAPTICS",
             isOn: localOptions.hapticsEnabled,
-            frame: CGRect(x: right.minX + 14, y: right.maxY - 112, width: 132, height: 38),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 112, width: 132, height: 38),
             action: .toggleHaptics
         )
         addToggle(
             title: "EFFECTS",
             isOn: !localOptions.reducedEffects,
-            frame: CGRect(x: right.minX + 14, y: right.maxY - 162, width: 132, height: 38),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 162, width: 132, height: 38),
             action: .toggleEffects
         )
         addButton(
             resetDataArmed ? "CONFIRM RESET" : "RESET DATA",
-            frame: CGRect(x: right.minX + 14, y: right.minY + 12, width: 156, height: 34),
+            frame: CGRect(x: frame.minX + 14, y: frame.minY + 12, width: 156, height: 34),
             action: .resetData,
             style: .danger
         )
@@ -1219,6 +1220,13 @@ private extension ArenaScene {
         addScrim(alpha: 0.62)
         let summary = runController.finalizedSummary
 
+        renderPostRunScore(summary: summary, layout: layout)
+        addDeathClarityMarker(at: movementController.state.position)
+        renderPostRunHighlights(summary: summary, in: layout.rightColumnFrame(width: 230))
+        renderPostRunButtons(layout: layout)
+    }
+
+    func renderPostRunScore(summary: RunSummary?, layout: ArenaLandscapeUILayout) {
         addLabel(
             "GAME OVER",
             at: CGPoint(x: layout.safeRect.minX, y: layout.safeRect.maxY - 52),
@@ -1239,10 +1247,10 @@ private extension ArenaScene {
             color: theme.playerAccentColor,
             alignment: .left
         )
-        addDeathClarityMarker(at: movementController.state.position)
+    }
 
-        let right = layout.rightColumnFrame(width: 230)
-        addPanel(frame: right)
+    func renderPostRunHighlights(summary: RunSummary?, in frame: CGRect) {
+        addPanel(frame: frame)
         let highlights = ArenaMenuContent.postRunHighlights(
             summary: summary,
             profile: runProfile,
@@ -1251,12 +1259,14 @@ private extension ArenaScene {
         for (index, text) in highlights.enumerated() {
             addSmallLabel(
                 text,
-                at: CGPoint(x: right.minX + 14, y: right.maxY - 28 - CGFloat(index) * 26),
+                at: CGPoint(x: frame.minX + 14, y: frame.maxY - 28 - CGFloat(index) * 26),
                 color: index == 0 ? theme.playerAccentColor : theme.borderColor,
                 alignment: .left
             )
         }
+    }
 
+    func renderPostRunButtons(layout: ArenaLandscapeUILayout) {
         addButton(
             "PLAY AGAIN",
             frame: layout.lowerRightButtonFrame,
@@ -1280,10 +1290,19 @@ private extension ArenaScene {
 
     func perform(_ action: ArenaControlAction) {
         switch action {
-        case .play:
-            if selectedModeIsAvailable {
-                preparePreRun()
-            }
+        case .play, .playAgain, .openModes, .openAwards, .openOptions, .home, .back:
+            performNavigationAction(action)
+        case .selectMode, .resume, .calibrate, .endRun:
+            performRunControlAction(action)
+        case .sensitivityDown, .sensitivityUp, .preset, .toggleAudio, .toggleHaptics, .toggleEffects, .resetData:
+            performOptionsAction(action)
+        }
+    }
+
+    func performNavigationAction(_ action: ArenaControlAction) {
+        switch action {
+        case .play where selectedModeIsAvailable:
+            preparePreRun()
         case .playAgain:
             preparePreRun()
         case .openModes:
@@ -1299,6 +1318,13 @@ private extension ArenaScene {
             show(.home)
         case .back:
             show(uiState == .options ? optionsReturnState : .home)
+        default:
+            break
+        }
+    }
+
+    func performRunControlAction(_ action: ArenaControlAction) {
+        switch action {
         case let .selectMode(mode):
             guard modeRowsByKind[mode]?.isAvailable == true else {
                 return
@@ -1312,6 +1338,13 @@ private extension ArenaScene {
             recalibrateTiltControls()
         case .endRun:
             finishRun(playFeedback: false)
+        default:
+            break
+        }
+    }
+
+    func performOptionsAction(_ action: ArenaControlAction) {
+        switch action {
         case .sensitivityDown:
             tiltSettingsStore.updateSensitivity(tiltSettingsStore.settings.clampedSensitivity - 0.1)
             rebuildUI()
@@ -1335,6 +1368,8 @@ private extension ArenaScene {
             rebuildUI()
         case .resetData:
             resetLocalDataOrArmConfirmation()
+        default:
+            break
         }
     }
 

--- a/TiltArena/Game/Enemies/EnemySpawnConfiguration.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnConfiguration.swift
@@ -1,0 +1,250 @@
+import CoreGraphics
+import Foundation
+
+enum EnemyDifficultyPhase: Equatable {
+    case warmup
+    case pressure
+    case chaos
+    case survivalHell
+
+    static func phase(at survivalTime: TimeInterval) -> EnemyDifficultyPhase {
+        let time = max(0, survivalTime)
+
+        if time < Self.pressure.startTime {
+            return .warmup
+        } else if time < Self.chaos.startTime {
+            return .pressure
+        } else if time < Self.survivalHell.startTime {
+            return .chaos
+        } else {
+            return .survivalHell
+        }
+    }
+
+    var startTime: TimeInterval {
+        switch self {
+        case .warmup:
+            return 0
+        case .pressure:
+            return 30
+        case .chaos:
+            return 90
+        case .survivalHell:
+            return 180
+        }
+    }
+}
+
+struct EnemyPhaseTuning: Equatable {
+    var chaserSpawnInterval: TimeInterval
+    var chaserSpeed: CGFloat
+    var maxActiveEnemies: Int
+    var formationSpawnInterval: TimeInterval?
+    var formationSpeed: CGFloat
+    var formationLaneCount: Int
+    var arrowRushSpawnInterval: TimeInterval?
+    var arrowRushSpeed: CGFloat = 0
+    var arrowRushEnemyCount: Int = 0
+    var mineDotSpawnInterval: TimeInterval?
+    var maxActiveMineDots: Int = 0
+    var hunterDotSpawnInterval: TimeInterval?
+    var hunterDotSpeed: CGFloat = 0
+    var hunterDotPredictionLead: CGFloat = 0
+    var maxActiveHunterDots: Int = 0
+    var paddleTrapSpawnInterval: TimeInterval?
+    var maxActivePaddleTraps: Int = 0
+    var paddleTrapLifetime: TimeInterval = 0
+    var paddleTrapBarEnemyCount: Int = 0
+    var paddleTrapDotSpeed: CGFloat = 0
+}
+
+struct EnemySpawnConfiguration: Equatable {
+    var enemyRadius: CGFloat = 8
+    var playerSafetyRadius: CGFloat = 120
+    var pickupClearance: CGFloat = 8
+    var formationTelegraphDuration: TimeInterval = 1.1
+    var formationLineInset: CGFloat = 28
+    var formationGapScale: CGFloat = 0.85
+    var formationSpawnOffset: CGFloat = 14
+    var minimumFormationEnemyCount = 2
+    var arrowRushTelegraphDuration: TimeInterval = 0.85
+    var arrowRushSpawnOffset: CGFloat = 18
+    var arrowRushEnemySpacing: CGFloat = 24
+    var minimumArrowRushEnemyCount = 2
+    var mineDotTelegraphDuration: TimeInterval = 0.9
+    var mineDotTelegraphRadius: CGFloat = 24
+    var mineDotPickupGuardDistance: CGFloat = 44
+    var mineDotCandidateInset: CGFloat = 48
+    var mineDotMinimumSpacing: CGFloat = 52
+    var hunterDotTelegraphDuration: TimeInterval = 0.75
+    var paddleTrapTelegraphDuration: TimeInterval = 1
+    var paddleTrapBarSpacing: CGFloat = 24
+    var paddleTrapBarGap: CGFloat = 96
+    var paddleTrapCandidateInset: CGFloat = 84
+    var paddleTrapMinimumSpacing: CGFloat = 64
+    var maxPendingEnemyTelegraphs = 2
+    var cullingOutset: CGFloat = 72
+    var warmup = EnemyPhaseTuning(
+        chaserSpawnInterval: 1.4,
+        chaserSpeed: 55,
+        maxActiveEnemies: 40,
+        formationSpawnInterval: nil,
+        formationSpeed: 86,
+        formationLaneCount: 5
+    )
+    var pressure = EnemyPhaseTuning(
+        chaserSpawnInterval: 1.05,
+        chaserSpeed: 70,
+        maxActiveEnemies: 70,
+        formationSpawnInterval: 12,
+        formationSpeed: 98,
+        formationLaneCount: 5
+    )
+    var chaos = EnemyPhaseTuning(
+        chaserSpawnInterval: 0.75,
+        chaserSpeed: 88,
+        maxActiveEnemies: 120,
+        formationSpawnInterval: 8,
+        formationSpeed: 116,
+        formationLaneCount: 7,
+        arrowRushSpawnInterval: 10,
+        arrowRushSpeed: 150,
+        arrowRushEnemyCount: 3,
+        mineDotSpawnInterval: 14,
+        maxActiveMineDots: 4,
+        hunterDotSpawnInterval: 18,
+        hunterDotSpeed: 108,
+        hunterDotPredictionLead: 0.6,
+        maxActiveHunterDots: 2,
+        paddleTrapSpawnInterval: 24,
+        maxActivePaddleTraps: 1,
+        paddleTrapLifetime: 7,
+        paddleTrapBarEnemyCount: 4,
+        paddleTrapDotSpeed: 145
+    )
+    var survivalHell = EnemyPhaseTuning(
+        chaserSpawnInterval: 0.5,
+        chaserSpeed: 108,
+        maxActiveEnemies: 180,
+        formationSpawnInterval: 5.5,
+        formationSpeed: 136,
+        formationLaneCount: 9,
+        arrowRushSpawnInterval: 7,
+        arrowRushSpeed: 175,
+        arrowRushEnemyCount: 5,
+        mineDotSpawnInterval: 10,
+        maxActiveMineDots: 7,
+        hunterDotSpawnInterval: 13,
+        hunterDotSpeed: 132,
+        hunterDotPredictionLead: 0.9,
+        maxActiveHunterDots: 3,
+        paddleTrapSpawnInterval: 18,
+        maxActivePaddleTraps: 2,
+        paddleTrapLifetime: 8,
+        paddleTrapBarEnemyCount: 5,
+        paddleTrapDotSpeed: 170
+    )
+
+    func tuning(at survivalTime: TimeInterval) -> EnemyPhaseTuning {
+        let phase = EnemyDifficultyPhase.phase(at: survivalTime)
+        let anchors = phaseAnchors
+        let currentIndex = anchors.firstIndex { $0.phase == phase } ?? 0
+        let current = anchors[currentIndex]
+        let next = currentIndex + 1 < anchors.count ? anchors[currentIndex + 1] : nil
+        let progress = interpolationProgress(survivalTime: survivalTime, current: current, next: next)
+
+        return EnemyPhaseTuning(
+            chaserSpawnInterval: interpolate(current.tuning.chaserSpawnInterval, next?.tuning.chaserSpawnInterval, progress),
+            chaserSpeed: interpolate(current.tuning.chaserSpeed, next?.tuning.chaserSpeed, progress),
+            maxActiveEnemies: interpolateCount(current.tuning.maxActiveEnemies, next?.tuning.maxActiveEnemies, progress),
+            formationSpawnInterval: current.tuning.formationSpawnInterval,
+            formationSpeed: interpolate(current.tuning.formationSpeed, next?.tuning.formationSpeed, progress),
+            formationLaneCount: max(3, current.tuning.formationLaneCount),
+            arrowRushSpawnInterval: current.tuning.arrowRushSpawnInterval,
+            arrowRushSpeed: interpolate(current.tuning.arrowRushSpeed, next?.tuning.arrowRushSpeed, progress),
+            arrowRushEnemyCount: interpolateCount(current.tuning.arrowRushEnemyCount, next?.tuning.arrowRushEnemyCount, progress),
+            mineDotSpawnInterval: current.tuning.mineDotSpawnInterval,
+            maxActiveMineDots: interpolateCount(current.tuning.maxActiveMineDots, next?.tuning.maxActiveMineDots, progress),
+            hunterDotSpawnInterval: current.tuning.hunterDotSpawnInterval,
+            hunterDotSpeed: interpolate(current.tuning.hunterDotSpeed, next?.tuning.hunterDotSpeed, progress),
+            hunterDotPredictionLead: interpolate(
+                current.tuning.hunterDotPredictionLead,
+                next?.tuning.hunterDotPredictionLead,
+                progress
+            ),
+            maxActiveHunterDots: interpolateCount(
+                current.tuning.maxActiveHunterDots,
+                next?.tuning.maxActiveHunterDots,
+                progress
+            ),
+            paddleTrapSpawnInterval: current.tuning.paddleTrapSpawnInterval,
+            maxActivePaddleTraps: interpolateCount(
+                current.tuning.maxActivePaddleTraps,
+                next?.tuning.maxActivePaddleTraps,
+                progress
+            ),
+            paddleTrapLifetime: interpolate(current.tuning.paddleTrapLifetime, next?.tuning.paddleTrapLifetime, progress),
+            paddleTrapBarEnemyCount: interpolateCount(
+                current.tuning.paddleTrapBarEnemyCount,
+                next?.tuning.paddleTrapBarEnemyCount,
+                progress
+            ),
+            paddleTrapDotSpeed: interpolate(current.tuning.paddleTrapDotSpeed, next?.tuning.paddleTrapDotSpeed, progress)
+        )
+    }
+
+    private var phaseAnchors: [(phase: EnemyDifficultyPhase, tuning: EnemyPhaseTuning)] {
+        [
+            (.warmup, warmup),
+            (.pressure, pressure),
+            (.chaos, chaos),
+            (.survivalHell, survivalHell)
+        ]
+    }
+
+    private func interpolationProgress(
+        survivalTime: TimeInterval,
+        current: (phase: EnemyDifficultyPhase, tuning: EnemyPhaseTuning),
+        next: (phase: EnemyDifficultyPhase, tuning: EnemyPhaseTuning)?
+    ) -> CGFloat {
+        guard let next else {
+            return 0
+        }
+
+        let span = next.phase.startTime - current.phase.startTime
+        guard span > 0 else {
+            return 0
+        }
+
+        let rawProgress = (max(0, survivalTime) - current.phase.startTime) / span
+        return CGFloat(min(1, max(0, rawProgress)))
+    }
+
+    private func interpolate(_ start: TimeInterval, _ end: TimeInterval?, _ progress: CGFloat) -> TimeInterval {
+        start + ((end ?? start) - start) * TimeInterval(progress)
+    }
+
+    private func interpolate(_ start: CGFloat, _ end: CGFloat?, _ progress: CGFloat) -> CGFloat {
+        start + ((end ?? start) - start) * progress
+    }
+
+    private func interpolateCount(_ start: Int, _ end: Int?, _ progress: CGFloat) -> Int {
+        max(0, Int(round(interpolate(CGFloat(start), end.map(CGFloat.init), progress))))
+    }
+}
+
+struct EnemyTelegraphSegment: Equatable {
+    let start: CGPoint
+    let end: CGPoint
+}
+
+struct EnemyTelegraph: Equatable, Identifiable {
+    let id: Int
+    let segments: [EnemyTelegraphSegment]
+}
+
+struct EnemySpawnFrame: Equatable {
+    var newEnemies: [ArenaEnemy] = []
+    var telegraphsToShow: [EnemyTelegraph] = []
+    var telegraphIDsToRemove: Set<Int> = []
+}

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+ArrowRush.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+ArrowRush.swift
@@ -3,20 +3,16 @@ import Foundation
 
 extension EnemySpawnDirector {
     mutating func spawnArrowRushTelegraphIfNeeded(
-        deltaTime: TimeInterval,
         projectedEnemyCount: Int,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
+        context: SpawnContext,
         frame: inout EnemySpawnFrame
     ) {
-        guard deltaTime > 0, let arrowRushSpawnInterval = tuning.arrowRushSpawnInterval else {
+        guard context.deltaTime > 0, let arrowRushSpawnInterval = context.tuning.arrowRushSpawnInterval else {
             timeUntilNextArrowRush = 0
             return
         }
 
-        let configuredEnemyCount = max(0, tuning.arrowRushEnemyCount)
+        let configuredEnemyCount = max(0, context.tuning.arrowRushEnemyCount)
         guard arrowRushSpawnInterval > 0, configuredEnemyCount > 0 else {
             return
         }
@@ -28,23 +24,23 @@ extension EnemySpawnDirector {
             return
         }
 
-        guard projectedEnemyCount + requiredEnemyCount <= tuning.maxActiveEnemies else {
+        guard projectedEnemyCount + requiredEnemyCount <= context.tuning.maxActiveEnemies else {
             timeUntilNextArrowRush = max(timeUntilNextArrowRush, arrowRushSpawnInterval)
             return
         }
 
-        timeUntilNextArrowRush -= deltaTime
+        timeUntilNextArrowRush -= context.deltaTime
 
         guard timeUntilNextArrowRush <= 0 else {
             return
         }
 
-        let availableSlots = tuning.maxActiveEnemies - projectedEnemyCount
+        let availableSlots = context.tuning.maxActiveEnemies - projectedEnemyCount
         guard let arrowRush = makePendingArrowRush(
-            in: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            tuning: tuning,
+            in: context.playableRect,
+            playerPosition: context.playerPosition,
+            pickupCircles: context.pickupCircles,
+            tuning: context.tuning,
             enemyCount: min(configuredEnemyCount, availableSlots),
             requiredEnemyCount: requiredEnemyCount
         ) else {

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+HunterDot.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+HunterDot.swift
@@ -3,20 +3,17 @@ import Foundation
 
 extension EnemySpawnDirector {
     mutating func spawnHunterDotTelegraphIfNeeded(
-        deltaTime: TimeInterval,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
-        activeEnemies: [ArenaEnemy],
+        context: SpawnContext,
         frame: inout EnemySpawnFrame
     ) {
-        guard deltaTime > 0, let hunterDotSpawnInterval = tuning.hunterDotSpawnInterval else {
+        guard context.deltaTime > 0, let hunterDotSpawnInterval = context.tuning.hunterDotSpawnInterval else {
             timeUntilNextHunterDot = 0
             return
         }
 
-        guard hunterDotSpawnInterval > 0, tuning.maxActiveHunterDots > 0, tuning.hunterDotSpeed > 0 else {
+        guard hunterDotSpawnInterval > 0,
+              context.tuning.maxActiveHunterDots > 0,
+              context.tuning.hunterDotSpeed > 0 else {
             return
         }
 
@@ -25,27 +22,27 @@ extension EnemySpawnDirector {
             return
         }
 
-        let activeAndNewEnemies = activeEnemies + frame.newEnemies
+        let activeAndNewEnemies = context.activeEnemies + frame.newEnemies
         let projectedEnemyCount = activeAndNewEnemies.count + pendingEnemyCount
         let projectedHunterDotCount = activeAndNewEnemies.filter(\.isHunterDot).count + pendingHunterDotCount
 
-        guard projectedEnemyCount + 1 <= tuning.maxActiveEnemies,
-              projectedHunterDotCount < tuning.maxActiveHunterDots else {
+        guard projectedEnemyCount + 1 <= context.tuning.maxActiveEnemies,
+              projectedHunterDotCount < context.tuning.maxActiveHunterDots else {
             timeUntilNextHunterDot = max(timeUntilNextHunterDot, hunterDotSpawnInterval)
             return
         }
 
-        timeUntilNextHunterDot -= deltaTime
+        timeUntilNextHunterDot -= context.deltaTime
 
         guard timeUntilNextHunterDot <= 0 else {
             return
         }
 
         guard let hunterDot = makePendingHunterDot(
-            in: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            tuning: tuning
+            in: context.playableRect,
+            playerPosition: context.playerPosition,
+            pickupCircles: context.pickupCircles,
+            tuning: context.tuning
         ) else {
             timeUntilNextHunterDot = hunterDotSpawnInterval
             return

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+MineDot.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+MineDot.swift
@@ -9,20 +9,15 @@ extension EnemySpawnDirector {
     }
 
     mutating func spawnMineDotTelegraphIfNeeded(
-        deltaTime: TimeInterval,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
-        activeEnemies: [ArenaEnemy],
+        context: SpawnContext,
         frame: inout EnemySpawnFrame
     ) {
-        guard deltaTime > 0, let mineDotSpawnInterval = tuning.mineDotSpawnInterval else {
+        guard context.deltaTime > 0, let mineDotSpawnInterval = context.tuning.mineDotSpawnInterval else {
             timeUntilNextMineDot = 0
             return
         }
 
-        guard mineDotSpawnInterval > 0, tuning.maxActiveMineDots > 0 else {
+        guard mineDotSpawnInterval > 0, context.tuning.maxActiveMineDots > 0 else {
             return
         }
 
@@ -31,26 +26,26 @@ extension EnemySpawnDirector {
             return
         }
 
-        let activeAndNewEnemies = activeEnemies + frame.newEnemies
+        let activeAndNewEnemies = context.activeEnemies + frame.newEnemies
         let projectedEnemyCount = activeAndNewEnemies.count + pendingEnemyCount
         let projectedMineDotCount = activeAndNewEnemies.filter(\.isMineDot).count + pendingMineDotCount
 
-        guard projectedEnemyCount + 1 <= tuning.maxActiveEnemies,
-              projectedMineDotCount < tuning.maxActiveMineDots else {
+        guard projectedEnemyCount + 1 <= context.tuning.maxActiveEnemies,
+              projectedMineDotCount < context.tuning.maxActiveMineDots else {
             timeUntilNextMineDot = max(timeUntilNextMineDot, mineDotSpawnInterval)
             return
         }
 
-        timeUntilNextMineDot -= deltaTime
+        timeUntilNextMineDot -= context.deltaTime
 
         guard timeUntilNextMineDot <= 0 else {
             return
         }
 
         guard let mineDot = makePendingMineDot(
-            in: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
+            in: context.playableRect,
+            playerPosition: context.playerPosition,
+            pickupCircles: context.pickupCircles,
             activeEnemies: activeAndNewEnemies
         ) else {
             timeUntilNextMineDot = mineDotSpawnInterval
@@ -72,41 +67,55 @@ extension EnemySpawnDirector {
             return nil
         }
 
-        let pendingMinePositions = pendingSpawns.values.flatMap { pendingSpawn in
+        guard let position = mineDotPosition(
+            in: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            activeEnemies: activeEnemies,
+            pendingMinePositions: pendingMineDotPositions()
+        ) else {
+            return nil
+        }
+
+        return pendingMineDot(at: position)
+    }
+
+    private func pendingMineDotPositions() -> [CGPoint] {
+        pendingSpawns.values.flatMap { pendingSpawn in
             pendingSpawn.enemies.compactMap { enemy in
                 enemy.isMineDot ? enemy.position : nil
             }
         }
+    }
 
-        let pickupCandidates = pickupAdjacentMineDotCandidates(in: playableRect, pickupCircles: pickupCircles)
-        let interiorCandidates = interiorMineDotCandidates(in: playableRect)
-        var selectedPosition: CGPoint?
-
-        for position in pickupCandidates where isSafeMineDotSpawn(
-            position,
-            avoiding: playerPosition,
-            pickupCircles: pickupCircles,
-            activeEnemies: activeEnemies,
-            pendingMinePositions: pendingMinePositions
-        ) {
-            selectedPosition = position
-            break
-        }
-
-        if selectedPosition == nil {
-            selectedPosition = nextSafeInteriorMineDotPosition(
-                candidates: interiorCandidates,
-                playerPosition: playerPosition,
+    private mutating func mineDotPosition(
+        in playableRect: CGRect,
+        playerPosition: CGPoint,
+        pickupCircles: [CollisionCircle],
+        activeEnemies: [ArenaEnemy],
+        pendingMinePositions: [CGPoint]
+    ) -> CGPoint? {
+        for position in pickupAdjacentMineDotCandidates(in: playableRect, pickupCircles: pickupCircles)
+            where isSafeMineDotSpawn(
+                position,
+                avoiding: playerPosition,
                 pickupCircles: pickupCircles,
                 activeEnemies: activeEnemies,
                 pendingMinePositions: pendingMinePositions
-            )
+            ) {
+            return position
         }
 
-        guard let position = selectedPosition else {
-            return nil
-        }
+        return nextSafeInteriorMineDotPosition(
+            candidates: interiorMineDotCandidates(in: playableRect),
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            activeEnemies: activeEnemies,
+            pendingMinePositions: pendingMinePositions
+        )
+    }
 
+    private mutating func pendingMineDot(at position: CGPoint) -> PendingEnemySpawn {
         let enemy = ArenaEnemy(
             id: nextEnemyID,
             position: position,
@@ -225,14 +234,14 @@ extension EnemySpawnDirector {
         guard activeEnemies.allSatisfy({ activeEnemy in
             let baseClearance = activeEnemy.radius + configuration.enemyRadius + configuration.pickupClearance
             let clearance = activeEnemy.isMineDot ? max(baseClearance, configuration.mineDotMinimumSpacing) : baseClearance
-            return squaredDistance(from: position, to: activeEnemy.position) >= clearance * clearance
+            return ArenaGeometry.squaredDistance(from: position, to: activeEnemy.position) >= clearance * clearance
         }) else {
             return false
         }
 
         return pendingMinePositions.allSatisfy { pendingPosition in
             let clearance = configuration.mineDotMinimumSpacing
-            return squaredDistance(from: position, to: pendingPosition) >= clearance * clearance
+            return ArenaGeometry.squaredDistance(from: position, to: pendingPosition) >= clearance * clearance
         }
     }
 

--- a/TiltArena/Game/Enemies/EnemySpawnDirector+PaddleTrap.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector+PaddleTrap.swift
@@ -25,25 +25,20 @@ extension EnemySpawnDirector {
     }
 
     mutating func spawnPaddleTrapTelegraphIfNeeded(
-        deltaTime: TimeInterval,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
-        activeEnemies: [ArenaEnemy],
+        context: SpawnContext,
         frame: inout EnemySpawnFrame
     ) {
-        guard deltaTime > 0, let paddleTrapSpawnInterval = tuning.paddleTrapSpawnInterval else {
+        guard context.deltaTime > 0, let paddleTrapSpawnInterval = context.tuning.paddleTrapSpawnInterval else {
             timeUntilNextPaddleTrap = 0
             return
         }
 
-        let componentCount = paddleTrapComponentCount(tuning: tuning)
+        let componentCount = paddleTrapComponentCount(tuning: context.tuning)
         guard paddleTrapSpawnInterval > 0,
-              tuning.maxActivePaddleTraps > 0,
-              tuning.paddleTrapLifetime > 0,
+              context.tuning.maxActivePaddleTraps > 0,
+              context.tuning.paddleTrapLifetime > 0,
               componentCount > 0,
-              tuning.paddleTrapDotSpeed > 0 else {
+              context.tuning.paddleTrapDotSpeed > 0 else {
             return
         }
 
@@ -52,28 +47,28 @@ extension EnemySpawnDirector {
             return
         }
 
-        let activeAndNewEnemies = activeEnemies + frame.newEnemies
+        let activeAndNewEnemies = context.activeEnemies + frame.newEnemies
         let projectedEnemyCount = activeAndNewEnemies.count + pendingEnemyCount
         let projectedTrapCount = Set(activeAndNewEnemies.compactMap(\.paddleTrapID)).count + pendingPaddleTrapCount
 
-        guard projectedEnemyCount + componentCount <= tuning.maxActiveEnemies,
-              projectedTrapCount < tuning.maxActivePaddleTraps else {
+        guard projectedEnemyCount + componentCount <= context.tuning.maxActiveEnemies,
+              projectedTrapCount < context.tuning.maxActivePaddleTraps else {
             timeUntilNextPaddleTrap = max(timeUntilNextPaddleTrap, paddleTrapSpawnInterval)
             return
         }
 
-        timeUntilNextPaddleTrap -= deltaTime
+        timeUntilNextPaddleTrap -= context.deltaTime
 
         guard timeUntilNextPaddleTrap <= 0 else {
             return
         }
 
         guard let paddleTrap = makePendingPaddleTrap(
-            in: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
+            in: context.playableRect,
+            playerPosition: context.playerPosition,
+            pickupCircles: context.pickupCircles,
             activeEnemies: activeAndNewEnemies,
-            tuning: tuning
+            tuning: context.tuning
         ) else {
             timeUntilNextPaddleTrap = paddleTrapSpawnInterval
             return
@@ -357,7 +352,7 @@ extension EnemySpawnDirector {
         activeEnemies.allSatisfy { activeEnemy in
             let baseClearance = activeEnemy.radius + configuration.enemyRadius + configuration.pickupClearance
             let clearance = activeEnemy.isPaddleTrap ? max(baseClearance, configuration.paddleTrapMinimumSpacing) : baseClearance
-            return squaredDistance(from: position, to: activeEnemy.position) >= clearance * clearance
+            return ArenaGeometry.squaredDistance(from: position, to: activeEnemy.position) >= clearance * clearance
         }
     }
 
@@ -367,7 +362,7 @@ extension EnemySpawnDirector {
     ) -> Bool {
         pendingTrapPositions.allSatisfy { pendingPosition in
             let clearance = configuration.paddleTrapMinimumSpacing
-            return squaredDistance(from: position, to: pendingPosition) >= clearance * clearance
+            return ArenaGeometry.squaredDistance(from: position, to: pendingPosition) >= clearance * clearance
         }
     }
 

--- a/TiltArena/Game/Enemies/EnemySpawnDirector.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector.swift
@@ -1,330 +1,6 @@
 import CoreGraphics
 import Foundation
 
-enum EnemyDifficultyPhase: Equatable {
-    case warmup
-    case pressure
-    case chaos
-    case survivalHell
-
-    static func phase(at survivalTime: TimeInterval) -> EnemyDifficultyPhase {
-        let time = max(0, survivalTime)
-
-        if time < Self.pressure.startTime {
-            return .warmup
-        } else if time < Self.chaos.startTime {
-            return .pressure
-        } else if time < Self.survivalHell.startTime {
-            return .chaos
-        } else {
-            return .survivalHell
-        }
-    }
-
-    var startTime: TimeInterval {
-        switch self {
-        case .warmup:
-            return 0
-        case .pressure:
-            return 30
-        case .chaos:
-            return 90
-        case .survivalHell:
-            return 180
-        }
-    }
-}
-
-struct EnemyPhaseTuning: Equatable {
-    var chaserSpawnInterval: TimeInterval
-    var chaserSpeed: CGFloat
-    var maxActiveEnemies: Int
-    var formationSpawnInterval: TimeInterval?
-    var formationSpeed: CGFloat
-    var formationLaneCount: Int
-    var arrowRushSpawnInterval: TimeInterval?
-    var arrowRushSpeed: CGFloat = 0
-    var arrowRushEnemyCount: Int = 0
-    var mineDotSpawnInterval: TimeInterval?
-    var maxActiveMineDots: Int = 0
-    var hunterDotSpawnInterval: TimeInterval?
-    var hunterDotSpeed: CGFloat = 0
-    var hunterDotPredictionLead: CGFloat = 0
-    var maxActiveHunterDots: Int = 0
-    var paddleTrapSpawnInterval: TimeInterval?
-    var maxActivePaddleTraps: Int = 0
-    var paddleTrapLifetime: TimeInterval = 0
-    var paddleTrapBarEnemyCount: Int = 0
-    var paddleTrapDotSpeed: CGFloat = 0
-}
-
-struct EnemySpawnConfiguration: Equatable {
-    var enemyRadius: CGFloat = 8
-    var playerSafetyRadius: CGFloat = 120
-    var pickupClearance: CGFloat = 8
-    var formationTelegraphDuration: TimeInterval = 1.1
-    var formationLineInset: CGFloat = 28
-    var formationGapScale: CGFloat = 0.85
-    var formationSpawnOffset: CGFloat = 14
-    var minimumFormationEnemyCount = 2
-    var arrowRushTelegraphDuration: TimeInterval = 0.85
-    var arrowRushSpawnOffset: CGFloat = 18
-    var arrowRushEnemySpacing: CGFloat = 24
-    var minimumArrowRushEnemyCount = 2
-    var mineDotTelegraphDuration: TimeInterval = 0.9
-    var mineDotTelegraphRadius: CGFloat = 24
-    var mineDotPickupGuardDistance: CGFloat = 44
-    var mineDotCandidateInset: CGFloat = 48
-    var mineDotMinimumSpacing: CGFloat = 52
-    var hunterDotTelegraphDuration: TimeInterval = 0.75
-    var paddleTrapTelegraphDuration: TimeInterval = 1
-    var paddleTrapBarSpacing: CGFloat = 24
-    var paddleTrapBarGap: CGFloat = 96
-    var paddleTrapCandidateInset: CGFloat = 84
-    var paddleTrapMinimumSpacing: CGFloat = 64
-    var maxPendingEnemyTelegraphs = 2
-    var cullingOutset: CGFloat = 72
-    var warmup = EnemyPhaseTuning(
-        chaserSpawnInterval: 1.4,
-        chaserSpeed: 55,
-        maxActiveEnemies: 40,
-        formationSpawnInterval: nil,
-        formationSpeed: 86,
-        formationLaneCount: 5,
-        arrowRushSpawnInterval: nil,
-        arrowRushSpeed: 0,
-        arrowRushEnemyCount: 0,
-        mineDotSpawnInterval: nil,
-        maxActiveMineDots: 0,
-        hunterDotSpawnInterval: nil,
-        hunterDotSpeed: 0,
-        hunterDotPredictionLead: 0,
-        maxActiveHunterDots: 0,
-        paddleTrapSpawnInterval: nil,
-        maxActivePaddleTraps: 0,
-        paddleTrapLifetime: 0,
-        paddleTrapBarEnemyCount: 0,
-        paddleTrapDotSpeed: 0
-    )
-    var pressure = EnemyPhaseTuning(
-        chaserSpawnInterval: 1.05,
-        chaserSpeed: 70,
-        maxActiveEnemies: 70,
-        formationSpawnInterval: 12,
-        formationSpeed: 98,
-        formationLaneCount: 5,
-        arrowRushSpawnInterval: nil,
-        arrowRushSpeed: 0,
-        arrowRushEnemyCount: 0,
-        mineDotSpawnInterval: nil,
-        maxActiveMineDots: 0,
-        hunterDotSpawnInterval: nil,
-        hunterDotSpeed: 0,
-        hunterDotPredictionLead: 0,
-        maxActiveHunterDots: 0,
-        paddleTrapSpawnInterval: nil,
-        maxActivePaddleTraps: 0,
-        paddleTrapLifetime: 0,
-        paddleTrapBarEnemyCount: 0,
-        paddleTrapDotSpeed: 0
-    )
-    var chaos = EnemyPhaseTuning(
-        chaserSpawnInterval: 0.75,
-        chaserSpeed: 88,
-        maxActiveEnemies: 120,
-        formationSpawnInterval: 8,
-        formationSpeed: 116,
-        formationLaneCount: 7,
-        arrowRushSpawnInterval: 10,
-        arrowRushSpeed: 150,
-        arrowRushEnemyCount: 3,
-        mineDotSpawnInterval: 14,
-        maxActiveMineDots: 4,
-        hunterDotSpawnInterval: 18,
-        hunterDotSpeed: 108,
-        hunterDotPredictionLead: 0.6,
-        maxActiveHunterDots: 2,
-        paddleTrapSpawnInterval: 24,
-        maxActivePaddleTraps: 1,
-        paddleTrapLifetime: 7,
-        paddleTrapBarEnemyCount: 4,
-        paddleTrapDotSpeed: 145
-    )
-    var survivalHell = EnemyPhaseTuning(
-        chaserSpawnInterval: 0.5,
-        chaserSpeed: 108,
-        maxActiveEnemies: 180,
-        formationSpawnInterval: 5.5,
-        formationSpeed: 136,
-        formationLaneCount: 9,
-        arrowRushSpawnInterval: 7,
-        arrowRushSpeed: 175,
-        arrowRushEnemyCount: 5,
-        mineDotSpawnInterval: 10,
-        maxActiveMineDots: 7,
-        hunterDotSpawnInterval: 13,
-        hunterDotSpeed: 132,
-        hunterDotPredictionLead: 0.9,
-        maxActiveHunterDots: 3,
-        paddleTrapSpawnInterval: 18,
-        maxActivePaddleTraps: 2,
-        paddleTrapLifetime: 8,
-        paddleTrapBarEnemyCount: 5,
-        paddleTrapDotSpeed: 170
-    )
-
-    func tuning(at survivalTime: TimeInterval) -> EnemyPhaseTuning {
-        let phase = EnemyDifficultyPhase.phase(at: survivalTime)
-        let anchors = phaseAnchors
-        let currentIndex = anchors.firstIndex { $0.phase == phase } ?? 0
-        let current = anchors[currentIndex]
-        let next = currentIndex + 1 < anchors.count ? anchors[currentIndex + 1] : nil
-        let progress = interpolationProgress(survivalTime: survivalTime, current: current, next: next)
-
-        return EnemyPhaseTuning(
-            chaserSpawnInterval: interpolate(
-                from: current.tuning.chaserSpawnInterval,
-                to: next?.tuning.chaserSpawnInterval ?? current.tuning.chaserSpawnInterval,
-                progress: progress
-            ),
-            chaserSpeed: interpolate(
-                from: current.tuning.chaserSpeed,
-                to: next?.tuning.chaserSpeed ?? current.tuning.chaserSpeed,
-                progress: progress
-            ),
-            maxActiveEnemies: Int(
-                round(interpolate(
-                    from: CGFloat(current.tuning.maxActiveEnemies),
-                    to: CGFloat(next?.tuning.maxActiveEnemies ?? current.tuning.maxActiveEnemies),
-                    progress: progress
-                ))
-            ),
-            formationSpawnInterval: current.tuning.formationSpawnInterval,
-            formationSpeed: interpolate(
-                from: current.tuning.formationSpeed,
-                to: next?.tuning.formationSpeed ?? current.tuning.formationSpeed,
-                progress: progress
-            ),
-            formationLaneCount: max(3, current.tuning.formationLaneCount),
-            arrowRushSpawnInterval: current.tuning.arrowRushSpawnInterval,
-            arrowRushSpeed: interpolate(
-                from: current.tuning.arrowRushSpeed,
-                to: next?.tuning.arrowRushSpeed ?? current.tuning.arrowRushSpeed,
-                progress: progress
-            ),
-            arrowRushEnemyCount: max(0, Int(
-                round(interpolate(
-                    from: CGFloat(current.tuning.arrowRushEnemyCount),
-                    to: CGFloat(next?.tuning.arrowRushEnemyCount ?? current.tuning.arrowRushEnemyCount),
-                    progress: progress
-                ))
-            )),
-            mineDotSpawnInterval: current.tuning.mineDotSpawnInterval,
-            maxActiveMineDots: max(0, Int(
-                round(interpolate(
-                    from: CGFloat(current.tuning.maxActiveMineDots),
-                    to: CGFloat(next?.tuning.maxActiveMineDots ?? current.tuning.maxActiveMineDots),
-                    progress: progress
-                ))
-            )),
-            hunterDotSpawnInterval: current.tuning.hunterDotSpawnInterval,
-            hunterDotSpeed: interpolate(
-                from: current.tuning.hunterDotSpeed,
-                to: next?.tuning.hunterDotSpeed ?? current.tuning.hunterDotSpeed,
-                progress: progress
-            ),
-            hunterDotPredictionLead: interpolate(
-                from: current.tuning.hunterDotPredictionLead,
-                to: next?.tuning.hunterDotPredictionLead ?? current.tuning.hunterDotPredictionLead,
-                progress: progress
-            ),
-            maxActiveHunterDots: max(0, Int(
-                round(interpolate(
-                    from: CGFloat(current.tuning.maxActiveHunterDots),
-                    to: CGFloat(next?.tuning.maxActiveHunterDots ?? current.tuning.maxActiveHunterDots),
-                    progress: progress
-                ))
-            )),
-            paddleTrapSpawnInterval: current.tuning.paddleTrapSpawnInterval,
-            maxActivePaddleTraps: max(0, Int(
-                round(interpolate(
-                    from: CGFloat(current.tuning.maxActivePaddleTraps),
-                    to: CGFloat(next?.tuning.maxActivePaddleTraps ?? current.tuning.maxActivePaddleTraps),
-                    progress: progress
-                ))
-            )),
-            paddleTrapLifetime: interpolate(
-                from: current.tuning.paddleTrapLifetime,
-                to: next?.tuning.paddleTrapLifetime ?? current.tuning.paddleTrapLifetime,
-                progress: progress
-            ),
-            paddleTrapBarEnemyCount: max(0, Int(
-                round(interpolate(
-                    from: CGFloat(current.tuning.paddleTrapBarEnemyCount),
-                    to: CGFloat(next?.tuning.paddleTrapBarEnemyCount ?? current.tuning.paddleTrapBarEnemyCount),
-                    progress: progress
-                ))
-            )),
-            paddleTrapDotSpeed: interpolate(
-                from: current.tuning.paddleTrapDotSpeed,
-                to: next?.tuning.paddleTrapDotSpeed ?? current.tuning.paddleTrapDotSpeed,
-                progress: progress
-            )
-        )
-    }
-
-    private var phaseAnchors: [(phase: EnemyDifficultyPhase, tuning: EnemyPhaseTuning)] {
-        [
-            (.warmup, warmup),
-            (.pressure, pressure),
-            (.chaos, chaos),
-            (.survivalHell, survivalHell)
-        ]
-    }
-
-    private func interpolationProgress(
-        survivalTime: TimeInterval,
-        current: (phase: EnemyDifficultyPhase, tuning: EnemyPhaseTuning),
-        next: (phase: EnemyDifficultyPhase, tuning: EnemyPhaseTuning)?
-    ) -> CGFloat {
-        guard let next else {
-            return 0
-        }
-
-        let span = next.phase.startTime - current.phase.startTime
-        guard span > 0 else {
-            return 0
-        }
-
-        let rawProgress = (max(0, survivalTime) - current.phase.startTime) / span
-        return CGFloat(min(1, max(0, rawProgress)))
-    }
-
-    private func interpolate(from start: TimeInterval, to end: TimeInterval, progress: CGFloat) -> TimeInterval {
-        start + (end - start) * TimeInterval(progress)
-    }
-
-    private func interpolate(from start: CGFloat, to end: CGFloat, progress: CGFloat) -> CGFloat {
-        start + (end - start) * progress
-    }
-}
-
-struct EnemyTelegraphSegment: Equatable {
-    let start: CGPoint
-    let end: CGPoint
-}
-
-struct EnemyTelegraph: Equatable, Identifiable {
-    let id: Int
-    let segments: [EnemyTelegraphSegment]
-}
-
-struct EnemySpawnFrame: Equatable {
-    var newEnemies: [ArenaEnemy] = []
-    var telegraphsToShow: [EnemyTelegraph] = []
-    var telegraphIDsToRemove: Set<Int> = []
-}
-
 struct EnemySpawnDirector {
     enum EdgeDirection: CaseIterable {
         case leftToRight
@@ -347,6 +23,15 @@ struct EnemySpawnDirector {
         let requiredEnemyCount: Int
         let enemies: [ArenaEnemy]
         let telegraph: EnemyTelegraph
+    }
+
+    struct SpawnContext {
+        let deltaTime: TimeInterval
+        let tuning: EnemyPhaseTuning
+        let playableRect: CGRect
+        let playerPosition: CGPoint
+        let pickupCircles: [CollisionCircle]
+        let activeEnemies: [ArenaEnemy]
     }
 
     static let candidateSideCount = 4
@@ -432,6 +117,14 @@ struct EnemySpawnDirector {
         let tuning = configuration.tuning(at: survivalTime)
         let activeEnemyCount = activeEnemies.count
         var frame = EnemySpawnFrame()
+        let context = SpawnContext(
+            deltaTime: clampedDelta,
+            tuning: tuning,
+            playableRect: playableRect,
+            playerPosition: playerPosition,
+            pickupCircles: pickupCircles,
+            activeEnemies: activeEnemies
+        )
 
         advancePendingEnemySpawns(
             deltaTime: clampedDelta,
@@ -441,62 +134,35 @@ struct EnemySpawnDirector {
         )
 
         spawnChasersIfNeeded(
-            deltaTime: clampedDelta,
             projectedEnemyCount: activeEnemyCount + frame.newEnemies.count + pendingEnemyCount,
-            tuning: tuning,
-            playableRect: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
+            context: context,
             frame: &frame
         )
 
         spawnFormationTelegraphIfNeeded(
-            deltaTime: clampedDelta,
             projectedEnemyCount: activeEnemyCount + frame.newEnemies.count + pendingEnemyCount,
-            tuning: tuning,
-            playableRect: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
+            context: context,
             frame: &frame
         )
 
         spawnArrowRushTelegraphIfNeeded(
-            deltaTime: clampedDelta,
             projectedEnemyCount: activeEnemyCount + frame.newEnemies.count + pendingEnemyCount,
-            tuning: tuning,
-            playableRect: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
+            context: context,
             frame: &frame
         )
 
         spawnMineDotTelegraphIfNeeded(
-            deltaTime: clampedDelta,
-            tuning: tuning,
-            playableRect: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            activeEnemies: activeEnemies,
+            context: context,
             frame: &frame
         )
 
         spawnHunterDotTelegraphIfNeeded(
-            deltaTime: clampedDelta,
-            tuning: tuning,
-            playableRect: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            activeEnemies: activeEnemies,
+            context: context,
             frame: &frame
         )
 
         spawnPaddleTrapTelegraphIfNeeded(
-            deltaTime: clampedDelta,
-            tuning: tuning,
-            playableRect: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            activeEnemies: activeEnemies,
+            context: context,
             frame: &frame
         )
 
@@ -509,13 +175,13 @@ struct EnemySpawnDirector {
         pickupCircles: [CollisionCircle] = []
     ) -> Bool {
         let playerClearance = configuration.playerSafetyRadius + configuration.enemyRadius
-        guard squaredDistance(from: position, to: playerPosition) >= playerClearance * playerClearance else {
+        guard ArenaGeometry.squaredDistance(from: position, to: playerPosition) >= playerClearance * playerClearance else {
             return false
         }
 
         return pickupCircles.allSatisfy { pickupCircle in
             let clearance = pickupCircle.radius + configuration.enemyRadius + configuration.pickupClearance
-            return squaredDistance(from: position, to: pickupCircle.center) >= clearance * clearance
+            return ArenaGeometry.squaredDistance(from: position, to: pickupCircle.center) >= clearance * clearance
         }
     }
 
@@ -553,40 +219,36 @@ struct EnemySpawnDirector {
     }
 
     private mutating func spawnChasersIfNeeded(
-        deltaTime: TimeInterval,
         projectedEnemyCount: Int,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
+        context: SpawnContext,
         frame: inout EnemySpawnFrame
     ) {
-        guard deltaTime > 0, tuning.chaserSpawnInterval > 0 else {
+        guard context.deltaTime > 0, context.tuning.chaserSpawnInterval > 0 else {
             return
         }
 
-        guard projectedEnemyCount < tuning.maxActiveEnemies else {
-            timeUntilNextChaser = max(timeUntilNextChaser, tuning.chaserSpawnInterval)
+        guard projectedEnemyCount < context.tuning.maxActiveEnemies else {
+            timeUntilNextChaser = max(timeUntilNextChaser, context.tuning.chaserSpawnInterval)
             return
         }
 
-        timeUntilNextChaser -= deltaTime
+        timeUntilNextChaser -= context.deltaTime
         var projectedEnemyCount = projectedEnemyCount
 
-        while timeUntilNextChaser <= 0, projectedEnemyCount < tuning.maxActiveEnemies {
+        while timeUntilNextChaser <= 0, projectedEnemyCount < context.tuning.maxActiveEnemies {
             guard let enemy = spawnChaser(
-                in: playableRect,
-                avoiding: playerPosition,
-                pickupCircles: pickupCircles,
-                tuning: tuning
+                in: context.playableRect,
+                avoiding: context.playerPosition,
+                pickupCircles: context.pickupCircles,
+                tuning: context.tuning
             ) else {
-                timeUntilNextChaser = tuning.chaserSpawnInterval
+                timeUntilNextChaser = context.tuning.chaserSpawnInterval
                 return
             }
 
             frame.newEnemies.append(enemy)
             projectedEnemyCount += 1
-            timeUntilNextChaser += tuning.chaserSpawnInterval
+            timeUntilNextChaser += context.tuning.chaserSpawnInterval
         }
     }
 
@@ -622,15 +284,11 @@ struct EnemySpawnDirector {
     }
 
     private mutating func spawnFormationTelegraphIfNeeded(
-        deltaTime: TimeInterval,
         projectedEnemyCount: Int,
-        tuning: EnemyPhaseTuning,
-        playableRect: CGRect,
-        playerPosition: CGPoint,
-        pickupCircles: [CollisionCircle],
+        context: SpawnContext,
         frame: inout EnemySpawnFrame
     ) {
-        guard deltaTime > 0, let formationSpawnInterval = tuning.formationSpawnInterval else {
+        guard context.deltaTime > 0, let formationSpawnInterval = context.tuning.formationSpawnInterval else {
             timeUntilNextFormation = 0
             return
         }
@@ -644,23 +302,23 @@ struct EnemySpawnDirector {
             return
         }
 
-        guard projectedEnemyCount + requiredFormationEnemyCount <= tuning.maxActiveEnemies else {
+        guard projectedEnemyCount + requiredFormationEnemyCount <= context.tuning.maxActiveEnemies else {
             timeUntilNextFormation = max(timeUntilNextFormation, formationSpawnInterval)
             return
         }
 
-        timeUntilNextFormation -= deltaTime
+        timeUntilNextFormation -= context.deltaTime
 
         guard timeUntilNextFormation <= 0 else {
             return
         }
 
-        let availableSlots = tuning.maxActiveEnemies - projectedEnemyCount
+        let availableSlots = context.tuning.maxActiveEnemies - projectedEnemyCount
         guard let formation = makePendingFormation(
-            in: playableRect,
-            playerPosition: playerPosition,
-            pickupCircles: pickupCircles,
-            tuning: tuning,
+            in: context.playableRect,
+            playerPosition: context.playerPosition,
+            pickupCircles: context.pickupCircles,
+            tuning: context.tuning,
             availableSlots: availableSlots
         ) else {
             timeUntilNextFormation = formationSpawnInterval
@@ -701,16 +359,13 @@ struct EnemySpawnDirector {
             .filter { isSafeSpawn($0, avoiding: playerPosition, pickupCircles: pickupCircles) }
             .prefix(max(0, availableSlots))
             .map { position in
-                defer {
-                    nextID += 1
-                }
-
-                return ArenaEnemy(
+                defer { nextID += 1 }
+                return makeFormationEnemy(
+                    at: position,
                     id: nextID,
-                    position: position,
-                    radius: configuration.enemyRadius,
-                    speed: tuning.formationSpeed,
-                    behavior: .formationLine(velocity: velocity, formationID: formationID)
+                    formationID: formationID,
+                    velocity: velocity,
+                    speed: tuning.formationSpeed
                 )
             }
 
@@ -721,20 +376,53 @@ struct EnemySpawnDirector {
         nextEnemyID += enemies.count
         nextFormationID += 1
         nextTelegraphID += 1
+        let telegraph = formationTelegraph(
+            id: telegraphID,
+            direction: direction,
+            laneCount: laneCount,
+            gapLaneIndex: gapLaneIndex,
+            playableRect: playableRect
+        )
 
         return PendingEnemySpawn(
             timeRemaining: configuration.formationTelegraphDuration,
             requiredEnemyCount: requiredFormationEnemyCount,
-            enemies: Array(enemies),
-            telegraph: EnemyTelegraph(
-                id: telegraphID,
-                segments: formationTelegraphSegments(
-                    direction: direction,
-                    laneCount: laneCount,
-                    gapLaneIndex: gapLaneIndex,
-                    playableRect: playableRect
-                )
+            enemies: enemies,
+            telegraph: telegraph
+        )
+    }
+
+    private func formationTelegraph(
+        id: Int,
+        direction: EdgeDirection,
+        laneCount: Int,
+        gapLaneIndex: Int,
+        playableRect: CGRect
+    ) -> EnemyTelegraph {
+        EnemyTelegraph(
+            id: id,
+            segments: formationTelegraphSegments(
+                direction: direction,
+                laneCount: laneCount,
+                gapLaneIndex: gapLaneIndex,
+                playableRect: playableRect
             )
+        )
+    }
+
+    private func makeFormationEnemy(
+        at position: CGPoint,
+        id: Int,
+        formationID: Int,
+        velocity: CGVector,
+        speed: CGFloat
+    ) -> ArenaEnemy {
+        ArenaEnemy(
+            id: id,
+            position: position,
+            radius: configuration.enemyRadius,
+            speed: speed,
+            behavior: .formationLine(velocity: velocity, formationID: formationID)
         )
     }
 
@@ -901,12 +589,6 @@ struct EnemySpawnDirector {
         case .topToBottom:
             return CGVector(dx: 0, dy: -speed)
         }
-    }
-
-    func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
-        let dx = lhs.x - rhs.x
-        let dy = lhs.y - rhs.y
-        return dx * dx + dy * dy
     }
 
     private var requiredFormationEnemyCount: Int {

--- a/TiltArena/Game/UI/ArenaLandscapeUILayout.swift
+++ b/TiltArena/Game/UI/ArenaLandscapeUILayout.swift
@@ -6,15 +6,11 @@ struct ArenaLandscapeUILayout: Equatable {
     let margin: CGFloat
 
     var safeRect: CGRect {
-        Self.safeRect(sceneSize: sceneSize, safeAreaInsets: safeAreaInsets, margin: margin)
+        ArenaGeometry.safeRect(sceneSize: sceneSize, safeAreaInsets: safeAreaInsets, margin: margin)
     }
 
     var titlePosition: CGPoint {
         CGPoint(x: safeRect.minX, y: safeRect.maxY)
-    }
-
-    var topRightControlPosition: CGPoint {
-        CGPoint(x: safeRect.maxX, y: safeRect.maxY)
     }
 
     var bottomCenterPosition: CGPoint {
@@ -73,22 +69,4 @@ struct ArenaLandscapeUILayout: Equatable {
         )
     }
 
-    static func safeRect(
-        sceneSize: CGSize,
-        safeAreaInsets: UIEdgeInsets,
-        margin: CGFloat
-    ) -> CGRect {
-        let width = max(0, sceneSize.width)
-        let height = max(0, sceneSize.height)
-        let leftInset = max(0, min(safeAreaInsets.left, width))
-        let rightInset = max(0, min(safeAreaInsets.right, width - leftInset))
-        let bottomInset = max(0, min(safeAreaInsets.bottom, height))
-        let topInset = max(0, min(safeAreaInsets.top, height - bottomInset))
-        let minX = leftInset + margin
-        let maxX = max(minX, width - rightInset - margin)
-        let minY = bottomInset + margin
-        let maxY = max(minY, height - topInset - margin)
-
-        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
-    }
 }

--- a/TiltArena/Game/UI/ArenaMenuModels.swift
+++ b/TiltArena/Game/UI/ArenaMenuModels.swift
@@ -12,7 +12,6 @@ struct ArenaModeRow: Equatable {
 struct ArenaAwardRow: Equatable {
     let title: String
     let progressText: String
-    let detailText: String
     let progressFraction: Double
     let isComplete: Bool
     let isPlaceholderProgress: Bool
@@ -57,42 +56,36 @@ struct ArenaMenuContent {
                 title: "COMBO SPARK",
                 progress: profile.highestCombo,
                 target: 10,
-                detail: "Reach a 10 combo",
                 placeholder: false
             ),
             award(
                 title: "SCORE CREST",
                 progress: profile.bestScore,
                 target: 5_000,
-                detail: "Score 5000 in Classic",
                 placeholder: false
             ),
             award(
                 title: "FREEZE SHATTER",
                 progress: min(profile.totalEnemiesDestroyed, 25),
                 target: 25,
-                detail: "Shatter frozen enemies",
                 placeholder: true
             ),
             award(
                 title: "DANGER GRAB",
                 progress: min(profile.totalRuns, 5),
                 target: 5,
-                detail: "Take risky weapon pickups",
                 placeholder: true
             ),
             award(
                 title: "WEAPON MASTER",
                 progress: profile.totalEnemiesDestroyed,
                 target: 250,
-                detail: "Destroy enemies with weapons",
                 placeholder: true
             ),
             award(
                 title: "SURVIVOR",
                 progress: Int(profile.longestSurvivalTime),
                 target: 120,
-                detail: "Survive for 120 seconds",
                 placeholder: false
             )
         ]
@@ -134,7 +127,6 @@ struct ArenaMenuContent {
         title: String,
         progress: Int,
         target: Int,
-        detail: String,
         placeholder: Bool
     ) -> ArenaAwardRow {
         let clampedTarget = max(1, target)
@@ -142,7 +134,6 @@ struct ArenaMenuContent {
         return ArenaAwardRow(
             title: title,
             progressText: "\(clampedProgress)/\(clampedTarget)",
-            detailText: detail,
             progressFraction: Double(clampedProgress) / Double(clampedTarget),
             isComplete: clampedProgress >= clampedTarget,
             isPlaceholderProgress: placeholder

--- a/TiltArena/Game/Weapons/FlameTrailState.swift
+++ b/TiltArena/Game/Weapons/FlameTrailState.swift
@@ -96,7 +96,7 @@ struct FlameTrailState {
         }
 
         let spacing = max(0, configuration.segmentSpacing)
-        guard spacing == 0 || squaredDistance(from: lastSegment.position, to: position) >= spacing * spacing else {
+        guard spacing == 0 || ArenaGeometry.squaredDistance(from: lastSegment.position, to: position) >= spacing * spacing else {
             return
         }
 
@@ -153,9 +153,4 @@ struct FlameTrailState {
         return burnedEnemyIDs
     }
 
-    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
-        let dx = lhs.x - rhs.x
-        let dy = lhs.y - rhs.y
-        return dx * dx + dy * dy
-    }
 }

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -161,13 +161,13 @@ struct PickupSpawnPlanner {
         configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()
     ) -> Bool {
         let playerClearance = configuration.playerClearance + configuration.pickupRadius
-        guard squaredDistance(from: position, to: playerPosition) >= playerClearance * playerClearance else {
+        guard ArenaGeometry.squaredDistance(from: position, to: playerPosition) >= playerClearance * playerClearance else {
             return false
         }
 
         return enemyCircles.allSatisfy { enemyCircle in
             let clearance = enemyCircle.radius + configuration.pickupRadius + configuration.enemyClearance
-            return squaredDistance(from: position, to: enemyCircle.center) >= clearance * clearance
+            return ArenaGeometry.squaredDistance(from: position, to: enemyCircle.center) >= clearance * clearance
         }
     }
 
@@ -185,9 +185,4 @@ struct PickupSpawnPlanner {
         )
     }
 
-    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
-        let dx = lhs.x - rhs.x
-        let dy = lhs.y - rhs.y
-        return dx * dx + dy * dy
-    }
 }

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -74,8 +74,8 @@ struct StartingWeaponResolver {
         return Set(
             enemies
                 .sorted {
-                    squaredDistance(from: $0.position, to: playerPosition)
-                        < squaredDistance(from: $1.position, to: playerPosition)
+                    ArenaGeometry.squaredDistance(from: $0.position, to: playerPosition)
+                        < ArenaGeometry.squaredDistance(from: $1.position, to: playerPosition)
                 }
                 .prefix(targetLimit)
                 .map(\.id)
@@ -135,17 +135,11 @@ struct StartingWeaponResolver {
         return enemies
             .filter { enemy in
                 !selectedIDs.contains(enemy.id)
-                    && squaredDistance(from: enemy.position, to: origin) <= maximumSquaredDistance
+                    && ArenaGeometry.squaredDistance(from: enemy.position, to: origin) <= maximumSquaredDistance
             }
             .min {
-                squaredDistance(from: $0.position, to: origin)
-                    < squaredDistance(from: $1.position, to: origin)
+                ArenaGeometry.squaredDistance(from: $0.position, to: origin)
+                    < ArenaGeometry.squaredDistance(from: $1.position, to: origin)
             }
-    }
-
-    private func squaredDistance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
-        let dx = lhs.x - rhs.x
-        let dy = lhs.y - rhs.y
-        return dx * dx + dy * dy
     }
 }


### PR DESCRIPTION
## Summary
- Consolidate duplicated arena geometry helpers for squared-distance and safe-area layout math.
- Move enemy spawn tuning and telegraph frame models out of the spawn director.
- Simplify spawn parameter plumbing and remove dead award-detail UI data.

## Validation
- swiftlint lint --no-cache
- git diff --check
- xcodebuild build -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS\ Simulator -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO
- xcodebuild build-for-testing -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS\ Simulator -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO

Note: simulator execution tests were not run because local CoreSimulatorService is unavailable.

Closes #55