### PR TITLE
Implement Redline and Daily arena modes

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -25,7 +25,7 @@ final class ArenaScene: SKScene {
     private var readyProgressRing: SKShapeNode?
     private var readyStatusLabel: SKLabelNode?
     private var spawnDirector = EnemySpawnDirector()
-    private let pickupSpawnConfiguration = PickupSpawnConfiguration()
+    private var pickupSpawnConfiguration = PickupSpawnConfiguration()
     private var pickupPlanner = PickupSpawnPlanner()
     let weaponResolver = StartingWeaponResolver()
     private var enemies: [ArenaEnemy] = []
@@ -361,18 +361,22 @@ final class ArenaScene: SKScene {
     }
 
     private func resetGameplayObjects() {
+        let modeSettings = applySelectedModeRunSettings()
         enemies.removeAll()
         enemyNodes.values.forEach { $0.removeFromParent() }
         enemyNodes.removeAll()
         enemyTelegraphNodes.values.forEach { $0.removeFromParent() }
         enemyTelegraphNodes.removeAll()
         formationEnemyIDs.removeAll()
-        spawnDirector.reset()
+        spawnDirector.reset(sequenceSeed: modeSettings.sequenceSeed)
 
         pickups.removeAll()
         pickupNodes.values.forEach { $0.removeFromParent() }
         pickupNodes.removeAll()
-        pickupPlanner.reset(configuration: pickupSpawnConfiguration)
+        pickupPlanner.reset(
+            configuration: pickupSpawnConfiguration,
+            sequenceSeed: modeSettings.sequenceSeed
+        )
         deactivateRazorShield()
         frozenCrasherTimeRemaining = 0
         flameTrailState.reset()
@@ -382,6 +386,13 @@ final class ArenaScene: SKScene {
         warpDashInvulnerabilityTimeRemaining = 0
         decoyBeaconState.reset()
         deactivateDecoyBeaconEffect()
+    }
+
+    private func applySelectedModeRunSettings() -> ArenaModeRunSettings {
+        let settings = ArenaModeRules.runSettings(for: selectedMode)
+        spawnDirector.configuration = settings.enemySpawnConfiguration
+        pickupSpawnConfiguration = settings.pickupSpawnConfiguration
+        return settings
     }
 
     private func resetPlayerFeedback() {

--- a/TiltArena/Game/Enemies/EnemySpawnDirector.swift
+++ b/TiltArena/Game/Enemies/EnemySpawnDirector.swift
@@ -80,11 +80,15 @@ struct EnemySpawnDirector {
         return Set(trapIDs).count
     }
 
-    init(configuration: EnemySpawnConfiguration = EnemySpawnConfiguration()) {
+    init(
+        configuration: EnemySpawnConfiguration = EnemySpawnConfiguration(),
+        sequenceSeed: Int? = nil
+    ) {
         self.configuration = configuration
+        applySequenceSeed(sequenceSeed)
     }
 
-    mutating func reset() {
+    mutating func reset(sequenceSeed: Int? = nil) {
         nextEnemyID = 1
         nextFormationID = 1
         nextTelegraphID = 1
@@ -103,6 +107,7 @@ struct EnemySpawnDirector {
         timeUntilNextHunterDot = 0
         timeUntilNextPaddleTrap = 0
         pendingSpawns.removeAll()
+        applySequenceSeed(sequenceSeed)
     }
 
     mutating func update(
@@ -281,6 +286,25 @@ struct EnemySpawnDirector {
         }
 
         return nil
+    }
+
+    private mutating func applySequenceSeed(_ seed: Int?) {
+        guard let seed else {
+            return
+        }
+
+        nextChaserCandidateIndex = positiveModulo(seed, Self.candidateSideCount * Self.candidateLaneCount)
+        nextFormationDirectionIndex = positiveModulo(seed / 3, EdgeDirection.allCases.count)
+        nextArrowRushDirectionIndex = positiveModulo(seed / 5, EdgeDirection.allCases.count)
+        nextMineDotCandidateIndex = positiveModulo(seed / 7, Self.candidateSideCount * Self.candidateLaneCount)
+        nextHunterDotCandidateIndex = positiveModulo(seed / 11, Self.candidateSideCount * Self.candidateLaneCount)
+        nextPaddleTrapCandidateIndex = positiveModulo(seed / 13, Self.candidateSideCount * Self.candidateLaneCount)
+        nextPaddleTrapOrientationIndex = positiveModulo(seed / 17, 2)
+    }
+
+    private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+        let remainder = value % divisor
+        return remainder >= 0 ? remainder : remainder + divisor
     }
 
     private mutating func spawnFormationTelegraphIfNeeded(

--- a/TiltArena/Game/Run/ArenaModeRules.swift
+++ b/TiltArena/Game/Run/ArenaModeRules.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+struct ArenaModeRunSettings: Equatable {
+    let enemySpawnConfiguration: EnemySpawnConfiguration
+    let pickupSpawnConfiguration: PickupSpawnConfiguration
+    let sequenceSeed: Int?
+}
+
+struct ArenaModeRules {
+    static let redlineBestScoreRequirement = 5_000
+    static let dailyEnemyUnlockRequirement = 400
+
+    static func isAvailable(_ mode: ArenaModeKind, profile: RunProfile) -> Bool {
+        switch mode {
+        case .classic:
+            return true
+        case .redline:
+            return profile.bestScore >= redlineBestScoreRequirement
+        case .daily:
+            return profile.totalEnemiesDestroyed >= dailyEnemyUnlockRequirement
+        }
+    }
+
+    static func subtitle(for mode: ArenaModeKind) -> String {
+        switch mode {
+        case .classic:
+            return "Classic Survival"
+        case .redline:
+            return "Faster pressure curve"
+        case .daily:
+            return "Local fixed-seed arena"
+        }
+    }
+
+    static func statusText(for mode: ArenaModeKind, selectedMode: ArenaModeKind, profile: RunProfile) -> String {
+        guard isAvailable(mode, profile: profile) else {
+            return "LOCKED"
+        }
+
+        return mode == selectedMode ? "SELECTED" : "AVAILABLE"
+    }
+
+    static func progressText(for mode: ArenaModeKind, profile: RunProfile) -> String {
+        switch mode {
+        case .classic:
+            return "BEST \(profile.bestScore)"
+        case .redline:
+            return "\(min(profile.bestScore, redlineBestScoreRequirement))/\(redlineBestScoreRequirement) CLASSIC BEST"
+        case .daily:
+            return "\(min(profile.totalEnemiesDestroyed, dailyEnemyUnlockRequirement))/\(dailyEnemyUnlockRequirement) UNLOCK TRACK"
+        }
+    }
+
+    static func activeUnlockText(profile: RunProfile) -> String {
+        if !isAvailable(.redline, profile: profile) {
+            return "REDLINE \(min(profile.bestScore, redlineBestScoreRequirement))/\(redlineBestScoreRequirement)"
+        }
+
+        if !isAvailable(.daily, profile: profile) {
+            return "DAILY \(min(profile.totalEnemiesDestroyed, dailyEnemyUnlockRequirement))/\(dailyEnemyUnlockRequirement)"
+        }
+
+        return "ALL LOCAL MODES READY"
+    }
+
+    static func runSettings(
+        for mode: ArenaModeKind,
+        date: Date = Date(),
+        calendar: Calendar = .current
+    ) -> ArenaModeRunSettings {
+        switch mode {
+        case .classic:
+            return ArenaModeRunSettings(
+                enemySpawnConfiguration: EnemySpawnConfiguration(),
+                pickupSpawnConfiguration: PickupSpawnConfiguration(),
+                sequenceSeed: nil
+            )
+        case .redline:
+            return ArenaModeRunSettings(
+                enemySpawnConfiguration: redlineEnemySpawnConfiguration(),
+                pickupSpawnConfiguration: redlinePickupSpawnConfiguration(),
+                sequenceSeed: nil
+            )
+        case .daily:
+            return ArenaModeRunSettings(
+                enemySpawnConfiguration: EnemySpawnConfiguration(),
+                pickupSpawnConfiguration: PickupSpawnConfiguration(),
+                sequenceSeed: dailySeed(for: date, calendar: calendar)
+            )
+        }
+    }
+
+    static func dailySeed(for date: Date = Date(), calendar: Calendar = .current) -> Int {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        let year = max(0, components.year ?? 0)
+        let month = max(0, components.month ?? 0)
+        let day = max(0, components.day ?? 0)
+        return year * 10_000 + month * 100 + day
+    }
+
+    private static func redlineEnemySpawnConfiguration() -> EnemySpawnConfiguration {
+        var configuration = EnemySpawnConfiguration()
+        configuration.warmup = EnemyPhaseTuning(
+            chaserSpawnInterval: 0.82,
+            chaserSpeed: 78,
+            maxActiveEnemies: 64,
+            formationSpawnInterval: 9,
+            formationSpeed: 112,
+            formationLaneCount: 5
+        )
+        configuration.pressure = EnemyPhaseTuning(
+            chaserSpawnInterval: 0.62,
+            chaserSpeed: 94,
+            maxActiveEnemies: 96,
+            formationSpawnInterval: 6.5,
+            formationSpeed: 124,
+            formationLaneCount: 7,
+            arrowRushSpawnInterval: 11,
+            arrowRushSpeed: 160,
+            arrowRushEnemyCount: 3,
+            mineDotSpawnInterval: 16,
+            maxActiveMineDots: 4,
+            hunterDotSpawnInterval: 18,
+            hunterDotSpeed: 112,
+            hunterDotPredictionLead: 0.65,
+            maxActiveHunterDots: 2,
+            paddleTrapSpawnInterval: 24,
+            maxActivePaddleTraps: 1,
+            paddleTrapLifetime: 7,
+            paddleTrapBarEnemyCount: 4,
+            paddleTrapDotSpeed: 150
+        )
+        configuration.chaos = EnemyPhaseTuning(
+            chaserSpawnInterval: 0.45,
+            chaserSpeed: 112,
+            maxActiveEnemies: 140,
+            formationSpawnInterval: 4.8,
+            formationSpeed: 144,
+            formationLaneCount: 9,
+            arrowRushSpawnInterval: 7.5,
+            arrowRushSpeed: 190,
+            arrowRushEnemyCount: 5,
+            mineDotSpawnInterval: 10,
+            maxActiveMineDots: 7,
+            hunterDotSpawnInterval: 12,
+            hunterDotSpeed: 140,
+            hunterDotPredictionLead: 0.9,
+            maxActiveHunterDots: 3,
+            paddleTrapSpawnInterval: 17,
+            maxActivePaddleTraps: 2,
+            paddleTrapLifetime: 8,
+            paddleTrapBarEnemyCount: 5,
+            paddleTrapDotSpeed: 178
+        )
+        configuration.survivalHell = EnemyPhaseTuning(
+            chaserSpawnInterval: 0.34,
+            chaserSpeed: 132,
+            maxActiveEnemies: 210,
+            formationSpawnInterval: 3.8,
+            formationSpeed: 164,
+            formationLaneCount: 9,
+            arrowRushSpawnInterval: 5.5,
+            arrowRushSpeed: 215,
+            arrowRushEnemyCount: 6,
+            mineDotSpawnInterval: 8,
+            maxActiveMineDots: 9,
+            hunterDotSpawnInterval: 10,
+            hunterDotSpeed: 158,
+            hunterDotPredictionLead: 1.1,
+            maxActiveHunterDots: 4,
+            paddleTrapSpawnInterval: 14,
+            maxActivePaddleTraps: 2,
+            paddleTrapLifetime: 8,
+            paddleTrapBarEnemyCount: 5,
+            paddleTrapDotSpeed: 195
+        )
+        return configuration
+    }
+
+    private static func redlinePickupSpawnConfiguration() -> PickupSpawnConfiguration {
+        PickupSpawnConfiguration(
+            initialSpawnDelay: 5.0,
+            spawnInterval: 5.2,
+            maxActivePickups: 2,
+            weaponKindCycle: [
+                .flameTrail,
+                .warpDash,
+                .freezeBurst,
+                .gravityWell,
+                .chainLightning,
+                .seekerSwarm,
+                .flameTrail,
+                .warpDash,
+                .decoyBeacon,
+                .freezeBurst,
+                .gravityWell,
+                .razorShield,
+                .chainLightning,
+                .flameTrail,
+                .warpDash,
+                .decoyBeacon,
+                .shockwave
+            ]
+        )
+    }
+}

--- a/TiltArena/Game/UI/ArenaMenuModels.swift
+++ b/TiltArena/Game/UI/ArenaMenuModels.swift
@@ -19,35 +19,16 @@ struct ArenaAwardRow: Equatable {
 
 struct ArenaMenuContent {
     static func modeRows(profile: RunProfile, selectedMode: ArenaModeKind) -> [ArenaModeRow] {
-        let redlineAvailable = profile.bestScore >= 5_000
-        let dailyAvailable = profile.totalEnemiesDestroyed >= 400
-
-        return [
+        ArenaModeKind.allCases.map { mode in
             ArenaModeRow(
-                kind: .classic,
-                title: ArenaModeKind.classic.displayName,
-                subtitle: "Classic Survival",
-                statusText: selectedMode == .classic ? "SELECTED" : "AVAILABLE",
-                progressText: "BEST \(profile.bestScore)",
-                isAvailable: true
-            ),
-            ArenaModeRow(
-                kind: .redline,
-                title: ArenaModeKind.redline.displayName,
-                subtitle: "Faster pressure curve",
-                statusText: modeStatus(kind: .redline, selectedMode: selectedMode, isAvailable: redlineAvailable),
-                progressText: "\(min(profile.bestScore, 5_000))/5000 CLASSIC BEST",
-                isAvailable: redlineAvailable
-            ),
-            ArenaModeRow(
-                kind: .daily,
-                title: ArenaModeKind.daily.displayName,
-                subtitle: "Local fixed-seed arena",
-                statusText: modeStatus(kind: .daily, selectedMode: selectedMode, isAvailable: dailyAvailable),
-                progressText: "\(min(profile.totalEnemiesDestroyed, 400))/400 UNLOCK TRACK",
-                isAvailable: dailyAvailable
+                kind: mode,
+                title: mode.displayName,
+                subtitle: ArenaModeRules.subtitle(for: mode),
+                statusText: ArenaModeRules.statusText(for: mode, selectedMode: selectedMode, profile: profile),
+                progressText: ArenaModeRules.progressText(for: mode, profile: profile),
+                isAvailable: ArenaModeRules.isAvailable(mode, profile: profile)
             )
-        ]
+        }
     }
 
     static func awardRows(profile: RunProfile) -> [ArenaAwardRow] {
@@ -92,15 +73,7 @@ struct ArenaMenuContent {
     }
 
     static func activeUnlockText(profile: RunProfile) -> String {
-        if profile.bestScore < 5_000 {
-            return "REDLINE \(min(profile.bestScore, 5_000))/5000"
-        }
-
-        if profile.totalEnemiesDestroyed < 400 {
-            return "DAILY \(min(profile.totalEnemiesDestroyed, 400))/400"
-        }
-
-        return "ALL LOCAL MODES READY"
+        ArenaModeRules.activeUnlockText(profile: profile)
     }
 
     static func postRunHighlights(
@@ -138,18 +111,6 @@ struct ArenaMenuContent {
             isComplete: clampedProgress >= clampedTarget,
             isPlaceholderProgress: placeholder
         )
-    }
-
-    private static func modeStatus(
-        kind: ArenaModeKind,
-        selectedMode: ArenaModeKind,
-        isAvailable: Bool
-    ) -> String {
-        guard isAvailable else {
-            return "LOCKED"
-        }
-
-        return kind == selectedMode ? "SELECTED" : "AVAILABLE"
     }
 
     private static func formatTime(_ time: TimeInterval) -> String {

--- a/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
+++ b/TiltArena/Game/Weapons/PickupSpawnPlanner.swift
@@ -57,15 +57,23 @@ struct PickupSpawnPlanner {
     private var nextCandidateIndex = 0
     private var timeUntilNextSpawn: TimeInterval
 
-    init(configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()) {
+    init(
+        configuration: PickupSpawnConfiguration = PickupSpawnConfiguration(),
+        sequenceSeed: Int? = nil
+    ) {
         timeUntilNextSpawn = configuration.initialSpawnDelay
+        applySequenceSeed(sequenceSeed, configuration: configuration)
     }
 
-    mutating func reset(configuration: PickupSpawnConfiguration = PickupSpawnConfiguration()) {
+    mutating func reset(
+        configuration: PickupSpawnConfiguration = PickupSpawnConfiguration(),
+        sequenceSeed: Int? = nil
+    ) {
         nextPickupID = 1
         nextKindIndex = 0
         nextCandidateIndex = 0
         timeUntilNextSpawn = configuration.initialSpawnDelay
+        applySequenceSeed(sequenceSeed, configuration: configuration)
     }
 
     mutating func update(
@@ -184,6 +192,20 @@ struct PickupSpawnPlanner {
             x: rect.minX + rect.width * normalized.x,
             y: rect.minY + rect.height * normalized.y
         )
+    }
+
+    private mutating func applySequenceSeed(_ seed: Int?, configuration: PickupSpawnConfiguration) {
+        guard let seed else {
+            return
+        }
+
+        nextKindIndex = positiveModulo(seed, max(1, configuration.weaponKindCycle.count))
+        nextCandidateIndex = positiveModulo(seed / 3, Self.candidatePositions.count)
+    }
+
+    private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+        let remainder = value % divisor
+        return remainder >= 0 ? remainder : remainder + divisor
     }
 
 }

--- a/TiltArenaTests/ArenaMenuContentTests.swift
+++ b/TiltArenaTests/ArenaMenuContentTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import TiltArena
 
 final class ArenaMenuContentTests: XCTestCase {
-    func testModeRowsKeepClassicAvailableAndGateMockModesFromProfile() {
+    func testModeRowsUseModeRulesForAvailabilityAndStatus() {
         var profile = RunProfile()
 
         var rows = ArenaMenuContent.modeRows(profile: profile, selectedMode: .classic)
@@ -19,6 +19,18 @@ final class ArenaMenuContentTests: XCTestCase {
         XCTAssertEqual(rows[1].statusText, "AVAILABLE")
         XCTAssertTrue(rows[2].isAvailable)
         XCTAssertEqual(rows[2].statusText, "AVAILABLE")
+    }
+
+    func testActiveUnlockTextComesFromModeRules() {
+        var profile = RunProfile()
+
+        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "REDLINE 0/5000")
+
+        profile.bestScore = 5_000
+        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "DAILY 0/400")
+
+        profile.totalEnemiesDestroyed = 400
+        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "ALL LOCAL MODES READY")
     }
 
     func testAwardRowsUseProfileDataAndMarkPlaceholderProgress() {

--- a/TiltArenaTests/ArenaModeRulesTests.swift
+++ b/TiltArenaTests/ArenaModeRulesTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import TiltArena
+
+final class ArenaModeRulesTests: XCTestCase {
+    func testAvailabilityUsesCurrentProgressionProxies() {
+        var profile = RunProfile()
+
+        XCTAssertTrue(ArenaModeRules.isAvailable(.classic, profile: profile))
+        XCTAssertFalse(ArenaModeRules.isAvailable(.redline, profile: profile))
+        XCTAssertFalse(ArenaModeRules.isAvailable(.daily, profile: profile))
+
+        profile.bestScore = ArenaModeRules.redlineBestScoreRequirement
+        XCTAssertTrue(ArenaModeRules.isAvailable(.redline, profile: profile))
+        XCTAssertFalse(ArenaModeRules.isAvailable(.daily, profile: profile))
+
+        profile.totalEnemiesDestroyed = ArenaModeRules.dailyEnemyUnlockRequirement
+        XCTAssertTrue(ArenaModeRules.isAvailable(.daily, profile: profile))
+    }
+
+    func testRedlineStartsFasterDenserAndBiasesMovementControlWeapons() {
+        let classic = ArenaModeRules.runSettings(for: .classic)
+        let redline = ArenaModeRules.runSettings(for: .redline)
+        let classicWarmup = classic.enemySpawnConfiguration.tuning(at: 0)
+        let redlineWarmup = redline.enemySpawnConfiguration.tuning(at: 0)
+
+        XCTAssertLessThan(redlineWarmup.chaserSpawnInterval, classicWarmup.chaserSpawnInterval)
+        XCTAssertGreaterThan(redlineWarmup.chaserSpeed, classicWarmup.chaserSpeed)
+        XCTAssertGreaterThan(redlineWarmup.maxActiveEnemies, classicWarmup.maxActiveEnemies)
+        XCTAssertNotNil(redlineWarmup.formationSpawnInterval)
+
+        let panicWeapons: Set<WeaponKind> = [.shockwave, .seekerSwarm, .razorShield, .novaBomb]
+        let movementControlWeapons: Set<WeaponKind> = [
+            .freezeBurst,
+            .gravityWell,
+            .chainLightning,
+            .flameTrail,
+            .warpDash,
+            .decoyBeacon
+        ]
+        let cycle = redline.pickupSpawnConfiguration.weaponKindCycle
+        let panicCount = cycle.filter { panicWeapons.contains($0) }.count
+        let movementControlCount = cycle.filter { movementControlWeapons.contains($0) }.count
+
+        XCTAssertGreaterThan(movementControlCount, panicCount)
+        XCTAssertLessThan(
+            cycle.filter { $0 == .shockwave }.count,
+            classic.pickupSpawnConfiguration.weaponKindCycle.filter { $0 == .shockwave }.count
+        )
+        XCTAssertFalse(cycle.contains(.novaBomb))
+    }
+
+    func testDailyUsesClassicBalanceWithStableLocalDaySeed() throws {
+        let calendar = utcCalendar()
+        let firstDate = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 21)))
+        let sameDayLater = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 5,
+            day: 21,
+            hour: 23,
+            minute: 30
+        )))
+        let nextDate = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 22)))
+
+        let classic = ArenaModeRules.runSettings(for: .classic)
+        let first = ArenaModeRules.runSettings(for: .daily, date: firstDate, calendar: calendar)
+        let sameDay = ArenaModeRules.runSettings(for: .daily, date: sameDayLater, calendar: calendar)
+        let nextDay = ArenaModeRules.runSettings(for: .daily, date: nextDate, calendar: calendar)
+
+        XCTAssertEqual(first.enemySpawnConfiguration, classic.enemySpawnConfiguration)
+        XCTAssertEqual(first.pickupSpawnConfiguration, classic.pickupSpawnConfiguration)
+        XCTAssertEqual(first.sequenceSeed, sameDay.sequenceSeed)
+        XCTAssertNotEqual(first.sequenceSeed, nextDay.sequenceSeed)
+        XCTAssertEqual(first.sequenceSeed, 20_260_521)
+    }
+
+    private func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        return calendar
+    }
+}

--- a/TiltArenaTests/EnemySpawnDirectorTests.swift
+++ b/TiltArenaTests/EnemySpawnDirectorTests.swift
@@ -66,6 +66,26 @@ final class EnemySpawnDirectorTests: XCTestCase {
         XCTAssertTrue(cappedFrame.newEnemies.isEmpty)
     }
 
+    func testSequenceSeedOffsetsChaserSpawnsRepeatably() {
+        var configuration = EnemySpawnConfiguration()
+        configuration.playerSafetyRadius = 0
+        configuration.warmup = EnemyPhaseTuning(
+            chaserSpawnInterval: 1,
+            chaserSpeed: 50,
+            maxActiveEnemies: 3,
+            formationSpawnInterval: nil,
+            formationSpeed: 80,
+            formationLaneCount: 5
+        )
+
+        let firstSeedFrame = firstChaserFrame(configuration: configuration, sequenceSeed: 20_260_521)
+        let repeatSeedFrame = firstChaserFrame(configuration: configuration, sequenceSeed: 20_260_521)
+        let nextSeedFrame = firstChaserFrame(configuration: configuration, sequenceSeed: 20_260_522)
+
+        XCTAssertEqual(firstSeedFrame.newEnemies.first?.position, repeatSeedFrame.newEnemies.first?.position)
+        XCTAssertNotEqual(firstSeedFrame.newEnemies.first?.position, nextSeedFrame.newEnemies.first?.position)
+    }
+
     func testEnemyTelegraphsBeforeSpawningAndLeavesPlayerLaneGap() {
         var configuration = formationTestConfiguration()
         configuration.playerSafetyRadius = 20
@@ -511,4 +531,16 @@ final class EnemySpawnDirectorTests: XCTestCase {
         lhs.dx * rhs.dx + lhs.dy * rhs.dy
     }
 
+}
+
+private func firstChaserFrame(configuration: EnemySpawnConfiguration, sequenceSeed: Int) -> EnemySpawnFrame {
+    var director = EnemySpawnDirector(configuration: configuration, sequenceSeed: sequenceSeed)
+    return director.update(
+        deltaTime: 0.1,
+        survivalTime: 0,
+        activeEnemies: [],
+        playableRect: CGRect(x: 0, y: 0, width: 320, height: 600),
+        playerPosition: CGPoint(x: 160, y: 300),
+        pickupCircles: []
+    )
 }

--- a/TiltArenaTests/PickupSpawnPlannerTests.swift
+++ b/TiltArenaTests/PickupSpawnPlannerTests.swift
@@ -148,6 +148,35 @@ final class PickupSpawnPlannerTests: XCTestCase {
         ])
     }
 
