### PR TITLE
Add Decoy Beacon weapon pattern

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -45,6 +45,8 @@ final class ArenaScene: SKScene {
     var gravityWellEffectNode: SKNode?
     private var warpDashState = WarpDashState()
     private var warpDashInvulnerabilityTimeRemaining: TimeInterval = 0
+    private var decoyBeaconState = DecoyBeaconState()
+    var decoyBeaconEffectNode: SKNode?
     private let timerLabel = SKLabelNode(fontNamed: "Menlo-Bold")
     private let bestMarkerLabel = SKLabelNode(fontNamed: "Menlo")
     private let comboLabel = SKLabelNode(fontNamed: "Menlo-Bold")
@@ -378,6 +380,8 @@ final class ArenaScene: SKScene {
         deactivateGravityWell()
         warpDashState.reset()
         warpDashInvulnerabilityTimeRemaining = 0
+        decoyBeaconState.reset()
+        deactivateDecoyBeaconEffect()
     }
 
     private func resetPlayerFeedback() {
@@ -395,6 +399,7 @@ final class ArenaScene: SKScene {
         spawnPickupIfNeeded(deltaTime: deltaTime, playerPosition: playerPosition)
         playerPosition = collectPickups(playerPosition: playerPosition)
         advanceEnemies(deltaTime: deltaTime, playerPosition: playerPosition)
+        updateDecoyBeacon(deltaTime: deltaTime)
         updateGravityWell(deltaTime: deltaTime)
         removeExpiredEnemies()
         cullExitedLinearPatternEnemies()
@@ -477,7 +482,11 @@ final class ArenaScene: SKScene {
 
     private func advanceEnemies(deltaTime: TimeInterval, playerPosition: CGPoint) {
         for index in enemies.indices {
-            enemies[index].advance(toward: playerPosition, deltaTime: deltaTime)
+            let targetPosition = decoyBeaconState.targetPosition(
+                for: enemies[index],
+                fallback: playerPosition
+            )
+            enemies[index].advance(toward: targetPosition, deltaTime: deltaTime)
             enemyNodes[enemies[index].id]?.apply(enemies[index])
         }
     }
@@ -590,6 +599,8 @@ final class ArenaScene: SKScene {
             flameTrailEffectNode.apply(segments: flameTrailState.segments)
         case .warpDash:
             performWarpDash(from: playerPosition)
+        case .decoyBeacon:
+            activateDecoyBeacon(at: playerPosition)
         case .novaBomb:
             playNovaBombEffect()
         }
@@ -1732,6 +1743,33 @@ private extension ArenaScene {
 }
 
 private extension ArenaScene {
+    func activateDecoyBeacon(at position: CGPoint) {
+        decoyBeaconState.activate(at: position)
+        guard decoyBeaconState.isActive else {
+            deactivateDecoyBeaconEffect()
+            return
+        }
+
+        playDecoyBeaconEffect(
+            at: position,
+            duration: decoyBeaconState.configuration.duration
+        )
+    }
+
+    func updateDecoyBeacon(deltaTime: TimeInterval) {
+        let frame = decoyBeaconState.update(deltaTime: deltaTime, enemies: enemies)
+
+        guard let explosionCenter = frame.explosionCenter else {
+            return
+        }
+
+        playDecoyBeaconExplosionEffect(
+            at: explosionCenter,
+            radius: decoyBeaconState.configuration.explosionRadius
+        )
+        destroyEnemies(ids: frame.destroyedEnemyIDs, weaponKind: .decoyBeacon)
+    }
+
     func activateGravityWell(at center: CGPoint, enemyIDs: Set<Int>) {
         gravityWellState = GravityWellState(
             center: center,

--- a/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
+++ b/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
@@ -138,4 +138,78 @@ extension ArenaScene {
         ])
         endpoint.run(.sequence([pulse, .removeFromParent()]))
     }
+
+    func playDecoyBeaconEffect(at position: CGPoint, duration: TimeInterval) {
+        decoyBeaconEffectNode?.removeFromParent()
+
+        let container = SKNode()
+        container.position = position
+        container.zPosition = 18
+        addChild(container)
+        decoyBeaconEffectNode = container
+
+        let body = SKShapeNode(path: Self.makeDecoyBeaconPath(radius: 13))
+        body.fillColor = theme.pickupViolet.withAlphaComponent(0.82)
+        body.strokeColor = theme.playerColor.withAlphaComponent(0.8)
+        body.lineWidth = 1.2
+        body.glowWidth = 3
+        container.addChild(body)
+
+        let ring = SKShapeNode(circleOfRadius: 24)
+        ring.strokeColor = theme.pickupViolet.withAlphaComponent(0.55)
+        ring.fillColor = .clear
+        ring.lineWidth = 1.4
+        ring.glowWidth = 3
+        container.addChild(ring)
+
+        let pulseDuration = max(0.24, min(0.5, duration / 4))
+        let pulse = SKAction.sequence([
+            .group([
+                .scale(to: 1.18, duration: pulseDuration),
+                .fadeAlpha(to: 0.62, duration: pulseDuration)
+            ]),
+            .group([
+                .scale(to: 0.92, duration: pulseDuration),
+                .fadeAlpha(to: 1, duration: pulseDuration)
+            ])
+        ])
+        container.run(.repeatForever(pulse))
+    }
+
+    func playDecoyBeaconExplosionEffect(at position: CGPoint, radius: CGFloat) {
+        decoyBeaconEffectNode?.removeFromParent()
+        decoyBeaconEffectNode = nil
+
+        let ring = SKShapeNode(circleOfRadius: max(0, radius))
+        ring.position = position
+        ring.strokeColor = theme.pickupViolet.withAlphaComponent(0.85)
+        ring.fillColor = theme.pickupViolet.withAlphaComponent(0.07)
+        ring.lineWidth = 2
+        ring.glowWidth = 5
+        ring.zPosition = 18
+        ring.setScale(0.24)
+        addChild(ring)
+
+        let burst = SKAction.group([
+            .scale(to: 1, duration: 0.16),
+            .fadeOut(withDuration: 0.16)
+        ])
+        ring.run(.sequence([burst, .removeFromParent()]))
+    }
+
+    func deactivateDecoyBeaconEffect() {
+        decoyBeaconEffectNode?.removeFromParent()
+        decoyBeaconEffectNode = nil
+    }
+
+    private static func makeDecoyBeaconPath(radius: CGFloat) -> CGPath {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: radius))
+        path.addLine(to: CGPoint(x: radius * 0.86, y: radius * 0.28))
+        path.addLine(to: CGPoint(x: radius * 0.54, y: -radius * 0.82))
+        path.addLine(to: CGPoint(x: -radius * 0.54, y: -radius * 0.82))
+        path.addLine(to: CGPoint(x: -radius * 0.86, y: radius * 0.28))
+        path.closeSubpath()
+        return path
+    }
 }

--- a/TiltArena/Game/Weapons/DecoyBeaconState.swift
+++ b/TiltArena/Game/Weapons/DecoyBeaconState.swift
@@ -1,0 +1,100 @@
+import CoreGraphics
+import Foundation
+
+struct DecoyBeaconConfiguration: Equatable {
+    var duration: TimeInterval = 2
+    var attractionRadius: CGFloat = 176
+    var explosionRadius: CGFloat = 64
+}
+
+struct DecoyBeaconFrame: Equatable {
+    var explosionCenter: CGPoint?
+    var destroyedEnemyIDs: Set<Int> = []
+}
+
+struct DecoyBeaconState {
+    var configuration = DecoyBeaconConfiguration()
+    private(set) var center: CGPoint?
+    private(set) var timeRemaining: TimeInterval = 0
+
+    init(configuration: DecoyBeaconConfiguration = DecoyBeaconConfiguration()) {
+        self.configuration = configuration
+    }
+
+    var isActive: Bool {
+        center != nil && timeRemaining > 0
+    }
+
+    mutating func activate(at position: CGPoint) {
+        let duration = max(0, configuration.duration)
+        guard duration > 0 else {
+            reset()
+            return
+        }
+
+        center = position
+        timeRemaining = duration
+    }
+
+    mutating func reset() {
+        center = nil
+        timeRemaining = 0
+    }
+
+    func targetPosition(for enemy: ArenaEnemy, fallback: CGPoint) -> CGPoint {
+        guard shouldRedirect(enemy), let center else {
+            return fallback
+        }
+
+        return center
+    }
+
+    private func shouldRedirect(_ enemy: ArenaEnemy) -> Bool {
+        guard isActive, let center, !enemy.isFrozen, isTargetSeeking(enemy) else {
+            return false
+        }
+
+        let attractionCircle = CollisionCircle(
+            center: center,
+            radius: max(0, configuration.attractionRadius)
+        )
+        return attractionCircle.intersects(enemy.collisionCircle)
+    }
+
+    mutating func update(deltaTime: TimeInterval, enemies: [ArenaEnemy]) -> DecoyBeaconFrame {
+        guard let activeCenter = center, timeRemaining > 0 else {
+            reset()
+            return DecoyBeaconFrame()
+        }
+
+        timeRemaining = max(0, timeRemaining - max(0, deltaTime))
+
+        guard timeRemaining == 0 else {
+            return DecoyBeaconFrame()
+        }
+
+        let destroyedEnemyIDs = explosionTargets(center: activeCenter, enemies: enemies)
+        reset()
+        return DecoyBeaconFrame(
+            explosionCenter: activeCenter,
+            destroyedEnemyIDs: destroyedEnemyIDs
+        )
+    }
+
+    private func explosionTargets(center: CGPoint, enemies: [ArenaEnemy]) -> Set<Int> {
+        let explosionCircle = CollisionCircle(
+            center: center,
+            radius: max(0, configuration.explosionRadius)
+        )
+        return Set(enemies.filter { explosionCircle.intersects($0.collisionCircle) }.map(\.id))
+    }
+
+    private func isTargetSeeking(_ enemy: ArenaEnemy) -> Bool {
+        switch enemy.behavior {
+        case .chaser, .hunterDot:
+            return true
+        case .formationLine, .arrowRush, .mineDot, .paddleTrapBar, .paddleTrapDot:
+            return false
+        }
+    }
+}

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -26,6 +26,7 @@ struct PickupSpawnConfiguration: Equatable {
         .chainLightning,
         .flameTrail,
         .warpDash,
+        .decoyBeacon,
         .novaBomb
     ]
 

--- a/TiltArena/Game/Weapons/StartingWeaponResolver.swift
+++ b/TiltArena/Game/Weapons/StartingWeaponResolver.swift
@@ -47,7 +47,7 @@ struct StartingWeaponResolver {
                 destroyedEnemyIDs: Set(targetIDs),
                 chainLightningEnemyIDs: targetIDs
             )
-        case .flameTrail, .warpDash:
+        case .flameTrail, .warpDash, .decoyBeacon:
             return WeaponResolution()
         case .novaBomb:
             return WeaponResolution(destroyedEnemyIDs: Set(enemies.map(\.id)))

--- a/TiltArena/Game/Weapons/WeaponKind.swift
+++ b/TiltArena/Game/Weapons/WeaponKind.swift
@@ -7,6 +7,7 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
     case chainLightning
     case flameTrail
     case warpDash
+    case decoyBeacon
     case novaBomb
 
     var displayName: String {
@@ -27,6 +28,8 @@ enum WeaponKind: String, CaseIterable, Codable, Equatable {
             return "Flame Trail"
         case .warpDash:
             return "Warp Dash"
+        case .decoyBeacon:
+            return "Decoy Beacon"
         case .novaBomb:
             return "Nova Bomb"
         }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -54,6 +54,8 @@ final class WeaponPickupNode: SKNode {
             return theme.pickupAmber
         case .warpDash:
             return theme.pickupViolet
+        case .decoyBeacon:
+            return theme.pickupViolet
         case .novaBomb:
             return theme.pickupAmber
         }

--- a/TiltArenaTests/DecoyBeaconStateTests.swift
+++ b/TiltArenaTests/DecoyBeaconStateTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import TiltArena
+
+final class DecoyBeaconStateTests: XCTestCase {
+    func testActivateStoresCenterAndCountsDownBeforeExplosion() {
+        var state = DecoyBeaconState(
+            configuration: DecoyBeaconConfiguration(
+                duration: 2,
+                attractionRadius: 100,
+                explosionRadius: 40
+            )
+        )
+
+        state.activate(at: CGPoint(x: 10, y: 20))
+        let frame = state.update(deltaTime: 0.75, enemies: [
+            enemy(id: 1, position: CGPoint(x: 10, y: 20))
+        ])
+
+        XCTAssertEqual(state.center, CGPoint(x: 10, y: 20))
+        XCTAssertEqual(state.timeRemaining, 1.25, accuracy: 0.0001)
+        XCTAssertTrue(state.isActive)
+        XCTAssertNil(frame.explosionCenter)
+        XCTAssertEqual(frame.destroyedEnemyIDs, [])
+    }
+
+    func testTargetPositionRedirectsOnlyNearbyTargetSeekingEnemies() {
+        var state = DecoyBeaconState(
+            configuration: DecoyBeaconConfiguration(
+                duration: 2,
+                attractionRadius: 100,
+                explosionRadius: 40
+            )
+        )
+        state.activate(at: .zero)
+        let fallback = CGPoint(x: 200, y: 0)
+
+        XCTAssertEqual(
+            state.targetPosition(for: enemy(id: 1, position: CGPoint(x: 80, y: 0)), fallback: fallback),
+            .zero
+        )
+        XCTAssertEqual(
+            state.targetPosition(
+                for: enemy(
+                    id: 2,
+                    position: CGPoint(x: 80, y: 0),
+                    behavior: .hunterDot(predictionLead: 0.2, previousTarget: nil)
+                ),
+                fallback: fallback
+            ),
+            .zero
+        )
+        XCTAssertEqual(
+            state.targetPosition(for: enemy(id: 3, position: CGPoint(x: 140, y: 0)), fallback: fallback),
+            fallback
+        )
+        XCTAssertEqual(
+            state.targetPosition(
+                for: enemy(
+                    id: 4,
+                    position: CGPoint(x: 40, y: 0),
+                    behavior: .formationLine(velocity: .zero, formationID: 1)
+                ),
+                fallback: fallback
+            ),
+            fallback
+        )
+        XCTAssertEqual(
+            state.targetPosition(
+                for: enemy(id: 5, position: CGPoint(x: 40, y: 0), behavior: .arrowRush(velocity: .zero)),
+                fallback: fallback
+            ),
+            fallback
+        )
+        XCTAssertEqual(
+            state.targetPosition(
+                for: enemy(id: 6, position: CGPoint(x: 40, y: 0), behavior: .mineDot),
+                fallback: fallback
+            ),
+            fallback
+        )
+        XCTAssertEqual(
+            state.targetPosition(
+                for: enemy(
+                    id: 7,
+                    position: CGPoint(x: 40, y: 0),
+                    behavior: .paddleTrapBar(trapID: 1, remainingLifetime: 1)
+                ),
+                fallback: fallback
+            ),
+            fallback
+        )
+        XCTAssertEqual(
+            state.targetPosition(
+                for: enemy(
+                    id: 8,
+                    position: CGPoint(x: 40, y: 0),
+                    behavior: .paddleTrapDot(
+                        trapID: 1,
+                        velocity: .zero,
+                        bounds: CGRect(x: -100, y: -100, width: 200, height: 200),
+                        remainingLifetime: 1
+                    )
+                ),
+                fallback: fallback
+            ),
+            fallback
+        )
+    }
+
+    func testFrozenTargetSeekingEnemyIsNotRedirected() {
+        var state = DecoyBeaconState(
+            configuration: DecoyBeaconConfiguration(
+                duration: 2,
+                attractionRadius: 100,
+                explosionRadius: 40
+            )
+        )
+        state.activate(at: .zero)
+        var frozenEnemy = enemy(id: 1, position: CGPoint(x: 40, y: 0))
+        frozenEnemy.freeze(duration: 1)
+        let fallback = CGPoint(x: 200, y: 0)
+
+        XCTAssertEqual(state.targetPosition(for: frozenEnemy, fallback: fallback), fallback)
+    }
+
+    func testExpiryExplodesAndClearsEnemiesInsideRadius() {
+        var state = DecoyBeaconState(
+            configuration: DecoyBeaconConfiguration(
+                duration: 2,
+                attractionRadius: 100,
+                explosionRadius: 40
+            )
+        )
+        state.activate(at: CGPoint(x: 10, y: 0))
+
+        let frame = state.update(deltaTime: 2, enemies: [
+            enemy(id: 1, position: CGPoint(x: 42, y: 0)),
+            enemy(id: 2, position: CGPoint(x: 80, y: 0))
+        ])
+
+        XCTAssertFalse(state.isActive)
+        XCTAssertNil(state.center)
+        XCTAssertEqual(frame.explosionCenter, CGPoint(x: 10, y: 0))
+        XCTAssertEqual(frame.destroyedEnemyIDs, [1])
+    }
+
+    func testZeroDurationActivationLeavesBeaconInactive() {
+        var state = DecoyBeaconState(
+            configuration: DecoyBeaconConfiguration(
+                duration: 0,
+                attractionRadius: 100,
+                explosionRadius: 40
+            )
+        )
+
+        state.activate(at: CGPoint(x: 10, y: 20))
+
+        XCTAssertFalse(state.isActive)
+        XCTAssertNil(state.center)
+        XCTAssertEqual(state.timeRemaining, 0)
+    }
+
+    func testResetClearsActiveBeacon() {
+        var state = DecoyBeaconState()
+        state.activate(at: CGPoint(x: 10, y: 20))
+
+        state.reset()
+
+        XCTAssertFalse(state.isActive)
+        XCTAssertNil(state.center)
+        XCTAssertEqual(state.timeRemaining, 0)
+    }
+
+    private func enemy(
+        id: Int,
+        position: CGPoint,
+        behavior: EnemyBehavior = .chaser
+    ) -> ArenaEnemy {
+        ArenaEnemy(
+            id: id,
+            position: position,
+            radius: 8,
+            speed: 0,
+            behavior: behavior
+        )
+    }
+}

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -148,18 +148,20 @@ final class PickupSpawnPlannerTests: XCTestCase {
         ])
     }
 
-    func testDefaultKindCycleMakesControlWeaponsRareAndNovaBombRarest() {
+    func testDefaultKindCycleMakesLateControlWeaponsRareAndNovaBombLast() {
         let kinds = spawnKinds(
             count: PickupSpawnConfiguration.defaultWeaponKindCycle.count,
             configuration: PickupSpawnConfiguration()
         )
 
         XCTAssertEqual(kinds, PickupSpawnConfiguration.defaultWeaponKindCycle)
+        XCTAssertEqual(Array(kinds.suffix(2)), [.decoyBeacon, .novaBomb])
         XCTAssertEqual(kinds.filter { $0 == .freezeBurst }.count, 3)
         XCTAssertEqual(kinds.filter { $0 == .gravityWell }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .chainLightning }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .flameTrail }.count, 2)
         XCTAssertEqual(kinds.filter { $0 == .warpDash }.count, 2)
+        XCTAssertEqual(kinds.filter { $0 == .decoyBeacon }.count, 1)
         XCTAssertEqual(kinds.filter { $0 == .novaBomb }.count, 1)
         XCTAssertGreaterThan(kinds.filter { $0 == .shockwave }.count, kinds.filter { $0 == .freezeBurst }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .seekerSwarm }.count, kinds.filter { $0 == .freezeBurst }.count)
