### PR TITLE
Fix gameplay safe area, orientation lock, and tilt mapping

### DIFF
--- a/TiltArena/App/GameViewController.swift
+++ b/TiltArena/App/GameViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 
 final class GameViewController: UIViewController {
     private var hasPresentedScene = false
+    private var lockedOrientationMask: UIInterfaceOrientationMask?
+    private var lastLandscapeOrientation: UIInterfaceOrientation?
 
     override func loadView() {
         view = SKView(frame: .zero)
@@ -15,6 +17,7 @@ final class GameViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        rememberCurrentLandscapeOrientation()
 
         guard let spriteView = view as? SKView else {
             return
@@ -25,6 +28,7 @@ final class GameViewController: UIViewController {
             (spriteView.scene as? ArenaScene)?.refreshSafeAreaLayout()
         } else {
             let scene = ArenaScene(size: spriteView.bounds.size)
+            scene.orientationDelegate = self
             scene.scaleMode = .resizeFill
             spriteView.presentScene(scene)
             scene.refreshSafeAreaLayout()
@@ -37,7 +41,7 @@ final class GameViewController: UIViewController {
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        .landscape
+        lockedOrientationMask ?? .landscape
     }
 
     override var prefersHomeIndicatorAutoHidden: Bool {
@@ -57,5 +61,66 @@ final class GameViewController: UIViewController {
         spriteView.showsFPS = true
         spriteView.showsNodeCount = true
         #endif
+    }
+
+    @discardableResult
+    func lockRunOrientation(
+        to orientation: UIInterfaceOrientation?,
+        fallback: TiltScreenOrientation = .landscapeLeft
+    ) -> TiltScreenOrientation {
+        let resolvedOrientation = Self.landscapeOrientation(for: orientation)
+            ?? lastLandscapeOrientation
+            ?? fallback.interfaceOrientation
+        lastLandscapeOrientation = resolvedOrientation
+        lockedOrientationMask = Self.landscapeMask(for: resolvedOrientation)
+        setNeedsUpdateOfSupportedInterfaceOrientations()
+        return TiltScreenOrientation(interfaceOrientation: resolvedOrientation) ?? fallback
+    }
+
+    func unlockRunOrientation() {
+        lockedOrientationMask = nil
+        setNeedsUpdateOfSupportedInterfaceOrientations()
+    }
+
+    private static func landscapeMask(for orientation: UIInterfaceOrientation?) -> UIInterfaceOrientationMask? {
+        switch orientation {
+        case .landscapeLeft:
+            return .landscapeLeft
+        case .landscapeRight:
+            return .landscapeRight
+        default:
+            return nil
+        }
+    }
+
+    private static func landscapeOrientation(for orientation: UIInterfaceOrientation?) -> UIInterfaceOrientation? {
+        switch orientation {
+        case .landscapeLeft, .landscapeRight:
+            return orientation
+        default:
+            return nil
+        }
+    }
+
+    private func rememberCurrentLandscapeOrientation() {
+        if let orientation = Self.landscapeOrientation(for: view.window?.windowScene?.interfaceOrientation) {
+            lastLandscapeOrientation = orientation
+        }
+    }
+}
+
+extension GameViewController: ArenaSceneOrientationDelegate {
+    func arenaSceneRequestsRunOrientationLock(
+        _ scene: ArenaScene,
+        preferredOrientation: TiltScreenOrientation
+    ) -> TiltScreenOrientation {
+        lockRunOrientation(
+            to: view.window?.windowScene?.interfaceOrientation,
+            fallback: preferredOrientation
+        )
+    }
+
+    func arenaSceneRequestsOrientationUnlock(_ scene: ArenaScene) {
+        unlockRunOrientation()
     }
 }

--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -1,8 +1,19 @@
 // swiftlint:disable file_length
 import SpriteKit
+import UIKit
+
+@MainActor
+protocol ArenaSceneOrientationDelegate: AnyObject {
+    func arenaSceneRequestsRunOrientationLock(
+        _ scene: ArenaScene,
+        preferredOrientation: TiltScreenOrientation
+    ) -> TiltScreenOrientation
+    func arenaSceneRequestsOrientationUnlock(_ scene: ArenaScene)
+}
 
 // swiftlint:disable:next type_body_length
 final class ArenaScene: SKScene {
+    weak var orientationDelegate: ArenaSceneOrientationDelegate?
     let theme = ArenaTheme.darkTacticalRadar
     private let tiltSettingsStore = TiltSettingsStore()
     private let runProfileStore = RunProfileStore()
@@ -56,6 +67,10 @@ final class ArenaScene: SKScene {
     private let hudMargin: CGFloat = 24
     private let pauseControlSize = CGSize(width: 48, height: 48)
     private var uiHitTargets: [ArenaControlHitTarget] = []
+    private var tiltReadoutValueLabels: [SKLabelNode] = []
+    private var tiltReadoutUpdateTime: TimeInterval = 0
+    private var runTiltScreenOrientation: TiltScreenOrientation?
+    private var lastKnownTiltScreenOrientation: TiltScreenOrientation = .landscapeLeft
     private var lastUpdateTime: TimeInterval?
 
     override init(size: CGSize) {
@@ -95,6 +110,7 @@ final class ArenaScene: SKScene {
     }
 
     override func willMove(from view: SKView) {
+        orientationDelegate?.arenaSceneRequestsOrientationUnlock(self)
         tiltInputController.stop()
         lastUpdateTime = nil
     }
@@ -118,18 +134,23 @@ final class ArenaScene: SKScene {
             updatePreRun(deltaTime: deltaTime)
         case .activeGameplay:
             updateGameplay(deltaTime: deltaTime)
-        case .home, .modeSelect, .awards, .options, .pause, .postRun:
+        case .options:
+            updateTiltReadoutDisplay(deltaTime: deltaTime)
+        case .home, .modeSelect, .awards, .pause, .postRun:
             break
         }
     }
 
     func recalibrateTiltControls() {
-        tiltInputController.recalibrateToCurrentAttitude()
+        tiltInputController.recalibrateToCurrentAttitude(orientation: currentTiltScreenOrientation)
         updateRunDisplay()
         rebuildUI()
     }
 
     func refreshSafeAreaLayout() {
+        rebuildArena()
+        let shouldResetPosition = playerNode == nil || uiState == .home
+        placePlayer(resetPosition: shouldResetPosition, resetTrail: shouldResetPosition)
         layoutLabels()
         layoutPauseControl()
         rebuildUI()
@@ -156,7 +177,10 @@ final class ArenaScene: SKScene {
 
     private func rebuildArena() {
         arenaRoot.removeFromParent()
-        arenaRoot = ArenaThemeRenderer(theme: theme).makeArenaBackground(size: size)
+        arenaRoot = ArenaThemeRenderer(theme: theme).makeArenaBackground(
+            size: size,
+            arenaRect: currentGameplayBounds
+        )
         addChild(arenaRoot)
     }
 
@@ -169,14 +193,14 @@ final class ArenaScene: SKScene {
         addChild(uiRoot)
     }
 
-    private func placePlayer(resetPosition: Bool) {
+    private func placePlayer(resetPosition: Bool, resetTrail: Bool = true) {
         ensurePlayerNodes()
 
         let state = resetPosition
-            ? movementController.reset(in: size)
-            : movementController.clampToArena(size)
+            ? movementController.reset(in: currentGameplayBounds)
+            : movementController.clampToArena(currentGameplayBounds)
 
-        applyPlayerState(state, resetTrail: true)
+        applyPlayerState(state, resetTrail: resetTrail)
     }
 
     private func ensurePlayerNodes() {
@@ -201,7 +225,7 @@ final class ArenaScene: SKScene {
 
         let speedFraction = state.velocity.length / max(
             1,
-            movementController.configuration.maximumSpeed(in: size)
+            movementController.configuration.maximumSpeed(in: currentGameplayBounds)
         )
 
         if resetTrail {
@@ -284,9 +308,34 @@ final class ArenaScene: SKScene {
         )
     }
 
+    var currentGameplayBounds: CGRect {
+        currentLandscapeLayout().safeRect
+    }
+
+    var currentPlayableRect: CGRect {
+        movementController.configuration.playableRect(in: currentGameplayBounds)
+    }
+
+    private var currentTiltScreenOrientation: TiltScreenOrientation {
+        if let runTiltScreenOrientation {
+            return runTiltScreenOrientation
+        }
+
+        if let windowOrientation = currentWindowTiltScreenOrientation {
+            lastKnownTiltScreenOrientation = windowOrientation
+            return windowOrientation
+        }
+
+        return lastKnownTiltScreenOrientation
+    }
+
+    private var currentWindowTiltScreenOrientation: TiltScreenOrientation? {
+        TiltScreenOrientation(interfaceOrientation: view?.window?.windowScene?.interfaceOrientation)
+    }
+
     private func updatePreRun(deltaTime: TimeInterval) {
-        let input = tiltInputController.update(deltaTime: deltaTime)
-        let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
+        let input = tiltInputController.update(deltaTime: deltaTime, orientation: currentTiltScreenOrientation)
+        let state = movementController.update(input: input, deltaTime: deltaTime, arenaBounds: currentGameplayBounds)
         applyPlayerState(state, resetTrail: false)
 
         let holdState = readyHoldController.update(
@@ -306,9 +355,9 @@ final class ArenaScene: SKScene {
             return
         }
 
-        let input = tiltInputController.update(deltaTime: deltaTime)
+        let input = tiltInputController.update(deltaTime: deltaTime, orientation: currentTiltScreenOrientation)
         warpDashState.record(input: input)
-        let state = movementController.update(input: input, deltaTime: deltaTime, arenaSize: size)
+        let state = movementController.update(input: input, deltaTime: deltaTime, arenaBounds: currentGameplayBounds)
         applyPlayerState(state, resetTrail: false)
         updateActiveRun(deltaTime: deltaTime, playerPosition: state.position)
     }
@@ -426,12 +475,11 @@ final class ArenaScene: SKScene {
     }
 
     private func spawnEnemiesIfNeeded(deltaTime: TimeInterval, playerPosition: CGPoint) {
-        let playableRect = movementController.configuration.playableRect(in: size)
         let frame = spawnDirector.update(
             deltaTime: deltaTime,
             survivalTime: runController.survivalTime,
             activeEnemies: enemies,
-            playableRect: playableRect,
+            playableRect: currentPlayableRect,
             playerPosition: playerPosition,
             pickupCircles: pickups.map(\.collisionCircle)
         )
@@ -471,14 +519,13 @@ final class ArenaScene: SKScene {
     }
 
     private func spawnPickupIfNeeded(deltaTime: TimeInterval, playerPosition: CGPoint) {
-        let playableRect = movementController.configuration.playableRect(in: size)
         let enemyCircles = enemies.map(\.collisionCircle)
 
         guard let pickup = pickupPlanner.update(
             deltaTime: deltaTime,
             phase: runController.phase,
             activePickupCount: pickups.count,
-            playableRect: playableRect,
+            playableRect: currentPlayableRect,
             playerPosition: playerPosition,
             enemyCircles: enemyCircles,
             configuration: pickupSpawnConfiguration
@@ -505,8 +552,7 @@ final class ArenaScene: SKScene {
     }
 
     private func cullExitedLinearPatternEnemies() {
-        let playableRect = movementController.configuration.playableRect(in: size)
-        let cullingRect = playableRect.insetBy(
+        let cullingRect = currentPlayableRect.insetBy(
             dx: -spawnDirector.configuration.cullingOutset,
             dy: -spawnDirector.configuration.cullingOutset
         )
@@ -731,7 +777,7 @@ final class ArenaScene: SKScene {
         let state = movementController.dash(
             direction: warpDashState.resolvedDirection(),
             distance: warpDashDistance(),
-            arenaSize: size
+            arenaBounds: currentGameplayBounds
         )
 
         applyPlayerState(state, resetTrail: false)
@@ -743,8 +789,7 @@ final class ArenaScene: SKScene {
     }
 
     private func warpDashDistance() -> CGFloat {
-        let playableRect = movementController.configuration.playableRect(in: size)
-        return min(playableRect.width, playableRect.height)
+        min(currentPlayableRect.width, currentPlayableRect.height)
             * max(0, weaponResolver.configuration.warpDashDistanceFractionOfShortSide)
     }
 
@@ -925,13 +970,44 @@ private extension ArenaScene {
         }
 
         uiState = state
+        syncOrientationLock()
         updateRunDisplay()
         rebuildUI()
+    }
+
+    func syncOrientationLock() {
+        if shouldLockCurrentOrientation {
+            let preferredOrientation = currentWindowTiltScreenOrientation
+                ?? runTiltScreenOrientation
+                ?? lastKnownTiltScreenOrientation
+            let lockedOrientation = orientationDelegate?.arenaSceneRequestsRunOrientationLock(
+                self,
+                preferredOrientation: preferredOrientation
+            ) ?? preferredOrientation
+            runTiltScreenOrientation = lockedOrientation
+            lastKnownTiltScreenOrientation = lockedOrientation
+        } else {
+            runTiltScreenOrientation = nil
+            orientationDelegate?.arenaSceneRequestsOrientationUnlock(self)
+        }
+    }
+
+    var shouldLockCurrentOrientation: Bool {
+        switch uiState {
+        case .preRun, .activeGameplay, .pause, .postRun:
+            return true
+        case .options:
+            return optionsReturnState.requiresLockedRunOrientation
+        case .home, .modeSelect, .awards:
+            return false
+        }
     }
 
     func rebuildUI() {
         uiRoot.removeAllChildren()
         uiHitTargets.removeAll()
+        tiltReadoutValueLabels.removeAll()
+        tiltReadoutUpdateTime = 0
         readyProgressRing = nil
         readyStatusLabel = nil
 
@@ -955,6 +1031,32 @@ private extension ArenaScene {
         }
 
         updateRunDisplay()
+    }
+
+    func updateTiltReadoutDisplay(deltaTime: TimeInterval) {
+        tiltReadoutUpdateTime += deltaTime
+        guard tiltReadoutUpdateTime >= 0.12 else {
+            return
+        }
+
+        updateTiltReadoutDisplay(force: true)
+    }
+
+    func updateTiltReadoutDisplay(force: Bool) {
+        guard force, !tiltReadoutValueLabels.isEmpty else {
+            return
+        }
+
+        tiltReadoutUpdateTime = 0
+        let orientation = currentTiltScreenOrientation
+        let rows = TiltReadoutFormatter.rows(
+            for: tiltInputController.readout(orientation: orientation),
+            fallbackOrientation: orientation
+        )
+
+        for (label, row) in zip(tiltReadoutValueLabels, rows) {
+            label.text = row.value
+        }
     }
 
     func renderHome() {
@@ -1100,31 +1202,31 @@ private extension ArenaScene {
     func renderTiltOptions(in frame: CGRect) {
         addButton(
             "CALIBRATE",
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 62, width: 148, height: 40),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 54, width: 148, height: 34),
             action: .calibrate,
             style: .primary
         )
         let settings = tiltSettingsStore.settings
         addSmallLabel(
             "SENSITIVITY \(String(format: "%.1f", settings.clampedSensitivity))",
-            at: CGPoint(x: frame.minX + 14, y: frame.maxY - 90),
+            at: CGPoint(x: frame.minX + 14, y: frame.maxY - 84),
             color: theme.borderColor,
             alignment: .left
         )
         addButton(
             "-",
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 140, width: 44, height: 36),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 124, width: 44, height: 30),
             action: .sensitivityDown,
             style: .secondary
         )
         addButton(
             "+",
-            frame: CGRect(x: frame.minX + 70, y: frame.maxY - 140, width: 44, height: 36),
+            frame: CGRect(x: frame.minX + 70, y: frame.maxY - 124, width: 44, height: 30),
             action: .sensitivityUp,
             style: .secondary
         )
 
-        let presetY = frame.maxY - 196
+        let presetY = frame.maxY - 162
         for (index, preset) in [TiltCalibrationPreset.standard, .flatTable, .reclined].enumerated() {
             let buttonFrame = CGRect(
                 x: frame.minX + 14 + CGFloat(index) * 82,
@@ -1139,6 +1241,40 @@ private extension ArenaScene {
                 style: settings.calibration.preset == preset ? .primary : .secondary
             )
         }
+
+        renderTiltReadout(in: frame)
+    }
+
+    func renderTiltReadout(in frame: CGRect) {
+        tiltReadoutValueLabels.removeAll()
+        let rows = TiltReadoutFormatter.rows(
+            for: nil,
+            fallbackOrientation: currentTiltScreenOrientation
+        )
+        let startY = frame.minY + 58
+        let rowSpacing: CGFloat = 12
+
+        for (index, row) in rows.enumerated() {
+            let y = startY - CGFloat(index) * rowSpacing
+            addLabel(
+                row.title,
+                at: CGPoint(x: frame.minX + 14, y: y),
+                fontSize: 10,
+                color: theme.borderColor,
+                alignment: .left
+            )
+            let valueLabel = makeLabel(
+                row.value,
+                at: CGPoint(x: frame.maxX - 14, y: y),
+                fontSize: 10,
+                color: theme.playerAccentColor,
+                alignment: .right
+            )
+            tiltReadoutValueLabels.append(valueLabel)
+            uiRoot.addChild(valueLabel)
+        }
+
+        updateTiltReadoutDisplay(force: true)
     }
 
     func renderLocalOptions(in frame: CGRect) {
@@ -1733,6 +1869,16 @@ private extension ArenaScene {
         color: SKColor,
         alignment: SKLabelHorizontalAlignmentMode
     ) {
+        uiRoot.addChild(makeLabel(text, at: position, fontSize: fontSize, color: color, alignment: alignment))
+    }
+
+    func makeLabel(
+        _ text: String,
+        at position: CGPoint,
+        fontSize: CGFloat,
+        color: SKColor,
+        alignment: SKLabelHorizontalAlignmentMode
+    ) -> SKLabelNode {
         let label = SKLabelNode(fontNamed: fontSize >= 16 ? "Menlo-Bold" : "Menlo")
         label.text = text
         label.fontSize = fontSize
@@ -1741,7 +1887,7 @@ private extension ArenaScene {
         label.verticalAlignmentMode = .center
         label.position = position
         label.zPosition = ArenaUIZPosition.label
-        uiRoot.addChild(label)
+        return label
     }
 
     func presetTitle(_ preset: TiltCalibrationPreset) -> String {

--- a/TiltArena/Game/Input/TiltGravityMapping.swift
+++ b/TiltArena/Game/Input/TiltGravityMapping.swift
@@ -1,0 +1,97 @@
+import CoreGraphics
+import Foundation
+import UIKit
+
+enum TiltScreenOrientation: String, Equatable {
+    case landscapeLeft
+    case landscapeRight
+
+    init?(interfaceOrientation: UIInterfaceOrientation?) {
+        switch interfaceOrientation {
+        case .landscapeLeft:
+            self = .landscapeLeft
+        case .landscapeRight:
+            self = .landscapeRight
+        default:
+            return nil
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .landscapeLeft:
+            return "LAND L"
+        case .landscapeRight:
+            return "LAND R"
+        }
+    }
+
+    var interfaceOrientation: UIInterfaceOrientation {
+        switch self {
+        case .landscapeLeft:
+            return .landscapeLeft
+        case .landscapeRight:
+            return .landscapeRight
+        }
+    }
+}
+
+enum TiltGravityMapper {
+    static func screenGravity(
+        from rawGravity: TiltGravityVector,
+        orientation: TiltScreenOrientation
+    ) -> TiltGravityVector {
+        switch orientation {
+        case .landscapeLeft:
+            return TiltGravityVector(x: -rawGravity.y, y: rawGravity.x)
+        case .landscapeRight:
+            return TiltGravityVector(x: rawGravity.y, y: -rawGravity.x)
+        }
+    }
+}
+
+struct TiltInputReadout: Equatable {
+    let orientation: TiltScreenOrientation
+    let rawGravity: TiltGravityVector
+    let screenGravity: TiltGravityVector
+    let neutralGravity: TiltGravityVector
+    let normalizedInput: CGVector
+}
+
+struct TiltReadoutRow: Equatable {
+    let title: String
+    let value: String
+}
+
+enum TiltReadoutFormatter {
+    static func rows(
+        for readout: TiltInputReadout?,
+        fallbackOrientation: TiltScreenOrientation
+    ) -> [TiltReadoutRow] {
+        guard let readout else {
+            return [
+                TiltReadoutRow(title: "ORIENT", value: fallbackOrientation.displayName),
+                TiltReadoutRow(title: "RAW", value: "--"),
+                TiltReadoutRow(title: "SCREEN", value: "--"),
+                TiltReadoutRow(title: "NEUTRAL", value: "--"),
+                TiltReadoutRow(title: "INPUT", value: "--")
+            ]
+        }
+
+        return [
+            TiltReadoutRow(title: "ORIENT", value: readout.orientation.displayName),
+            TiltReadoutRow(title: "RAW", value: format(readout.rawGravity)),
+            TiltReadoutRow(title: "SCREEN", value: format(readout.screenGravity)),
+            TiltReadoutRow(title: "NEUTRAL", value: format(readout.neutralGravity)),
+            TiltReadoutRow(title: "INPUT", value: format(readout.normalizedInput))
+        ]
+    }
+
+    private static func format(_ vector: TiltGravityVector) -> String {
+        String(format: "%+.3f %+.3f", vector.x, vector.y)
+    }
+
+    private static func format(_ vector: CGVector) -> String {
+        String(format: "%+.3f %+.3f", Double(vector.dx), Double(vector.dy))
+    }
+}

--- a/TiltArena/Game/Input/TiltInputController.swift
+++ b/TiltArena/Game/Input/TiltInputController.swift
@@ -1,5 +1,5 @@
-import CoreMotion
 import CoreGraphics
+import CoreMotion
 import Foundation
 
 @MainActor
@@ -34,26 +34,58 @@ final class TiltInputController {
         signalProcessor.reset()
     }
 
-    func recalibrateToCurrentAttitude() {
-        guard let gravity = currentGravityVector() else {
+    func recalibrateToCurrentAttitude(orientation: TiltScreenOrientation) {
+        guard let rawGravity = currentGravityVector() else {
             return
         }
 
-        settingsStore.recalibrate(using: gravity)
+        let screenGravity = TiltGravityMapper.screenGravity(
+            from: rawGravity,
+            orientation: orientation
+        )
+        settingsStore.recalibrate(using: screenGravity)
         signalProcessor.reset()
     }
 
-    func update(deltaTime: TimeInterval) -> CGVector {
-        guard let gravity = currentGravityVector() else {
+    func update(deltaTime: TimeInterval, orientation: TiltScreenOrientation) -> CGVector {
+        guard let rawGravity = currentGravityVector() else {
             return .zero
         }
 
-        settingsStore.ensureInitialCalibration(using: gravity)
+        let screenGravity = TiltGravityMapper.screenGravity(
+            from: rawGravity,
+            orientation: orientation
+        )
+        settingsStore.ensureInitialCalibration(using: screenGravity)
 
         return signalProcessor.inputVector(
-            gravity: gravity,
+            gravity: screenGravity,
             settings: settingsStore.settings,
             deltaTime: deltaTime
+        )
+    }
+
+    func readout(orientation: TiltScreenOrientation) -> TiltInputReadout? {
+        guard let rawGravity = currentGravityVector() else {
+            return nil
+        }
+
+        let settings = settingsStore.settings
+        let screenGravity = TiltGravityMapper.screenGravity(
+            from: rawGravity,
+            orientation: orientation
+        )
+        let normalizedInput = signalProcessor.normalizedInputVector(
+            gravity: screenGravity,
+            settings: settings
+        )
+
+        return TiltInputReadout(
+            orientation: orientation,
+            rawGravity: rawGravity,
+            screenGravity: screenGravity,
+            neutralGravity: settings.calibration.neutralGravity,
+            normalizedInput: normalizedInput
         )
     }
 

--- a/TiltArena/Game/Input/TiltSettingsStore.swift
+++ b/TiltArena/Game/Input/TiltSettingsStore.swift
@@ -1,12 +1,16 @@
 import Foundation
 
 final class TiltSettingsStore {
+    private static let currentCalibrationSpaceVersion = 2
+
     private let defaults: UserDefaults
     private let settingsKey = "tiltArena.tiltControlSettings"
     private let initialCalibrationKey = "tiltArena.hasCapturedInitialTiltCalibration"
+    private let calibrationSpaceVersionKey = "tiltArena.tiltCalibrationSpaceVersion"
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        migrateCalibrationSpaceIfNeeded()
     }
 
     var settings: TiltControlSettings {
@@ -40,12 +44,14 @@ final class TiltSettingsStore {
 
         recalibrate(using: gravity)
         defaults.set(true, forKey: initialCalibrationKey)
+        markCurrentCalibrationSpaceVersion()
     }
 
     func recalibrate(using gravity: TiltGravityVector) {
         var currentSettings = settings
         currentSettings.calibration = .custom(neutralGravity: gravity)
         settings = currentSettings
+        markCurrentCalibrationSpaceVersion()
     }
 
     func selectPreset(_ preset: TiltCalibrationPreset) {
@@ -53,6 +59,7 @@ final class TiltSettingsStore {
         currentSettings.calibration = .defaultCalibration(for: preset)
         settings = currentSettings
         defaults.set(true, forKey: initialCalibrationKey)
+        markCurrentCalibrationSpaceVersion()
     }
 
     func updateSensitivity(_ sensitivity: Double) {
@@ -67,5 +74,30 @@ final class TiltSettingsStore {
     func reset() {
         defaults.removeObject(forKey: settingsKey)
         defaults.removeObject(forKey: initialCalibrationKey)
+        defaults.removeObject(forKey: calibrationSpaceVersionKey)
+    }
+
+    private func migrateCalibrationSpaceIfNeeded() {
+        guard defaults.integer(forKey: calibrationSpaceVersionKey) < Self.currentCalibrationSpaceVersion else {
+            return
+        }
+
+        guard defaults.data(forKey: settingsKey) != nil else {
+            markCurrentCalibrationSpaceVersion()
+            return
+        }
+
+        var currentSettings = settings
+        if currentSettings.calibration.preset == .custom {
+            currentSettings.calibration = TiltControlSettings.defaults.calibration
+            settings = currentSettings
+            defaults.removeObject(forKey: initialCalibrationKey)
+        }
+
+        markCurrentCalibrationSpaceVersion()
+    }
+
+    private func markCurrentCalibrationSpaceVersion() {
+        defaults.set(Self.currentCalibrationSpaceVersion, forKey: calibrationSpaceVersionKey)
     }
 }

--- a/TiltArena/Game/Input/TiltSignalProcessor.swift
+++ b/TiltArena/Game/Input/TiltSignalProcessor.swift
@@ -47,7 +47,7 @@ struct TiltSignalProcessor {
         let neutral = settings.calibration.neutralGravity
         let rawInput = CGVector(
             dx: gravity.x - neutral.x,
-            dy: -(gravity.y - neutral.y)
+            dy: gravity.y - neutral.y
         )
         let magnitude = rawInput.length
         let deadZone = configuration.deadZoneMagnitude

--- a/TiltArena/Game/Player/PlayerMovementController.swift
+++ b/TiltArena/Game/Player/PlayerMovementController.swift
@@ -7,15 +7,28 @@ struct PlayerMovementConfiguration: Equatable {
     var arenaCrossingDuration: TimeInterval = 2.5
 
     func maximumSpeed(in arenaSize: CGSize) -> CGFloat {
-        playableRect(in: arenaSize).width / CGFloat(max(0.001, arenaCrossingDuration))
+        maximumSpeed(in: CGRect(origin: .zero, size: arenaSize))
+    }
+
+    func maximumSpeed(in arenaBounds: CGRect) -> CGFloat {
+        playableRect(in: arenaBounds).width / CGFloat(max(0.001, arenaCrossingDuration))
     }
 
     func playableRect(in arenaSize: CGSize) -> CGRect {
-        let inset = borderInset + visualRadius
-        let width = max(0, arenaSize.width - inset * 2)
-        let height = max(0, arenaSize.height - inset * 2)
+        playableRect(in: CGRect(origin: .zero, size: arenaSize))
+    }
 
-        return CGRect(x: inset, y: inset, width: width, height: height)
+    func playableRect(in arenaBounds: CGRect) -> CGRect {
+        let inset = borderInset + visualRadius
+        let width = max(0, arenaBounds.width - inset * 2)
+        let height = max(0, arenaBounds.height - inset * 2)
+
+        return CGRect(
+            x: arenaBounds.minX + inset,
+            y: arenaBounds.minY + inset,
+            width: width,
+            height: height
+        )
     }
 }
 
@@ -29,7 +42,11 @@ struct PlayerMovementController {
     private(set) var state = PlayerMovementState(position: .zero, velocity: .zero)
 
     mutating func reset(in arenaSize: CGSize) -> PlayerMovementState {
-        let rect = configuration.playableRect(in: arenaSize)
+        reset(in: CGRect(origin: .zero, size: arenaSize))
+    }
+
+    mutating func reset(in arenaBounds: CGRect) -> PlayerMovementState {
+        let rect = configuration.playableRect(in: arenaBounds)
         state = PlayerMovementState(
             position: CGPoint(x: rect.midX, y: rect.midY),
             velocity: .zero
@@ -38,8 +55,12 @@ struct PlayerMovementController {
     }
 
     mutating func update(input: CGVector, deltaTime: TimeInterval, arenaSize: CGSize) -> PlayerMovementState {
+        update(input: input, deltaTime: deltaTime, arenaBounds: CGRect(origin: .zero, size: arenaSize))
+    }
+
+    mutating func update(input: CGVector, deltaTime: TimeInterval, arenaBounds: CGRect) -> PlayerMovementState {
         let clampedInput = input.clamped(toMaximumLength: 1)
-        let maximumSpeed = configuration.maximumSpeed(in: arenaSize)
+        let maximumSpeed = configuration.maximumSpeed(in: arenaBounds)
         let velocity = CGVector(
             dx: clampedInput.dx * maximumSpeed,
             dy: clampedInput.dy * maximumSpeed
@@ -50,7 +71,7 @@ struct PlayerMovementController {
         )
 
         state = PlayerMovementState(
-            position: clampedPosition(proposedPosition, in: arenaSize),
+            position: clampedPosition(proposedPosition, in: arenaBounds),
             velocity: velocity
         )
 
@@ -58,6 +79,10 @@ struct PlayerMovementController {
     }
 
     mutating func dash(direction: CGVector, distance: CGFloat, arenaSize: CGSize) -> PlayerMovementState {
+        dash(direction: direction, distance: distance, arenaBounds: CGRect(origin: .zero, size: arenaSize))
+    }
+
+    mutating func dash(direction: CGVector, distance: CGFloat, arenaBounds: CGRect) -> PlayerMovementState {
         guard direction.length > 0 else {
             return state
         }
@@ -72,10 +97,10 @@ struct PlayerMovementController {
             x: state.position.x + dashDirection.dx * clampedDistance,
             y: state.position.y + dashDirection.dy * clampedDistance
         )
-        let maximumSpeed = configuration.maximumSpeed(in: arenaSize)
+        let maximumSpeed = configuration.maximumSpeed(in: arenaBounds)
 
         state = PlayerMovementState(
-            position: clampedPosition(proposedPosition, in: arenaSize),
+            position: clampedPosition(proposedPosition, in: arenaBounds),
             velocity: CGVector(
                 dx: dashDirection.dx * maximumSpeed,
                 dy: dashDirection.dy * maximumSpeed
@@ -86,18 +111,26 @@ struct PlayerMovementController {
     }
 
     mutating func clampToArena(_ arenaSize: CGSize) -> PlayerMovementState {
+        clampToArena(CGRect(origin: .zero, size: arenaSize))
+    }
+
+    mutating func clampToArena(_ arenaBounds: CGRect) -> PlayerMovementState {
         state = PlayerMovementState(
-            position: clampedPosition(state.position, in: arenaSize),
+            position: clampedPosition(state.position, in: arenaBounds),
             velocity: state.velocity
         )
         return state
     }
 
     func clampedPosition(_ position: CGPoint, in arenaSize: CGSize) -> CGPoint {
-        let rect = configuration.playableRect(in: arenaSize)
+        clampedPosition(position, in: CGRect(origin: .zero, size: arenaSize))
+    }
+
+    func clampedPosition(_ position: CGPoint, in arenaBounds: CGRect) -> CGPoint {
+        let rect = configuration.playableRect(in: arenaBounds)
 
         guard rect.width > 0, rect.height > 0 else {
-            return CGPoint(x: arenaSize.width / 2, y: arenaSize.height / 2)
+            return CGPoint(x: arenaBounds.midX, y: arenaBounds.midY)
         }
 
         return CGPoint(

--- a/TiltArena/Game/Theme/ArenaThemeRenderer.swift
+++ b/TiltArena/Game/Theme/ArenaThemeRenderer.swift
@@ -8,14 +8,15 @@ final class ArenaThemeRenderer {
         self.theme = theme
     }
 
-    func makeArenaBackground(size: CGSize) -> SKNode {
+    func makeArenaBackground(size: CGSize, arenaRect: CGRect? = nil) -> SKNode {
+        let arenaRect = arenaRect ?? CGRect(origin: .zero, size: size)
         let root = SKNode()
         root.zPosition = -100
 
         root.addChild(makeBackdrop(size: size))
-        root.addChild(makeGrid(size: size))
-        root.addChild(makeRadarRings(size: size))
-        root.addChild(makeBorder(size: size))
+        root.addChild(makeGrid(in: arenaRect))
+        root.addChild(makeRadarRings(in: arenaRect))
+        root.addChild(makeBorder(in: arenaRect))
 
         return root
     }
@@ -28,21 +29,21 @@ final class ArenaThemeRenderer {
         return node
     }
 
-    private func makeGrid(size: CGSize) -> SKNode {
+    private func makeGrid(in rect: CGRect) -> SKNode {
         let path = CGMutablePath()
         let spacing: CGFloat = 48
 
-        var x: CGFloat = 0
-        while x <= size.width {
-            path.move(to: CGPoint(x: x, y: 0))
-            path.addLine(to: CGPoint(x: x, y: size.height))
+        var x = rect.minX
+        while x <= rect.maxX {
+            path.move(to: CGPoint(x: x, y: rect.minY))
+            path.addLine(to: CGPoint(x: x, y: rect.maxY))
             x += spacing
         }
 
-        var y: CGFloat = 0
-        while y <= size.height {
-            path.move(to: CGPoint(x: 0, y: y))
-            path.addLine(to: CGPoint(x: size.width, y: y))
+        var y = rect.minY
+        while y <= rect.maxY {
+            path.move(to: CGPoint(x: rect.minX, y: y))
+            path.addLine(to: CGPoint(x: rect.maxX, y: y))
             y += spacing
         }
 
@@ -53,10 +54,10 @@ final class ArenaThemeRenderer {
         return node
     }
 
-    private func makeRadarRings(size: CGSize) -> SKNode {
+    private func makeRadarRings(in rect: CGRect) -> SKNode {
         let root = SKNode()
-        let center = CGPoint(x: size.width / 2, y: size.height / 2)
-        let maxRadius = min(size.width, size.height) * 0.48
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let maxRadius = min(rect.width, rect.height) * 0.48
 
         for index in 1...4 {
             let radius = maxRadius * CGFloat(index) / 4
@@ -71,13 +72,13 @@ final class ArenaThemeRenderer {
         return root
     }
 
-    private func makeBorder(size: CGSize) -> SKNode {
+    private func makeBorder(in arenaRect: CGRect) -> SKNode {
         let inset: CGFloat = 14
         let rect = CGRect(
-            x: inset,
-            y: inset,
-            width: max(0, size.width - inset * 2),
-            height: max(0, size.height - inset * 2)
+            x: arenaRect.minX + inset,
+            y: arenaRect.minY + inset,
+            width: max(0, arenaRect.width - inset * 2),
+            height: max(0, arenaRect.height - inset * 2)
         )
 
         let border = SKShapeNode(rect: rect, cornerRadius: 6)

--- a/TiltArena/Game/UI/ArenaUISceneState.swift
+++ b/TiltArena/Game/UI/ArenaUISceneState.swift
@@ -7,6 +7,15 @@ enum ArenaUISceneState: Equatable {
     case activeGameplay
     case pause
     case postRun
+
+    var requiresLockedRunOrientation: Bool {
+        switch self {
+        case .preRun, .activeGameplay, .pause, .postRun:
+            return true
+        case .home, .modeSelect, .awards, .options:
+            return false
+        }
+    }
 }
 
 enum ArenaModeKind: String, CaseIterable, Codable, Equatable {

--- a/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
+++ b/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
@@ -19,7 +19,7 @@ extension ArenaScene {
     }
 
     func playNovaBombEffect() {
-        let playableRect = movementController.configuration.playableRect(in: size)
+        let playableRect = currentPlayableRect
 
         guard playableRect.width > 0, playableRect.height > 0 else {
             return

--- a/TiltArenaTests/GameViewControllerTests.swift
+++ b/TiltArenaTests/GameViewControllerTests.swift
@@ -9,4 +9,54 @@ final class GameViewControllerTests: XCTestCase {
 
         XCTAssertEqual(controller.supportedInterfaceOrientations, .landscape)
     }
+
+    @MainActor
+    func testRunOrientationLockNarrowsToLandscapeLeft() {
+        let controller = GameViewController()
+
+        controller.lockRunOrientation(to: .landscapeLeft)
+
+        XCTAssertEqual(controller.supportedInterfaceOrientations, .landscapeLeft)
+    }
+
+    @MainActor
+    func testRunOrientationLockNarrowsToLandscapeRight() {
+        let controller = GameViewController()
+
+        controller.lockRunOrientation(to: .landscapeRight)
+
+        XCTAssertEqual(controller.supportedInterfaceOrientations, .landscapeRight)
+    }
+
+    @MainActor
+    func testRunOrientationUnlockRestoresBothLandscapeSides() {
+        let controller = GameViewController()
+
+        controller.lockRunOrientation(to: .landscapeLeft)
+        controller.unlockRunOrientation()
+
+        XCTAssertEqual(controller.supportedInterfaceOrientations, .landscape)
+    }
+
+    @MainActor
+    func testRunOrientationLockFallsBackToPreferredLandscapeSide() {
+        let controller = GameViewController()
+
+        let lockedOrientation = controller.lockRunOrientation(to: nil, fallback: .landscapeRight)
+
+        XCTAssertEqual(lockedOrientation, .landscapeRight)
+        XCTAssertEqual(controller.supportedInterfaceOrientations, .landscapeRight)
+    }
+
+    @MainActor
+    func testRunOrientationLockReusesLastConcreteLandscapeSide() {
+        let controller = GameViewController()
+        controller.lockRunOrientation(to: .landscapeRight)
+        controller.unlockRunOrientation()
+
+        let lockedOrientation = controller.lockRunOrientation(to: nil, fallback: .landscapeLeft)
+
+        XCTAssertEqual(lockedOrientation, .landscapeRight)
+        XCTAssertEqual(controller.supportedInterfaceOrientations, .landscapeRight)
+    }
 }

--- a/TiltArenaTests/PlayerMovementControllerTests.swift
+++ b/TiltArenaTests/PlayerMovementControllerTests.swift
@@ -11,6 +11,18 @@ final class PlayerMovementControllerTests: XCTestCase {
         XCTAssertEqual(state.position.y, 422, accuracy: 0.0001)
     }
 
+    func testResetPlacesPlayerAtSafeGameplayBoundsCenter() {
+        let safeBounds = CGRect(x: 83, y: 45, width: 686, height: 324)
+        var controller = PlayerMovementController()
+        let state = controller.reset(in: safeBounds)
+        let playableRect = controller.configuration.playableRect(in: safeBounds)
+
+        XCTAssertEqual(state.position.x, playableRect.midX, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, playableRect.midY, accuracy: 0.0001)
+        XCTAssertGreaterThan(state.position.x, safeBounds.minX)
+        XCTAssertGreaterThan(state.position.y, safeBounds.minY)
+    }
+
     func testFullTiltCrossesPlayableWidthAtConfiguredSpeed() {
         let arenaSize = CGSize(width: 390, height: 844)
         var controller = PlayerMovementController()
@@ -30,6 +42,18 @@ final class PlayerMovementControllerTests: XCTestCase {
 
         let state = controller.update(input: CGVector(dx: 20, dy: 20), deltaTime: 10, arenaSize: arenaSize)
         let playableRect = controller.configuration.playableRect(in: arenaSize)
+
+        XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, playableRect.maxY, accuracy: 0.0001)
+    }
+
+    func testMovementClampsToSafeGameplayBounds() {
+        let safeBounds = CGRect(x: 83, y: 45, width: 686, height: 324)
+        var controller = PlayerMovementController()
+        _ = controller.reset(in: safeBounds)
+
+        let state = controller.update(input: CGVector(dx: 20, dy: 20), deltaTime: 10, arenaBounds: safeBounds)
+        let playableRect = controller.configuration.playableRect(in: safeBounds)
 
         XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)
         XCTAssertEqual(state.position.y, playableRect.maxY, accuracy: 0.0001)
@@ -62,6 +86,22 @@ final class PlayerMovementControllerTests: XCTestCase {
             direction: CGVector(dx: 1, dy: 1),
             distance: 10_000,
             arenaSize: arenaSize
+        )
+
+        XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)
+        XCTAssertEqual(state.position.y, playableRect.maxY, accuracy: 0.0001)
+    }
+
+    func testDashClampsToSafeGameplayBounds() {
+        let safeBounds = CGRect(x: 83, y: 45, width: 686, height: 324)
+        var controller = PlayerMovementController()
+        _ = controller.reset(in: safeBounds)
+        let playableRect = controller.configuration.playableRect(in: safeBounds)
+
+        let state = controller.dash(
+            direction: CGVector(dx: 1, dy: 1),
+            distance: 10_000,
+            arenaBounds: safeBounds
         )
 
         XCTAssertEqual(state.position.x, playableRect.maxX, accuracy: 0.0001)

--- a/TiltArenaTests/TiltGravityMappingTests.swift
+++ b/TiltArenaTests/TiltGravityMappingTests.swift
@@ -1,0 +1,72 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class TiltGravityMappingTests: XCTestCase {
+    private let settings = TiltControlSettings(
+        calibration: .custom(neutralGravity: TiltGravityVector(x: 0, y: 0)),
+        sensitivity: 1
+    )
+
+    func testLandscapeLeftMapsRawYToScreenXAndRawXToScreenY() {
+        let screenGravity = TiltGravityMapper.screenGravity(
+            from: TiltGravityVector(x: 0.25, y: -0.4),
+            orientation: .landscapeLeft
+        )
+
+        XCTAssertEqual(screenGravity.x, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(screenGravity.y, 0.25, accuracy: 0.0001)
+    }
+
+    func testLandscapeRightMapsRawYToScreenXAndRawXToScreenYWithOppositeSigns() {
+        let screenGravity = TiltGravityMapper.screenGravity(
+            from: TiltGravityVector(x: -0.25, y: 0.4),
+            orientation: .landscapeRight
+        )
+
+        XCTAssertEqual(screenGravity.x, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(screenGravity.y, 0.25, accuracy: 0.0001)
+    }
+
+    func testLandscapeLeftVisibleTiltDirectionsDriveScreenInputAxes() {
+        XCTAssertLessThan(input(from: TiltGravityVector(x: 0, y: 0.3), orientation: .landscapeLeft).dx, 0)
+        XCTAssertGreaterThan(input(from: TiltGravityVector(x: 0, y: -0.3), orientation: .landscapeLeft).dx, 0)
+        XCTAssertLessThan(input(from: TiltGravityVector(x: -0.3, y: 0), orientation: .landscapeLeft).dy, 0)
+        XCTAssertGreaterThan(input(from: TiltGravityVector(x: 0.3, y: 0), orientation: .landscapeLeft).dy, 0)
+    }
+
+    func testLandscapeRightVisibleTiltDirectionsDriveScreenInputAxes() {
+        XCTAssertLessThan(input(from: TiltGravityVector(x: 0, y: -0.3), orientation: .landscapeRight).dx, 0)
+        XCTAssertGreaterThan(input(from: TiltGravityVector(x: 0, y: 0.3), orientation: .landscapeRight).dx, 0)
+        XCTAssertLessThan(input(from: TiltGravityVector(x: 0.3, y: 0), orientation: .landscapeRight).dy, 0)
+        XCTAssertGreaterThan(input(from: TiltGravityVector(x: -0.3, y: 0), orientation: .landscapeRight).dy, 0)
+    }
+
+    func testReadoutFormatterUsesStableCompactRows() {
+        let readout = TiltInputReadout(
+            orientation: .landscapeLeft,
+            rawGravity: TiltGravityVector(x: 0.1234, y: -0.9876),
+            screenGravity: TiltGravityVector(x: 0.9876, y: 0.1234),
+            neutralGravity: TiltGravityVector(x: 0, y: -0.35),
+            normalizedInput: CGVector(dx: 0.5, dy: -0.25)
+        )
+
+        XCTAssertEqual(
+            TiltReadoutFormatter.rows(for: readout, fallbackOrientation: .landscapeRight),
+            [
+                TiltReadoutRow(title: "ORIENT", value: "LAND L"),
+                TiltReadoutRow(title: "RAW", value: "+0.123 -0.988"),
+                TiltReadoutRow(title: "SCREEN", value: "+0.988 +0.123"),
+                TiltReadoutRow(title: "NEUTRAL", value: "+0.000 -0.350"),
+                TiltReadoutRow(title: "INPUT", value: "+0.500 -0.250")
+            ]
+        )
+    }
+
+    private func input(from rawGravity: TiltGravityVector, orientation: TiltScreenOrientation) -> CGVector {
+        TiltSignalProcessor().normalizedInputVector(
+            gravity: TiltGravityMapper.screenGravity(from: rawGravity, orientation: orientation),
+            settings: settings
+        )
+    }
+}

--- a/TiltArenaTests/TiltSettingsStoreTests.swift
+++ b/TiltArenaTests/TiltSettingsStoreTests.swift
@@ -2,6 +2,9 @@ import XCTest
 @testable import TiltArena
 
 final class TiltSettingsStoreTests: XCTestCase {
+    private static let settingsKey = "tiltArena.tiltControlSettings"
+    private static let initialCalibrationKey = "tiltArena.hasCapturedInitialTiltCalibration"
+
     private var defaults: UserDefaults!
     private var suiteName: String!
 
@@ -60,5 +63,39 @@ final class TiltSettingsStoreTests: XCTestCase {
 
         XCTAssertTrue(store.needsInitialCalibration)
         XCTAssertEqual(store.settings, .defaults)
+    }
+
+    func testLegacyCustomCalibrationMigratesToScreenSpaceDefaults() throws {
+        try writeLegacySettings(
+            TiltControlSettings(
+                calibration: .custom(neutralGravity: TiltGravityVector(x: 0.2, y: -0.4)),
+                sensitivity: 1.3
+            )
+        )
+
+        let store = TiltSettingsStore(defaults: defaults)
+
+        XCTAssertTrue(store.needsInitialCalibration)
+        XCTAssertEqual(store.settings.calibration, TiltControlSettings.defaults.calibration)
+        XCTAssertEqual(store.settings.sensitivity, 1.3)
+    }
+
+    func testLegacyPresetCalibrationKeepsCapturedState() throws {
+        let legacySettings = TiltControlSettings(
+            calibration: .defaultCalibration(for: .flatTable),
+            sensitivity: 1.2
+        )
+        try writeLegacySettings(legacySettings)
+
+        let store = TiltSettingsStore(defaults: defaults)
+
+        XCTAssertFalse(store.needsInitialCalibration)
+        XCTAssertEqual(store.settings, legacySettings)
+    }
+
+    private func writeLegacySettings(_ settings: TiltControlSettings) throws {
+        let data = try JSONEncoder().encode(settings)
+        defaults.set(data, forKey: Self.settingsKey)
+        defaults.set(true, forKey: Self.initialCalibrationKey)
     }
 }


### PR DESCRIPTION
## Summary
- Use safe gameplay bounds for movement, spawns, dash clamps, nova effects, and arena framing while keeping the backdrop full-screen.
- Lock each run to one concrete landscape orientation and map CoreMotion gravity into screen-space tilt values.
- Add live tilt readout rows in Options and migrate legacy custom calibration so old raw-space neutral values are not reused.

## Validation
- `xcodegen generate`
- `swiftlint lint --no-cache` (passes with 3 pre-existing warnings)
- `xcodebuild -scheme TiltArena -destination 'platform=iOS Simulator,id=F9038B9B-519B-49B6-9531-99DAA4F64D6C' build`
- `xcodebuild -scheme TiltArena -destination 'platform=iOS Simulator,id=F9038B9B-519B-49B6-9531-99DAA4F64D6C' test` (165 tests, 0 failures)

Closes #61