+    func testSequenceSeedOffsetsPickupOrderRepeatably() {
+        let configuration = PickupSpawnConfiguration(initialSpawnDelay: 0)
+        let firstSeedKinds = spawnKinds(count: 4, configuration: configuration, sequenceSeed: 20_260_521)
+        let repeatSeedKinds = spawnKinds(count: 4, configuration: configuration, sequenceSeed: 20_260_521)
+        let nextSeedKinds = spawnKinds(count: 4, configuration: configuration, sequenceSeed: 20_260_522)
+
+        XCTAssertEqual(firstSeedKinds, repeatSeedKinds)
+        XCTAssertNotEqual(firstSeedKinds, nextSeedKinds)
+    }
+
+    func testSequenceSeedUsesActivePickupCycleLength() {
+        let configuration = PickupSpawnConfiguration(
+            initialSpawnDelay: 0,
+            weaponKindCycle: [
+                .shockwave,
+                .warpDash,
+                .freezeBurst,
+                .gravityWell,
+                .chainLightning,
+                .novaBomb
+            ]
+        )
+
+        XCTAssertEqual(
+            spawnKinds(count: 1, configuration: configuration, sequenceSeed: 25),
+            [.warpDash]
+        )
+    }
+
     func testDefaultKindCycleMakesLateControlWeaponsRareAndNovaBombLast() {
         let kinds = spawnKinds(
             count: PickupSpawnConfiguration.defaultWeaponKindCycle.count,
@@ -192,8 +221,12 @@ final class PickupSpawnPlannerTests: XCTestCase {
         ))
     }
 
-    private func spawnKinds(count: Int, configuration: PickupSpawnConfiguration) -> [WeaponKind] {
-        var planner = PickupSpawnPlanner(configuration: configuration)
+    private func spawnKinds(
+        count: Int,
+        configuration: PickupSpawnConfiguration,
+        sequenceSeed: Int? = nil
+    ) -> [WeaponKind] {
+        var planner = PickupSpawnPlanner(configuration: configuration, sequenceSeed: sequenceSeed)
         let rect = CGRect(x: 0, y: 0, width: 320, height: 640)
         let playerPosition = CGPoint(x: -1_000, y: -1_000)
 


### PR DESCRIPTION
## Summary
- adds `ArenaModeRules` for Classic, Redline, and Daily availability, display text, and run settings
- applies selected mode enemy tuning, pickup tuning, and local Daily sequence seeds before each run reset
- adds focused coverage for menu availability, Redline tuning, Daily repeatability, and seeded spawn offsets

Closes #11

## Validation
- `git diff --check`
- `xcodegen generate`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`

XCTest execution was not run because CoreSimulator is unavailable in this environment: `xcodebuild -showdestinations` only reports placeholder simulator destinations and `xcrun simctl list devices available` cannot connect to `CoreSimulatorService`.