@@ -172,6 +174,7 @@ final class PickupSpawnPlannerTests: XCTestCase {
         XCTAssertGreaterThan(kinds.filter { $0 == .chainLightning }.count, kinds.filter { $0 == .novaBomb }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .flameTrail }.count, kinds.filter { $0 == .novaBomb }.count)
         XCTAssertGreaterThan(kinds.filter { $0 == .warpDash }.count, kinds.filter { $0 == .novaBomb }.count)
+        XCTAssertGreaterThan(kinds.filter { $0 == .warpDash }.count, kinds.filter { $0 == .decoyBeacon }.count)
     }
 
     func testEmptyKindCycleDoesNotSpawnPickup() {

--- a/TiltArenaTests/StartingWeaponResolverTests.swift
+++ b/TiltArenaTests/StartingWeaponResolverTests.swift
@@ -261,6 +261,24 @@ final class StartingWeaponResolverTests: XCTestCase {
         XCTAssertEqual(resolution.chainLightningEnemyIDs, [])
     }
 
+    func testDecoyBeaconDoesNotInstantlyResolveTargets() {
+        let resolver = StartingWeaponResolver()
+        let enemies = [
+            enemy(id: 1, position: CGPoint(x: 10, y: 0))
+        ]
+
+        let resolution = resolver.resolve(
+            kind: .decoyBeacon,
+            playerPosition: .zero,
+            enemies: enemies
+        )
+
+        XCTAssertEqual(resolution.destroyedEnemyIDs, [])
+        XCTAssertEqual(resolution.frozenEnemyIDs, [])
+        XCTAssertEqual(resolution.gravityWellEnemyIDs, [])
+        XCTAssertEqual(resolution.chainLightningEnemyIDs, [])
+    }
+
     func testNovaBombHandlesEmptyArena() {
         let resolver = StartingWeaponResolver()
 


### PR DESCRIPTION
## Summary
- add Decoy Beacon as the final weapon pickup in the roster
- redirect nearby target-seeking enemies to a temporary beacon, then explode and credit Decoy Beacon kills
- add focused unit coverage for activation, redirect eligibility, expiry, pickup cycle, and resolver behavior

## Validation
- xcodebuild test -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination id=EEB0A2D3-E963-4E3C-B215-B86A3120F13C -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO
- git diff --check

Closes #57
Parent: #10