### PR TITLE
Add progression, awards, unlocks, and profile storage

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -18,6 +18,7 @@ final class ArenaScene: SKScene {
     private var optionsReturnState: ArenaUISceneState = .home
     private var selectedMode: ArenaModeKind = .classic
     private var previousBestScore = 0
+    private var lastProgressionResult: ArenaProgressionResult?
     private var resetDataArmed = false
     private var hasPersistedFinalRun = false
     private var readyHoldController = ReadyStartHoldController()
@@ -344,7 +345,7 @@ final class ArenaScene: SKScene {
 
     private func finishRun(playFeedback: Bool = true) {
         previousBestScore = runProfile.bestScore
-        runController.endRun()
+        runController.endRun(mode: selectedMode)
         persistFinalRunIfNeeded()
         if playFeedback {
             playDeathFeedback()
@@ -354,6 +355,7 @@ final class ArenaScene: SKScene {
 
     private func resetActiveRun() {
         hasPersistedFinalRun = false
+        lastProgressionResult = nil
         resetGameplayObjects()
         placePlayer(resetPosition: true)
         resetPlayerFeedback()
@@ -389,7 +391,7 @@ final class ArenaScene: SKScene {
     }
 
     private func applySelectedModeRunSettings() -> ArenaModeRunSettings {
-        let settings = ArenaModeRules.runSettings(for: selectedMode)
+        let settings = ArenaModeRules.runSettings(for: selectedMode, profile: runProfile)
         spawnDirector.configuration = settings.enemySpawnConfiguration
         pickupSpawnConfiguration = settings.pickupSpawnConfiguration
         return settings
@@ -889,7 +891,9 @@ final class ArenaScene: SKScene {
             return
         }
 
-        runProfile = runProfileStore.record(summary)
+        let result = runProfileStore.record(summary)
+        runProfile = result.profile
+        lastProgressionResult = result
         hasPersistedFinalRun = true
     }
 
@@ -1276,7 +1280,8 @@ private extension ArenaScene {
         let highlights = ArenaMenuContent.postRunHighlights(
             summary: summary,
             profile: runProfile,
-            previousBestScore: previousBestScore
+            previousBestScore: previousBestScore,
+            progressionResult: lastProgressionResult
         )
         for (index, text) in highlights.enumerated() {
             addSmallLabel(
@@ -1435,6 +1440,7 @@ private extension ArenaScene {
         localOptionsStore.reset()
         runProfile = RunProfile()
         localOptions = .defaults
+        lastProgressionResult = nil
         selectedMode = .classic
         resetDataArmed = false
         rebuildUI()
@@ -1600,8 +1606,7 @@ private extension ArenaScene {
         )
         addProgressBar(
             frame: CGRect(x: frame.minX + 12, y: frame.minY + 9, width: frame.width - 24, height: 5),
-            fraction: row.progressFraction,
-            placeholder: row.isPlaceholderProgress
+            fraction: row.progressFraction
         )
     }
 
@@ -1644,7 +1649,7 @@ private extension ArenaScene {
         uiRoot.addChild(panel)
     }
 
-    func addProgressBar(frame: CGRect, fraction: Double, placeholder: Bool) {
+    func addProgressBar(frame: CGRect, fraction: Double) {
         let background = SKShapeNode(rect: frame, cornerRadius: 2)
         background.zPosition = ArenaUIZPosition.control
         background.fillColor = theme.borderColor.withAlphaComponent(0.18)
@@ -1661,7 +1666,7 @@ private extension ArenaScene {
             cornerRadius: 2
         )
         fill.zPosition = ArenaUIZPosition.controlFill
-        fill.fillColor = (placeholder ? theme.pickupAmber : theme.playerAccentColor).withAlphaComponent(0.85)
+        fill.fillColor = theme.playerAccentColor.withAlphaComponent(0.85)
         fill.strokeColor = .clear
         uiRoot.addChild(fill)
     }

--- a/TiltArena/Game/Run/ArenaModeRules.swift
+++ b/TiltArena/Game/Run/ArenaModeRules.swift
@@ -7,17 +7,16 @@ struct ArenaModeRunSettings: Equatable {
 }
 
 struct ArenaModeRules {
-    static let redlineBestScoreRequirement = 5_000
-    static let dailyEnemyUnlockRequirement = 400
+    static let redlineBestScoreRequirement = ArenaProgressionRules.redlineBestScoreRequirement
 
     static func isAvailable(_ mode: ArenaModeKind, profile: RunProfile) -> Bool {
         switch mode {
         case .classic:
             return true
         case .redline:
-            return profile.bestScore >= redlineBestScoreRequirement
+            return ArenaProgressionRules.isRedlineAvailable(profile: profile)
         case .daily:
-            return profile.totalEnemiesDestroyed >= dailyEnemyUnlockRequirement
+            return ArenaProgressionRules.isDailyAvailable(profile: profile)
         }
     }
 
@@ -47,47 +46,58 @@ struct ArenaModeRules {
         case .redline:
             return "\(min(profile.bestScore, redlineBestScoreRequirement))/\(redlineBestScoreRequirement) CLASSIC BEST"
         case .daily:
-            return "\(min(profile.totalEnemiesDestroyed, dailyEnemyUnlockRequirement))/\(dailyEnemyUnlockRequirement) UNLOCK TRACK"
+            return "\(ArenaProgressionRules.unlockedWeapons(for: profile).count)/\(ArenaProgressionRules.allGameplayWeapons.count) WEAPONS"
         }
     }
 
     static func activeUnlockText(profile: RunProfile) -> String {
-        if !isAvailable(.redline, profile: profile) {
-            return "REDLINE \(min(profile.bestScore, redlineBestScoreRequirement))/\(redlineBestScoreRequirement)"
-        }
-
-        if !isAvailable(.daily, profile: profile) {
-            return "DAILY \(min(profile.totalEnemiesDestroyed, dailyEnemyUnlockRequirement))/\(dailyEnemyUnlockRequirement)"
-        }
-
-        return "ALL LOCAL MODES READY"
+        ArenaProgressionRules.nextUnlockText(profile: profile)
     }
 
     static func runSettings(
         for mode: ArenaModeKind,
+        profile: RunProfile? = nil,
         date: Date = Date(),
         calendar: Calendar = .current
     ) -> ArenaModeRunSettings {
+        let settings: ArenaModeRunSettings
+
         switch mode {
         case .classic:
-            return ArenaModeRunSettings(
+            settings = ArenaModeRunSettings(
                 enemySpawnConfiguration: EnemySpawnConfiguration(),
                 pickupSpawnConfiguration: PickupSpawnConfiguration(),
                 sequenceSeed: nil
             )
         case .redline:
-            return ArenaModeRunSettings(
+            settings = ArenaModeRunSettings(
                 enemySpawnConfiguration: redlineEnemySpawnConfiguration(),
                 pickupSpawnConfiguration: redlinePickupSpawnConfiguration(),
                 sequenceSeed: nil
             )
         case .daily:
-            return ArenaModeRunSettings(
+            settings = ArenaModeRunSettings(
                 enemySpawnConfiguration: EnemySpawnConfiguration(),
                 pickupSpawnConfiguration: PickupSpawnConfiguration(),
                 sequenceSeed: dailySeed(for: date, calendar: calendar)
             )
         }
+
+        guard let profile else {
+            return settings
+        }
+
+        var pickupSpawnConfiguration = settings.pickupSpawnConfiguration
+        pickupSpawnConfiguration.weaponKindCycle = ArenaProgressionRules.filteredWeaponCycle(
+            pickupSpawnConfiguration.weaponKindCycle,
+            profile: profile
+        )
+
+        return ArenaModeRunSettings(
+            enemySpawnConfiguration: settings.enemySpawnConfiguration,
+            pickupSpawnConfiguration: pickupSpawnConfiguration,
+            sequenceSeed: settings.sequenceSeed
+        )
     }
 
     static func dailySeed(for date: Date = Date(), calendar: Calendar = .current) -> Int {

--- a/TiltArena/Game/Run/ArenaProgressionRules.swift
+++ b/TiltArena/Game/Run/ArenaProgressionRules.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+enum ArenaAwardID: String, CaseIterable, Codable, Equatable {
+    case comboSpark
+    case scoreCrest
+    case freezeShatter
+    case dangerGrab
+    case weaponMaster
+    case survivor
+
+    var displayName: String {
+        switch self {
+        case .comboSpark:
+            return "Combo Spark"
+        case .scoreCrest:
+            return "Score Crest"
+        case .freezeShatter:
+            return "Freeze Shatter"
+        case .dangerGrab:
+            return "Danger Grab"
+        case .weaponMaster:
+            return "Weapon Master"
+        case .survivor:
+            return "Survivor"
+        }
+    }
+}
+
+struct ArenaProgressionResult: Equatable {
+    let profile: RunProfile
+    let newlyUnlockedWeapons: [WeaponKind]
+    let newlyEarnedAwardIDs: [ArenaAwardID]
+}
+
+struct WeaponUnlockMilestone: Equatable {
+    let weapon: WeaponKind
+    let requirement: ArenaProgressionRequirement
+}
+
+enum ArenaProgressionRequirement: Equatable {
+    case totalEnemiesDestroyed(Int)
+    case bestScore(Int)
+    case highestCombo(Int)
+
+    var target: Int {
+        switch self {
+        case let .totalEnemiesDestroyed(target), let .bestScore(target), let .highestCombo(target):
+            return target
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .totalEnemiesDestroyed:
+            return "KILLS"
+        case .bestScore:
+            return "BEST"
+        case .highestCombo:
+            return "COMBO"
+        }
+    }
+
+    func progress(in profile: RunProfile) -> Int {
+        switch self {
+        case .totalEnemiesDestroyed:
+            return profile.totalEnemiesDestroyed
+        case .bestScore:
+            return profile.bestScore
+        case .highestCombo:
+            return profile.highestCombo
+        }
+    }
+
+    func isMet(by profile: RunProfile) -> Bool {
+        progress(in: profile) >= target
+    }
+}
+
+struct ArenaAwardProgress: Equatable {
+    let title: String
+    let progress: Int
+    let target: Int
+    let isComplete: Bool
+}
+
+struct ArenaProgressionRules {
+    static let redlineBestScoreRequirement = 5_000
+
+    static let startingWeapons: [WeaponKind] = [
+        .shockwave,
+        .seekerSwarm,
+        .razorShield
+    ]
+
+    static let weaponUnlockMilestones: [WeaponUnlockMilestone] = [
+        WeaponUnlockMilestone(weapon: .freezeBurst, requirement: .totalEnemiesDestroyed(50)),
+        WeaponUnlockMilestone(weapon: .gravityWell, requirement: .totalEnemiesDestroyed(100)),
+        WeaponUnlockMilestone(weapon: .flameTrail, requirement: .bestScore(1_500)),
+        WeaponUnlockMilestone(weapon: .chainLightning, requirement: .totalEnemiesDestroyed(175)),
+        WeaponUnlockMilestone(weapon: .warpDash, requirement: .highestCombo(20)),
+        WeaponUnlockMilestone(weapon: .decoyBeacon, requirement: .bestScore(3_000)),
+        WeaponUnlockMilestone(weapon: .novaBomb, requirement: .totalEnemiesDestroyed(300))
+    ]
+
+    static var allGameplayWeapons: [WeaponKind] {
+        startingWeapons + weaponUnlockMilestones.map(\.weapon)
+    }
+
+    static func unlockedWeapons(for profile: RunProfile) -> [WeaponKind] {
+        var unlockedWeapons = Set(startingWeapons)
+        unlockedWeapons.formUnion(profile.unlockedWeapons)
+
+        for milestone in weaponUnlockMilestones where milestone.requirement.isMet(by: profile) {
+            unlockedWeapons.insert(milestone.weapon)
+        }
+
+        return allGameplayWeapons.filter { unlockedWeapons.contains($0) }
+    }
+
+    static func newlyUnlockedWeapons(before previousProfile: RunProfile, after updatedProfile: RunProfile) -> [WeaponKind] {
+        let previous = Set(unlockedWeapons(for: previousProfile))
+        let updated = Set(unlockedWeapons(for: updatedProfile))
+
+        return weaponUnlockMilestones
+            .map(\.weapon)
+            .filter { updated.contains($0) && !previous.contains($0) }
+    }
+
+    static func allGameplayWeaponsUnlocked(profile: RunProfile) -> Bool {
+        Set(unlockedWeapons(for: profile)) == Set(allGameplayWeapons)
+    }
+
+    static func isRedlineAvailable(profile: RunProfile) -> Bool {
+        profile.bestScore >= redlineBestScoreRequirement
+    }
+
+    static func isDailyAvailable(profile: RunProfile) -> Bool {
+        allGameplayWeaponsUnlocked(profile: profile)
+    }
+
+    static func filteredWeaponCycle(_ cycle: [WeaponKind], profile: RunProfile) -> [WeaponKind] {
+        let unlocked = Set(unlockedWeapons(for: profile))
+        let filteredCycle = cycle.filter { unlocked.contains($0) }
+        return filteredCycle.isEmpty ? startingWeapons : filteredCycle
+    }
+
+    static func nextUnlockText(profile: RunProfile) -> String {
+        if let milestone = weaponUnlockMilestones.first(where: { !unlockedWeapons(for: profile).contains($0.weapon) }) {
+            return unlockText(
+                title: "NEXT \(milestone.weapon.displayName.uppercased())",
+                progress: milestone.requirement.progress(in: profile),
+                target: milestone.requirement.target,
+                label: milestone.requirement.label
+            )
+        }
+
+        if !isRedlineAvailable(profile: profile) {
+            return unlockText(
+                title: "REDLINE",
+                progress: profile.bestScore,
+                target: redlineBestScoreRequirement,
+                label: "BEST"
+            )
+        }
+
+        return "ALL LOCAL MODES READY"
+    }
+
+    static func awardProgress(for id: ArenaAwardID, profile: RunProfile) -> ArenaAwardProgress {
+        let progress: Int
+        let target: Int
+
+        switch id {
+        case .comboSpark:
+            progress = profile.highestCombo
+            target = 10
+        case .scoreCrest:
+            progress = profile.bestScore
+            target = 5_000
+        case .freezeShatter:
+            progress = profile.totalEnemiesDestroyed
+            target = 25
+        case .dangerGrab:
+            progress = profile.totalRuns
+            target = 5
+        case .weaponMaster:
+            progress = unlockedWeapons(for: profile).count
+            target = allGameplayWeapons.count
+        case .survivor:
+            progress = Int(profile.longestSurvivalTime)
+            target = 120
+        }
+
+        let clampedTarget = max(1, target)
+        let clampedProgress = max(0, min(progress, clampedTarget))
+
+        return ArenaAwardProgress(
+            title: id.displayName.uppercased(),
+            progress: clampedProgress,
+            target: clampedTarget,
+            isComplete: clampedProgress >= clampedTarget
+        )
+    }
+
+    static func completedAwardIDs(for profile: RunProfile) -> [ArenaAwardID] {
+        ArenaAwardID.allCases.filter { awardProgress(for: $0, profile: profile).isComplete }
+    }
+
+    static func newlyEarnedAwardIDs(before previousProfile: RunProfile, after updatedProfile: RunProfile) -> [ArenaAwardID] {
+        let previous = previousProfile.earnedAwardIDs.union(completedAwardIDs(for: previousProfile))
+        let updated = Set(completedAwardIDs(for: updatedProfile))
+
+        return ArenaAwardID.allCases.filter { updated.contains($0) && !previous.contains($0) }
+    }
+
+    static func awardSummaryText(ids: [ArenaAwardID]) -> String? {
+        guard !ids.isEmpty else {
+            return nil
+        }
+
+        let names = ids.prefix(2).map { $0.displayName.uppercased() }
+        let suffix = ids.count > 2 ? " +\(ids.count - 2)" : ""
+        return "AWARDS \(names.joined(separator: ", "))\(suffix)"
+    }
+
+    static func unlockSummaryText(weapons: [WeaponKind]) -> String? {
+        guard !weapons.isEmpty else {
+            return nil
+        }
+
+        let names = weapons.prefix(2).map { $0.displayName.uppercased() }
+        let suffix = weapons.count > 2 ? " +\(weapons.count - 2)" : ""
+        return "UNLOCK \(names.joined(separator: ", "))\(suffix)"
+    }
+
+    static func normalizedUnlockedWeapons(_ weapons: Set<WeaponKind>) -> Set<WeaponKind> {
+        Set(allGameplayWeapons).intersection(weapons).union(startingWeapons)
+    }
+
+    private static func unlockText(title: String, progress: Int, target: Int, label: String) -> String {
+        "\(title) \(min(max(0, progress), target))/\(target) \(label)"
+    }
+}

--- a/TiltArena/Game/Run/ClassicRunController.swift
+++ b/TiltArena/Game/Run/ClassicRunController.swift
@@ -37,6 +37,46 @@ struct RunSummary: Codable, Equatable {
     let enemiesDestroyed: Int
     let bestWeapon: WeaponKind?
     let timestamp: Date
+    let mode: ArenaModeKind
+
+    private enum CodingKeys: String, CodingKey {
+        case score
+        case survivalTime
+        case maxCombo
+        case enemiesDestroyed
+        case bestWeapon
+        case timestamp
+        case mode
+    }
+
+    init(
+        score: Int,
+        survivalTime: TimeInterval,
+        maxCombo: Int,
+        enemiesDestroyed: Int,
+        bestWeapon: WeaponKind?,
+        timestamp: Date,
+        mode: ArenaModeKind = .classic
+    ) {
+        self.score = score
+        self.survivalTime = survivalTime
+        self.maxCombo = maxCombo
+        self.enemiesDestroyed = enemiesDestroyed
+        self.bestWeapon = bestWeapon
+        self.timestamp = timestamp
+        self.mode = mode
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        score = try container.decode(Int.self, forKey: .score)
+        survivalTime = try container.decode(TimeInterval.self, forKey: .survivalTime)
+        maxCombo = try container.decode(Int.self, forKey: .maxCombo)
+        enemiesDestroyed = try container.decode(Int.self, forKey: .enemiesDestroyed)
+        bestWeapon = try container.decodeIfPresent(WeaponKind.self, forKey: .bestWeapon)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        mode = try container.decodeIfPresent(ArenaModeKind.self, forKey: .mode) ?? .classic
+    }
 }
 
 struct ClassicRunController {
@@ -79,7 +119,7 @@ struct ClassicRunController {
         phase = .active
     }
 
-    mutating func endRun(at timestamp: Date = Date()) {
+    mutating func endRun(at timestamp: Date = Date(), mode: ArenaModeKind = .classic) {
         guard phase == .active || phase == .paused else {
             return
         }
@@ -91,7 +131,8 @@ struct ClassicRunController {
             maxCombo: maxCombo,
             enemiesDestroyed: enemiesDestroyed,
             bestWeapon: bestWeapon,
-            timestamp: timestamp
+            timestamp: timestamp,
+            mode: mode
         )
     }
 

--- a/TiltArena/Game/Run/RunProfileStore.swift
+++ b/TiltArena/Game/Run/RunProfileStore.swift
@@ -7,8 +7,46 @@ struct RunProfile: Codable, Equatable {
     var totalRuns = 0
     var totalEnemiesDestroyed = 0
     var recentRuns: [RunSummary] = []
+    var unlockedWeapons: Set<WeaponKind> = Set(ArenaProgressionRules.startingWeapons)
+    var earnedAwardIDs: Set<ArenaAwardID> = []
+    var dailyParticipationSeeds: Set<Int> = []
 
-    mutating func record(_ summary: RunSummary, recentRunLimit: Int = 5) {
+    private enum CodingKeys: String, CodingKey {
+        case bestScore
+        case highestCombo
+        case longestSurvivalTime
+        case totalRuns
+        case totalEnemiesDestroyed
+        case recentRuns
+        case unlockedWeapons
+        case earnedAwardIDs
+        case dailyParticipationSeeds
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        bestScore = try container.decodeIfPresent(Int.self, forKey: .bestScore) ?? 0
+        highestCombo = try container.decodeIfPresent(Int.self, forKey: .highestCombo) ?? 0
+        longestSurvivalTime = try container.decodeIfPresent(TimeInterval.self, forKey: .longestSurvivalTime) ?? 0
+        totalRuns = try container.decodeIfPresent(Int.self, forKey: .totalRuns) ?? 0
+        totalEnemiesDestroyed = try container.decodeIfPresent(Int.self, forKey: .totalEnemiesDestroyed) ?? 0
+        recentRuns = try container.decodeIfPresent([RunSummary].self, forKey: .recentRuns) ?? []
+        unlockedWeapons = try container.decodeIfPresent(Set<WeaponKind>.self, forKey: .unlockedWeapons) ?? []
+        earnedAwardIDs = try container.decodeIfPresent(Set<ArenaAwardID>.self, forKey: .earnedAwardIDs) ?? []
+        dailyParticipationSeeds = try container.decodeIfPresent(Set<Int>.self, forKey: .dailyParticipationSeeds) ?? []
+
+        unlockedWeapons = ArenaProgressionRules.normalizedUnlockedWeapons(
+            Set(ArenaProgressionRules.unlockedWeapons(for: self))
+        )
+        earnedAwardIDs.formUnion(ArenaProgressionRules.completedAwardIDs(for: self))
+    }
+
+    @discardableResult
+    mutating func record(_ summary: RunSummary, recentRunLimit: Int = 5) -> ArenaProgressionResult {
+        let previousProfile = self
+
         bestScore = max(bestScore, summary.score)
         highestCombo = max(highestCombo, summary.maxCombo)
         longestSurvivalTime = max(longestSurvivalTime, summary.survivalTime)
@@ -17,6 +55,30 @@ struct RunProfile: Codable, Equatable {
 
         recentRuns.insert(summary, at: 0)
         recentRuns = Array(recentRuns.prefix(max(0, recentRunLimit)))
+
+        if summary.mode == .daily {
+            dailyParticipationSeeds.insert(ArenaModeRules.dailySeed(for: summary.timestamp))
+        }
+
+        let newlyUnlockedWeapons = ArenaProgressionRules.newlyUnlockedWeapons(
+            before: previousProfile,
+            after: self
+        )
+        unlockedWeapons = ArenaProgressionRules.normalizedUnlockedWeapons(
+            Set(ArenaProgressionRules.unlockedWeapons(for: self))
+        )
+
+        let newlyEarnedAwardIDs = ArenaProgressionRules.newlyEarnedAwardIDs(
+            before: previousProfile,
+            after: self
+        )
+        earnedAwardIDs.formUnion(ArenaProgressionRules.completedAwardIDs(for: self))
+
+        return ArenaProgressionResult(
+            profile: self,
+            newlyUnlockedWeapons: newlyUnlockedWeapons,
+            newlyEarnedAwardIDs: newlyEarnedAwardIDs
+        )
     }
 }
 
@@ -49,11 +111,11 @@ final class RunProfileStore {
     }
 
     @discardableResult
-    func record(_ summary: RunSummary) -> RunProfile {
+    func record(_ summary: RunSummary) -> ArenaProgressionResult {
         var updatedProfile = profile
-        updatedProfile.record(summary)
+        let result = updatedProfile.record(summary)
         profile = updatedProfile
-        return updatedProfile
+        return result
     }
 
     func reset() {

--- a/TiltArena/Game/UI/ArenaMenuModels.swift
+++ b/TiltArena/Game/UI/ArenaMenuModels.swift
@@ -14,7 +14,6 @@ struct ArenaAwardRow: Equatable {
     let progressText: String
     let progressFraction: Double
     let isComplete: Bool
-    let isPlaceholderProgress: Bool
 }
 
 struct ArenaMenuContent {
@@ -32,44 +31,7 @@ struct ArenaMenuContent {
     }
 
     static func awardRows(profile: RunProfile) -> [ArenaAwardRow] {
-        [
-            award(
-                title: "COMBO SPARK",
-                progress: profile.highestCombo,
-                target: 10,
-                placeholder: false
-            ),
-            award(
-                title: "SCORE CREST",
-                progress: profile.bestScore,
-                target: 5_000,
-                placeholder: false
-            ),
-            award(
-                title: "FREEZE SHATTER",
-                progress: min(profile.totalEnemiesDestroyed, 25),
-                target: 25,
-                placeholder: true
-            ),
-            award(
-                title: "DANGER GRAB",
-                progress: min(profile.totalRuns, 5),
-                target: 5,
-                placeholder: true
-            ),
-            award(
-                title: "WEAPON MASTER",
-                progress: profile.totalEnemiesDestroyed,
-                target: 250,
-                placeholder: true
-            ),
-            award(
-                title: "SURVIVOR",
-                progress: Int(profile.longestSurvivalTime),
-                target: 120,
-                placeholder: false
-            )
-        ]
+        ArenaAwardID.allCases.map { award(id: $0, profile: profile) }
     }
 
     static func activeUnlockText(profile: RunProfile) -> String {
@@ -79,37 +41,46 @@ struct ArenaMenuContent {
     static func postRunHighlights(
         summary: RunSummary?,
         profile: RunProfile,
-        previousBestScore: Int
+        previousBestScore: Int,
+        progressionResult: ArenaProgressionResult? = nil
     ) -> [String] {
         guard let summary else {
             return ["NO RUN SUMMARY"]
         }
 
         let bestText = summary.score > previousBestScore ? "NEW BEST" : "BEST \(profile.bestScore)"
-        return [
+        var highlights = [
             bestText,
             "TIME \(formatTime(summary.survivalTime))",
             "MAX COMBO \(summary.maxCombo)",
             "KILLS \(summary.enemiesDestroyed)",
-            "WEAPON \(summary.bestWeapon?.displayName.uppercased() ?? "NONE")",
-            activeUnlockText(profile: profile)
+            "WEAPON \(summary.bestWeapon?.displayName.uppercased() ?? "NONE")"
         ]
+
+        if let unlockText = ArenaProgressionRules.unlockSummaryText(
+            weapons: progressionResult?.newlyUnlockedWeapons ?? []
+        ) {
+            highlights.append(unlockText)
+        }
+
+        if let awardText = ArenaProgressionRules.awardSummaryText(
+            ids: progressionResult?.newlyEarnedAwardIDs ?? []
+        ) {
+            highlights.append(awardText)
+        }
+
+        highlights.append(activeUnlockText(profile: profile))
+        return highlights
     }
 
-    private static func award(
-        title: String,
-        progress: Int,
-        target: Int,
-        placeholder: Bool
-    ) -> ArenaAwardRow {
-        let clampedTarget = max(1, target)
-        let clampedProgress = max(0, min(progress, clampedTarget))
+    private static func award(id: ArenaAwardID, profile: RunProfile) -> ArenaAwardRow {
+        let progress = ArenaProgressionRules.awardProgress(for: id, profile: profile)
+
         return ArenaAwardRow(
-            title: title,
-            progressText: "\(clampedProgress)/\(clampedTarget)",
-            progressFraction: Double(clampedProgress) / Double(clampedTarget),
-            isComplete: clampedProgress >= clampedTarget,
-            isPlaceholderProgress: placeholder
+            title: progress.title,
+            progressText: "\(progress.progress)/\(progress.target)",
+            progressFraction: Double(progress.progress) / Double(progress.target),
+            isComplete: progress.isComplete
         )
     }
 

--- a/TiltArena/Game/UI/ArenaUISceneState.swift
+++ b/TiltArena/Game/UI/ArenaUISceneState.swift
@@ -9,7 +9,7 @@ enum ArenaUISceneState: Equatable {
     case postRun
 }
 
-enum ArenaModeKind: String, CaseIterable, Equatable {
+enum ArenaModeKind: String, CaseIterable, Codable, Equatable {
     case classic
     case redline
     case daily

--- a/TiltArenaTests/ArenaMenuContentTests.swift
+++ b/TiltArenaTests/ArenaMenuContentTests.swift
@@ -12,11 +12,17 @@ final class ArenaMenuContentTests: XCTestCase {
         XCTAssertFalse(rows[2].isAvailable)
 
         profile.bestScore = 5_000
-        profile.totalEnemiesDestroyed = 400
+        profile.totalEnemiesDestroyed = 300
         rows = ArenaMenuContent.modeRows(profile: profile, selectedMode: .classic)
 
         XCTAssertTrue(rows[1].isAvailable)
         XCTAssertEqual(rows[1].statusText, "AVAILABLE")
+        XCTAssertFalse(rows[2].isAvailable)
+        XCTAssertEqual(rows[2].statusText, "LOCKED")
+
+        profile.highestCombo = 20
+        rows = ArenaMenuContent.modeRows(profile: profile, selectedMode: .classic)
+
         XCTAssertTrue(rows[2].isAvailable)
         XCTAssertEqual(rows[2].statusText, "AVAILABLE")
     }
@@ -24,16 +30,21 @@ final class ArenaMenuContentTests: XCTestCase {
     func testActiveUnlockTextComesFromModeRules() {
         var profile = RunProfile()
 
-        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "REDLINE 0/5000")
+        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "NEXT FREEZE BURST 0/50 KILLS")
+
+        profile.totalEnemiesDestroyed = 50
+        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "NEXT GRAVITY WELL 50/100 KILLS")
+
+        profile.bestScore = 3_000
+        profile.highestCombo = 20
+        profile.totalEnemiesDestroyed = 300
+        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "REDLINE 3000/5000 BEST")
 
         profile.bestScore = 5_000
-        XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "DAILY 0/400")
-
-        profile.totalEnemiesDestroyed = 400
         XCTAssertEqual(ArenaMenuContent.activeUnlockText(profile: profile), "ALL LOCAL MODES READY")
     }
 
-    func testAwardRowsUseProfileDataAndMarkPlaceholderProgress() {
+    func testAwardRowsUseProfileData() {
         var profile = RunProfile()
         profile.bestScore = 2_500
         profile.highestCombo = 8
@@ -44,28 +55,32 @@ final class ArenaMenuContentTests: XCTestCase {
         XCTAssertEqual(rows.first?.title, "COMBO SPARK")
         XCTAssertEqual(rows.first?.progressText, "8/10")
         XCTAssertEqual(rows[1].progressText, "2500/5000")
-        XCTAssertTrue(rows.contains(where: \.isPlaceholderProgress))
+        XCTAssertFalse(rows.first?.isComplete ?? true)
     }
 
-    func testPostRunHighlightsReportNewBestAgainstPreviousBest() {
+    func testPostRunHighlightsReportNewAwardsAndNextUnlock() {
         let summary = RunSummary(
             score: 600,
             survivalTime: 12.5,
-            maxCombo: 7,
-            enemiesDestroyed: 9,
+            maxCombo: 10,
+            enemiesDestroyed: 50,
             bestWeapon: .shockwave,
             timestamp: Date(timeIntervalSince1970: 1)
         )
         var profile = RunProfile()
-        profile.record(summary)
+        let result = profile.record(summary)
 
         let highlights = ArenaMenuContent.postRunHighlights(
             summary: summary,
             profile: profile,
-            previousBestScore: 500
+            previousBestScore: 500,
+            progressionResult: result
         )
 
         XCTAssertEqual(highlights.first, "NEW BEST")
         XCTAssertTrue(highlights.contains("WEAPON SHOCKWAVE"))
+        XCTAssertTrue(highlights.contains("UNLOCK FREEZE BURST"))
+        XCTAssertTrue(highlights.contains("AWARDS COMBO SPARK, FREEZE SHATTER"))
+        XCTAssertEqual(highlights.last, "NEXT GRAVITY WELL 50/100 KILLS")
     }
 }

--- a/TiltArenaTests/ArenaModeRulesTests.swift
+++ b/TiltArenaTests/ArenaModeRulesTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import TiltArena
 
 final class ArenaModeRulesTests: XCTestCase {
-    func testAvailabilityUsesCurrentProgressionProxies() {
+    func testAvailabilityUsesProgressionState() {
         var profile = RunProfile()
 
         XCTAssertTrue(ArenaModeRules.isAvailable(.classic, profile: profile))
@@ -13,7 +13,9 @@ final class ArenaModeRulesTests: XCTestCase {
         XCTAssertTrue(ArenaModeRules.isAvailable(.redline, profile: profile))
         XCTAssertFalse(ArenaModeRules.isAvailable(.daily, profile: profile))
 
-        profile.totalEnemiesDestroyed = ArenaModeRules.dailyEnemyUnlockRequirement
+        profile.bestScore = 3_000
+        profile.highestCombo = 20
+        profile.totalEnemiesDestroyed = 300
         XCTAssertTrue(ArenaModeRules.isAvailable(.daily, profile: profile))
     }
 

--- a/TiltArenaTests/ArenaProgressionRulesTests.swift
+++ b/TiltArenaTests/ArenaProgressionRulesTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import TiltArena
+
+final class ArenaProgressionRulesTests: XCTestCase {
+    func testWeaponUnlockOrderUsesConcreteMilestones() {
+        var profile = RunProfile()
+
+        XCTAssertEqual(ArenaProgressionRules.unlockedWeapons(for: profile), [
+            .shockwave,
+            .seekerSwarm,
+            .razorShield
+        ])
+
+        profile.totalEnemiesDestroyed = 50
+        XCTAssertEqual(ArenaProgressionRules.unlockedWeapons(for: profile), [
+            .shockwave,
+            .seekerSwarm,
+            .razorShield,
+            .freezeBurst
+        ])
+
+        profile.totalEnemiesDestroyed = 100
+        profile.bestScore = 1_500
+        profile.highestCombo = 20
+        XCTAssertEqual(ArenaProgressionRules.unlockedWeapons(for: profile), [
+            .shockwave,
+            .seekerSwarm,
+            .razorShield,
+            .freezeBurst,
+            .gravityWell,
+            .flameTrail,
+            .warpDash
+        ])
+
+        profile.totalEnemiesDestroyed = 300
+        profile.bestScore = 3_000
+        XCTAssertEqual(ArenaProgressionRules.unlockedWeapons(for: profile), ArenaProgressionRules.allGameplayWeapons)
+    }
+
+    func testNewUnlocksAreReportedAfterRunRecord() {
+        var profile = RunProfile()
+
+        let result = profile.record(RunSummary(
+            score: 100,
+            survivalTime: 12,
+            maxCombo: 4,
+            enemiesDestroyed: 50,
+            bestWeapon: .shockwave,
+            timestamp: Date(timeIntervalSince1970: 1)
+        ))
+
+        XCTAssertEqual(result.newlyUnlockedWeapons, [.freezeBurst])
+        XCTAssertTrue(profile.unlockedWeapons.contains(.freezeBurst))
+    }
+
+    func testPickupCyclesFilterToUnlockedWeapons() {
+        var profile = RunProfile()
+
+        var classic = ArenaModeRules.runSettings(for: .classic, profile: profile)
+        XCTAssertEqual(Set(classic.pickupSpawnConfiguration.weaponKindCycle), Set(ArenaProgressionRules.startingWeapons))
+        let daily = ArenaModeRules.runSettings(for: .daily, profile: profile)
+        XCTAssertEqual(Set(daily.pickupSpawnConfiguration.weaponKindCycle), Set(ArenaProgressionRules.startingWeapons))
+
+        profile.totalEnemiesDestroyed = 300
+        profile.bestScore = 3_000
+        profile.highestCombo = 20
+        classic = ArenaModeRules.runSettings(for: .classic, profile: profile)
+        let fullyUnlockedDaily = ArenaModeRules.runSettings(for: .daily, profile: profile)
+
+        XCTAssertEqual(Set(classic.pickupSpawnConfiguration.weaponKindCycle), Set(WeaponKind.allCases))
+        XCTAssertEqual(Set(fullyUnlockedDaily.pickupSpawnConfiguration.weaponKindCycle), Set(WeaponKind.allCases))
+    }
+
+    func testRedlineKeepsModeCycleButFiltersLockedWeapons() {
+        var profile = RunProfile()
+        profile.bestScore = ArenaProgressionRules.redlineBestScoreRequirement
+
+        var redline = ArenaModeRules.runSettings(for: .redline, profile: profile)
+        XCTAssertEqual(Set(redline.pickupSpawnConfiguration.weaponKindCycle), [
+            .shockwave,
+            .seekerSwarm,
+            .razorShield,
+            .flameTrail,
+            .decoyBeacon
+        ])
+        XCTAssertFalse(redline.pickupSpawnConfiguration.weaponKindCycle.contains(.warpDash))
+        XCTAssertFalse(redline.pickupSpawnConfiguration.weaponKindCycle.contains(.novaBomb))
+
+        profile.totalEnemiesDestroyed = 300
+        profile.highestCombo = 20
+        redline = ArenaModeRules.runSettings(for: .redline, profile: profile)
+
+        XCTAssertTrue(redline.pickupSpawnConfiguration.weaponKindCycle.contains(.flameTrail))
+        XCTAssertTrue(redline.pickupSpawnConfiguration.weaponKindCycle.contains(.warpDash))
+        XCTAssertFalse(redline.pickupSpawnConfiguration.weaponKindCycle.contains(.novaBomb))
+    }
+
+    func testAwardCompletionAndNewAwardsUseProfileState() {
+        var profile = RunProfile()
+
+        let result = profile.record(RunSummary(
+            score: 5_000,
+            survivalTime: 120,
+            maxCombo: 10,
+            enemiesDestroyed: 25,
+            bestWeapon: .shockwave,
+            timestamp: Date(timeIntervalSince1970: 1)
+        ))
+
+        XCTAssertEqual(
+            result.newlyEarnedAwardIDs,
+            [.comboSpark, .scoreCrest, .freezeShatter, .survivor]
+        )
+        XCTAssertTrue(profile.earnedAwardIDs.contains(.comboSpark))
+        XCTAssertTrue(profile.earnedAwardIDs.contains(.survivor))
+    }
+}

--- a/TiltArenaTests/RunProfileStoreTests.swift
+++ b/TiltArenaTests/RunProfileStoreTests.swift
@@ -42,9 +42,64 @@ final class RunProfileStoreTests: XCTestCase {
         XCTAssertEqual(reloadedProfile.longestSurvivalTime, 60)
         XCTAssertEqual(reloadedProfile.totalRuns, 6)
         XCTAssertEqual(reloadedProfile.totalEnemiesDestroyed, 63)
+        XCTAssertTrue(reloadedProfile.unlockedWeapons.contains(.freezeBurst))
         XCTAssertEqual(reloadedProfile.recentRuns.count, 5)
         XCTAssertEqual(reloadedProfile.recentRuns.first?.score, 600)
         XCTAssertEqual(reloadedProfile.recentRuns.last?.score, 200)
+    }
+
+    func testOldProfileDecodingDefaultsProgressionFieldsAndClassicRunMode() throws {
+        let oldProfile = OldRunProfile(
+            bestScore: 1_600,
+            highestCombo: 4,
+            longestSurvivalTime: 20,
+            totalRuns: 1,
+            totalEnemiesDestroyed: 55,
+            recentRuns: [
+                OldRunSummary(
+                    score: 1_600,
+                    survivalTime: 20,
+                    maxCombo: 4,
+                    enemiesDestroyed: 55,
+                    bestWeapon: .shockwave,
+                    timestamp: Date(timeIntervalSince1970: 1)
+                )
+            ]
+        )
+
+        let data = try JSONEncoder().encode(oldProfile)
+        let profile = try JSONDecoder().decode(RunProfile.self, from: data)
+
+        XCTAssertEqual(profile.recentRuns.first?.mode, .classic)
+        XCTAssertTrue(profile.unlockedWeapons.contains(.freezeBurst))
+        XCTAssertTrue(profile.unlockedWeapons.contains(.flameTrail))
+        XCTAssertFalse(profile.unlockedWeapons.contains(.gravityWell))
+        XCTAssertEqual(profile.dailyParticipationSeeds, [])
+    }
+
+    func testDailyParticipationAndAwardsPersist() throws {
+        let store = RunProfileStore(defaults: defaults)
+        let timestamp = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2026, month: 5, day: 21)))
+
+        let result = store.record(
+            RunSummary(
+                score: 5_000,
+                survivalTime: 120,
+                maxCombo: 20,
+                enemiesDestroyed: 300,
+                bestWeapon: .novaBomb,
+                timestamp: timestamp,
+                mode: .daily
+            )
+        )
+
+        let reloadedProfile = RunProfileStore(defaults: defaults).profile
+
+        XCTAssertEqual(result.profile.dailyParticipationSeeds, [ArenaModeRules.dailySeed(for: timestamp)])
+        XCTAssertEqual(reloadedProfile.dailyParticipationSeeds, [ArenaModeRules.dailySeed(for: timestamp)])
+        XCTAssertEqual(reloadedProfile.unlockedWeapons, Set(ArenaProgressionRules.allGameplayWeapons))
+        XCTAssertTrue(reloadedProfile.earnedAwardIDs.contains(.comboSpark))
+        XCTAssertTrue(reloadedProfile.earnedAwardIDs.contains(.weaponMaster))
     }
 
     func testMissingOrCorruptProfileFallsBackToEmptyProfile() {
@@ -74,4 +129,22 @@ final class RunProfileStoreTests: XCTestCase {
 
         XCTAssertEqual(store.profile, RunProfile())
     }
+}
+
+private struct OldRunProfile: Encodable {
+    let bestScore: Int
+    let highestCombo: Int
+    let longestSurvivalTime: TimeInterval
+    let totalRuns: Int
+    let totalEnemiesDestroyed: Int
+    let recentRuns: [OldRunSummary]
+}
+
+private struct OldRunSummary: Encodable {
+    let score: Int
+    let survivalTime: TimeInterval
+    let maxCombo: Int
+    let enemiesDestroyed: Int
+    let bestWeapon: WeaponKind?
+    let timestamp: Date
 }


### PR DESCRIPTION
Closes #12

## Summary
- add local progression rules for weapon unlocks, mode gates, award rows, and post-run highlights
- persist unlocked weapons, earned awards, Daily participation days, and mode-aware run summaries with old-save decode defaults
- filter Classic, Daily, and Redline pickup cycles through unlocked weapons while preserving Daily local seed behavior

## Validation
- git diff --check
- xcodegen generate
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing

XCTest execution was not run because CoreSimulator currently only exposes placeholder destinations and simctl fails with CoreSimulator connection refused.