### PR TITLE
Complete visual themes and readability polish

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -14,7 +14,9 @@ protocol ArenaSceneOrientationDelegate: AnyObject {
 // swiftlint:disable:next type_body_length
 final class ArenaScene: SKScene {
     weak var orientationDelegate: ArenaSceneOrientationDelegate?
-    let theme = ArenaTheme.darkTacticalRadar
+    var theme: ArenaTheme {
+        localOptions.themeKind.theme
+    }
     private let tiltSettingsStore = TiltSettingsStore()
     private let runProfileStore = RunProfileStore()
     private let localOptionsStore = ArenaLocalOptionsStore()
@@ -86,6 +88,7 @@ final class ArenaScene: SKScene {
     override func didMove(to view: SKView) {
         runProfile = runProfileStore.profile
         localOptions = localOptionsStore.options
+        backgroundColor = theme.backgroundColor
         rebuildArena()
         if flameTrailEffectNode.parent == nil { addChild(flameTrailEffectNode) }
         configureLabels()
@@ -99,7 +102,8 @@ final class ArenaScene: SKScene {
 
     override func didChangeSize(_ oldSize: CGSize) {
         rebuildArena()
-        placePlayer(resetPosition: playerNode == nil || uiState == .home)
+        let shouldResetPosition = playerNode == nil || uiState == .home
+        placePlayer(resetPosition: shouldResetPosition, resetTrail: shouldResetPosition)
         if uiState == .preRun {
             readyStartPoint = movementController.state.position
             readyHoldController.reset()
@@ -263,8 +267,7 @@ final class ArenaScene: SKScene {
         }
 
         pauseControlNode.zPosition = 60
-        addPauseControlBackground()
-        configurePauseIcon()
+        rebuildPauseControlAppearance()
         addChild(pauseControlNode)
         layoutPauseControl()
         updatePauseControl()
@@ -450,6 +453,55 @@ final class ArenaScene: SKScene {
         playerNode?.removeAllActions()
         playerNode?.alpha = 1
         playerNode?.setScale(1)
+    }
+
+    private func applyThemeChange() {
+        backgroundColor = theme.backgroundColor
+        configureLabels()
+        rebuildPauseControlAppearance()
+        rebuildArena()
+        refreshGameplayNodesForTheme()
+        rebuildUI()
+    }
+
+    private func refreshGameplayNodesForTheme() {
+        playerNode?.applyTheme(theme)
+        playerTrailNode?.applyTheme(theme)
+        flameTrailEffectNode.applyTheme(theme)
+        refreshEnemyNodesForTheme()
+        refreshPickupNodesForTheme()
+        refreshTelegraphNodesForTheme()
+        refreshActiveWeaponEffectNodesForTheme()
+    }
+
+    private func refreshEnemyNodesForTheme() {
+        for enemy in enemies {
+            enemyNodes[enemy.id]?.applyTheme(theme, enemy: enemy)
+        }
+    }
+
+    private func refreshPickupNodesForTheme() {
+        for pickup in pickups {
+            pickupNodes[pickup.id]?.applyTheme(theme, pickup: pickup)
+        }
+    }
+
+    private func refreshTelegraphNodesForTheme() {
+        enemyTelegraphNodes.values.forEach { $0.applyTheme(theme) }
+    }
+
+    private func refreshActiveWeaponEffectNodesForTheme() {
+        if let razorShieldNode {
+            styleRazorShieldNode(razorShieldNode)
+        }
+
+        if let gravityWellState {
+            playGravityWellEffect(at: gravityWellState.center, duration: gravityWellState.timeRemaining)
+        }
+
+        if decoyBeaconState.isActive, let center = decoyBeaconState.center {
+            playDecoyBeaconEffect(at: center, duration: decoyBeaconState.timeRemaining)
+        }
     }
 
     private func updateActiveRun(deltaTime: TimeInterval, playerPosition initialPlayerPosition: CGPoint) {
@@ -727,17 +779,21 @@ final class ArenaScene: SKScene {
 
         if razorShieldNode == nil {
             let node = SKShapeNode(circleOfRadius: weaponResolver.configuration.razorShieldRadius)
-            node.strokeColor = theme.pickupBlue.withAlphaComponent(0.9)
-            node.fillColor = .clear
-            node.lineWidth = 2
-            node.glowWidth = 4
             node.zPosition = 19
+            styleRazorShieldNode(node)
             addChild(node)
             razorShieldNode = node
         }
 
         razorShieldNode?.position = playerPosition
         razorShieldNode?.isHidden = false
+    }
+
+    private func styleRazorShieldNode(_ node: SKShapeNode) {
+        node.strokeColor = theme.pickupBlue.withAlphaComponent(0.9)
+        node.fillColor = .clear
+        node.lineWidth = 2
+        node.glowWidth = 4
     }
 
     private func updateRazorShield(deltaTime: TimeInterval, playerPosition: CGPoint) {
@@ -951,6 +1007,7 @@ final class ArenaScene: SKScene {
     }
 
     private func configurePauseIcon() {
+        pauseIconNode.removeAllChildren()
         for xOffset in [CGFloat(-5.5), CGFloat(5.5)] {
             let bar = SKShapeNode(rectOf: CGSize(width: 5, height: 18), cornerRadius: 1.5)
             bar.position = CGPoint(x: xOffset, y: 0)
@@ -960,6 +1017,12 @@ final class ArenaScene: SKScene {
         }
 
         pauseControlNode.addChild(pauseIconNode)
+    }
+
+    private func rebuildPauseControlAppearance() {
+        pauseControlNode.removeAllChildren()
+        addPauseControlBackground()
+        configurePauseIcon()
     }
 }
 
@@ -1039,11 +1102,11 @@ private extension ArenaScene {
             return
         }
 
-        updateTiltReadoutDisplay(force: true)
+        updateTiltReadoutDisplay()
     }
 
-    func updateTiltReadoutDisplay(force: Bool) {
-        guard force, !tiltReadoutValueLabels.isEmpty else {
+    func updateTiltReadoutDisplay() {
+        guard !tiltReadoutValueLabels.isEmpty else {
             return
         }
 
@@ -1274,31 +1337,52 @@ private extension ArenaScene {
             uiRoot.addChild(valueLabel)
         }
 
-        updateTiltReadoutDisplay(force: true)
+        updateTiltReadoutDisplay()
     }
 
     func renderLocalOptions(in frame: CGRect) {
         addToggle(
             title: "AUDIO",
             isOn: localOptions.audioEnabled,
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 62, width: 132, height: 38),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 54, width: 132, height: 34),
             action: .toggleAudio
         )
         addToggle(
             title: "HAPTICS",
             isOn: localOptions.hapticsEnabled,
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 112, width: 132, height: 38),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 96, width: 132, height: 34),
             action: .toggleHaptics
         )
         addToggle(
             title: "EFFECTS",
             isOn: !localOptions.reducedEffects,
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 162, width: 132, height: 38),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 138, width: 132, height: 34),
             action: .toggleEffects
         )
+        addSmallLabel(
+            "THEME",
+            at: CGPoint(x: frame.minX + 14, y: frame.minY + 70),
+            color: theme.borderColor,
+            alignment: .left
+        )
+
+        for (index, themeKind) in ArenaThemeKind.allCases.enumerated() {
+            addButton(
+                themeKind.shortTitle,
+                frame: CGRect(
+                    x: frame.minX + 14 + CGFloat(index) * 70,
+                    y: frame.minY + 26,
+                    width: 62,
+                    height: 30
+                ),
+                action: .selectTheme(themeKind),
+                style: localOptions.themeKind == themeKind ? .primary : .secondary
+            )
+        }
+
         addButton(
-            resetDataArmed ? "CONFIRM RESET" : "RESET DATA",
-            frame: CGRect(x: frame.minX + 14, y: frame.minY + 12, width: 156, height: 34),
+            resetDataArmed ? "CONFIRM" : "RESET",
+            frame: CGRect(x: frame.maxX - 104, y: frame.minY + 26, width: 90, height: 30),
             action: .resetData,
             style: .danger
         )
@@ -1457,7 +1541,7 @@ private extension ArenaScene {
             performNavigationAction(action)
         case .selectMode, .resume, .calibrate, .endRun:
             performRunControlAction(action)
-        case .sensitivityDown, .sensitivityUp, .preset, .toggleAudio, .toggleHaptics, .toggleEffects, .resetData:
+        case .sensitivityDown, .sensitivityUp, .preset, .toggleAudio, .toggleHaptics, .toggleEffects, .selectTheme, .resetData:
             performOptionsAction(action)
         }
     }
@@ -1529,6 +1613,14 @@ private extension ArenaScene {
             localOptions.reducedEffects.toggle()
             localOptionsStore.options = localOptions
             rebuildUI()
+        case let .selectTheme(themeKind):
+            guard localOptions.themeKind != themeKind else {
+                return
+            }
+
+            localOptions.themeKind = themeKind
+            localOptionsStore.options = localOptions
+            applyThemeChange()
         case .resetData:
             resetLocalDataOrArmConfirmation()
         default:
@@ -1579,8 +1671,7 @@ private extension ArenaScene {
         lastProgressionResult = nil
         selectedMode = .classic
         resetDataArmed = false
-        rebuildUI()
-        updateRunDisplay()
+        applyThemeChange()
     }
 
     func addReadyStartCircle(at point: CGPoint) {
@@ -1774,13 +1865,13 @@ private extension ArenaScene {
 
     func addPanel(
         frame: CGRect,
-        stroke: SKColor = SKColor(red: 0.37, green: 0.66, blue: 0.78, alpha: 0.35),
-        fill: SKColor = SKColor(red: 0.03, green: 0.07, blue: 0.11, alpha: 0.62)
+        stroke: SKColor? = nil,
+        fill: SKColor? = nil
     ) {
         let panel = SKShapeNode(rect: frame, cornerRadius: 8)
         panel.zPosition = ArenaUIZPosition.panel
-        panel.fillColor = fill
-        panel.strokeColor = stroke
+        panel.fillColor = fill ?? theme.panelFillColor
+        panel.strokeColor = stroke ?? theme.panelStrokeColor
         panel.lineWidth = 1
         uiRoot.addChild(panel)
     }
@@ -2052,6 +2143,7 @@ private enum ArenaControlAction: Equatable {
     case toggleAudio
     case toggleHaptics
     case toggleEffects
+    case selectTheme(ArenaThemeKind)
     case resetData
 }
 

--- a/TiltArena/Game/Enemies/EnemyNode.swift
+++ b/TiltArena/Game/Enemies/EnemyNode.swift
@@ -4,7 +4,7 @@ import SpriteKit
 final class EnemyNode: SKNode {
     private let bodyNode: SKShapeNode
     private let ringNode: SKShapeNode
-    private let theme: ArenaTheme
+    private var theme: ArenaTheme
 
     init(enemy: ArenaEnemy, theme: ArenaTheme) {
         bodyNode = SKShapeNode(circleOfRadius: enemy.radius)
@@ -28,6 +28,11 @@ final class EnemyNode: SKNode {
 
     func apply(_ enemy: ArenaEnemy) {
         position = enemy.position
+        applyAppearance(enemy)
+    }
+
+    func applyTheme(_ theme: ArenaTheme, enemy: ArenaEnemy) {
+        self.theme = theme
         applyAppearance(enemy)
     }
 

--- a/TiltArena/Game/Enemies/EnemyTelegraphNode.swift
+++ b/TiltArena/Game/Enemies/EnemyTelegraphNode.swift
@@ -2,20 +2,19 @@ import SpriteKit
 
 @MainActor
 final class EnemyTelegraphNode: SKNode {
+    private let lineNode: SKShapeNode
+
     init(telegraph: EnemyTelegraph, theme: ArenaTheme) {
+        let path = CGMutablePath()
+        for segment in telegraph.segments {
+            Self.appendDashes(from: segment.start, to: segment.end, to: path)
+        }
+        lineNode = SKShapeNode(path: path)
+
         super.init()
 
         zPosition = 14
-
-        let path = CGMutablePath()
-        for segment in telegraph.segments {
-            appendDashes(from: segment.start, to: segment.end, to: path)
-        }
-
-        let lineNode = SKShapeNode(path: path)
-        lineNode.strokeColor = theme.enemyColor.withAlphaComponent(0.58)
-        lineNode.lineWidth = 2
-        lineNode.glowWidth = 2
+        applyTheme(theme)
         addChild(lineNode)
     }
 
@@ -23,7 +22,13 @@ final class EnemyTelegraphNode: SKNode {
         fatalError("EnemyTelegraphNode does not support storyboard initialization.")
     }
 
-    private func appendDashes(from start: CGPoint, to end: CGPoint, to path: CGMutablePath) {
+    func applyTheme(_ theme: ArenaTheme) {
+        lineNode.strokeColor = theme.enemyColor.withAlphaComponent(0.58)
+        lineNode.lineWidth = 2
+        lineNode.glowWidth = 2
+    }
+
+    private static func appendDashes(from start: CGPoint, to end: CGPoint, to path: CGMutablePath) {
         let dx = end.x - start.x
         let dy = end.y - start.y
         let length = hypot(dx, dy)

--- a/TiltArena/Game/Player/PlayerCraftNode.swift
+++ b/TiltArena/Game/Player/PlayerCraftNode.swift
@@ -4,30 +4,36 @@ import SpriteKit
 final class PlayerCraftNode: SKNode {
     private let bodyNode: SKShapeNode
     private let coreNode: SKShapeNode
+    private let visualRadius: CGFloat
 
     init(theme: ArenaTheme, visualRadius: CGFloat) {
         bodyNode = SKShapeNode(path: Self.makeBodyPath(radius: visualRadius))
         coreNode = SKShapeNode(circleOfRadius: visualRadius * 0.2)
+        self.visualRadius = visualRadius
         super.init()
 
         zPosition = 20
 
-        bodyNode.fillColor = theme.playerColor
-        bodyNode.strokeColor = theme.playerAccentColor
-        bodyNode.lineWidth = 1.4
-        bodyNode.lineJoin = .round
-        bodyNode.glowWidth = 1.5
+        applyTheme(theme)
         addChild(bodyNode)
-
-        coreNode.fillColor = theme.playerAccentColor
-        coreNode.strokeColor = .clear
-        coreNode.position = CGPoint(x: 0, y: -visualRadius * 0.03)
-        coreNode.glowWidth = 3
         addChild(coreNode)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("PlayerCraftNode does not support storyboard initialization.")
+    }
+
+    func applyTheme(_ theme: ArenaTheme) {
+        bodyNode.fillColor = theme.playerColor
+        bodyNode.strokeColor = theme.playerAccentColor
+        bodyNode.lineWidth = 1.4
+        bodyNode.lineJoin = .round
+        bodyNode.glowWidth = 1.5
+
+        coreNode.fillColor = theme.playerAccentColor
+        coreNode.strokeColor = .clear
+        coreNode.position = CGPoint(x: 0, y: -visualRadius * 0.03)
+        coreNode.glowWidth = 3
     }
 
     func apply(state: PlayerMovementState) {

--- a/TiltArena/Game/Player/PlayerTrailNode.swift
+++ b/TiltArena/Game/Player/PlayerTrailNode.swift
@@ -9,16 +9,20 @@ final class PlayerTrailNode: SKShapeNode {
         super.init()
 
         zPosition = 8
+        applyTheme(theme)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("PlayerTrailNode does not support storyboard initialization.")
+    }
+
+    func applyTheme(_ theme: ArenaTheme) {
         strokeColor = theme.playerAccentColor.withAlphaComponent(0.65)
         fillColor = .clear
         lineCap = .round
         lineJoin = .round
         lineWidth = 3
         glowWidth = 2
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("PlayerTrailNode does not support storyboard initialization.")
     }
 
     func reset(to position: CGPoint) {

--- a/TiltArena/Game/Theme/ArenaTheme.swift
+++ b/TiltArena/Game/Theme/ArenaTheme.swift
@@ -1,37 +1,72 @@
 import SpriteKit
 
+enum ArenaThemeKind: String, CaseIterable, Codable, Equatable {
+    case darkTacticalRadar
+    case whitePrecisionBoard
+
+    var shortTitle: String {
+        switch self {
+        case .darkTacticalRadar:
+            return "DARK"
+        case .whitePrecisionBoard:
+            return "WHITE"
+        }
+    }
+
+    var theme: ArenaTheme {
+        switch self {
+        case .darkTacticalRadar:
+            return .darkTacticalRadar
+        case .whitePrecisionBoard:
+            return .whitePrecisionBoard
+        }
+    }
+}
+
 struct ArenaTheme {
+    let kind: ArenaThemeKind
     let backgroundColor: SKColor
     let gridColor: SKColor
     let borderColor: SKColor
+    let panelFillColor: SKColor
+    let panelStrokeColor: SKColor
     let playerColor: SKColor
     let playerAccentColor: SKColor
     let enemyColor: SKColor
     let pickupAmber: SKColor
     let pickupBlue: SKColor
     let pickupViolet: SKColor
+    let flameTrailFillColor: SKColor
 
     static let darkTacticalRadar = ArenaTheme(
+        kind: .darkTacticalRadar,
         backgroundColor: SKColor(red: 0.03, green: 0.07, blue: 0.11, alpha: 1.00),
         gridColor: SKColor(red: 0.12, green: 0.35, blue: 0.48, alpha: 0.28),
         borderColor: SKColor(red: 0.37, green: 0.66, blue: 0.78, alpha: 0.70),
+        panelFillColor: SKColor(red: 0.03, green: 0.07, blue: 0.11, alpha: 0.62),
+        panelStrokeColor: SKColor(red: 0.37, green: 0.66, blue: 0.78, alpha: 0.35),
         playerColor: SKColor(red: 0.97, green: 0.98, blue: 1.00, alpha: 1.00),
         playerAccentColor: SKColor(red: 0.09, green: 0.78, blue: 1.00, alpha: 1.00),
         enemyColor: SKColor(red: 1.00, green: 0.16, blue: 0.16, alpha: 1.00),
         pickupAmber: SKColor(red: 1.00, green: 0.75, blue: 0.20, alpha: 1.00),
         pickupBlue: SKColor(red: 0.16, green: 0.78, blue: 1.00, alpha: 1.00),
-        pickupViolet: SKColor(red: 0.55, green: 0.36, blue: 1.00, alpha: 1.00)
+        pickupViolet: SKColor(red: 0.55, green: 0.36, blue: 1.00, alpha: 1.00),
+        flameTrailFillColor: SKColor(red: 1.00, green: 0.46, blue: 0.12, alpha: 0.24)
     )
 
     static let whitePrecisionBoard = ArenaTheme(
-        backgroundColor: SKColor(red: 0.96, green: 0.94, blue: 0.89, alpha: 1.00),
-        gridColor: SKColor(red: 0.68, green: 0.70, blue: 0.72, alpha: 0.28),
-        borderColor: SKColor(red: 0.11, green: 0.12, blue: 0.13, alpha: 0.70),
+        kind: .whitePrecisionBoard,
+        backgroundColor: SKColor(red: 0.95, green: 0.96, blue: 0.94, alpha: 1.00),
+        gridColor: SKColor(red: 0.37, green: 0.41, blue: 0.43, alpha: 0.24),
+        borderColor: SKColor(red: 0.10, green: 0.12, blue: 0.13, alpha: 0.74),
+        panelFillColor: SKColor(red: 1.00, green: 1.00, blue: 0.98, alpha: 0.72),
+        panelStrokeColor: SKColor(red: 0.10, green: 0.12, blue: 0.13, alpha: 0.24),
         playerColor: SKColor(red: 0.10, green: 0.11, blue: 0.12, alpha: 1.00),
         playerAccentColor: SKColor(red: 0.09, green: 0.78, blue: 1.00, alpha: 1.00),
         enemyColor: SKColor(red: 1.00, green: 0.16, blue: 0.16, alpha: 1.00),
         pickupAmber: SKColor(red: 1.00, green: 0.75, blue: 0.20, alpha: 1.00),
         pickupBlue: SKColor(red: 0.16, green: 0.78, blue: 1.00, alpha: 1.00),
-        pickupViolet: SKColor(red: 0.55, green: 0.36, blue: 1.00, alpha: 1.00)
+        pickupViolet: SKColor(red: 0.55, green: 0.36, blue: 1.00, alpha: 1.00),
+        flameTrailFillColor: SKColor(red: 1.00, green: 0.54, blue: 0.18, alpha: 0.18)
     )
 }

--- a/TiltArena/Game/Theme/ArenaThemeRenderer.swift
+++ b/TiltArena/Game/Theme/ArenaThemeRenderer.swift
@@ -15,7 +15,14 @@ final class ArenaThemeRenderer {
 
         root.addChild(makeBackdrop(size: size))
         root.addChild(makeGrid(in: arenaRect))
-        root.addChild(makeRadarRings(in: arenaRect))
+        switch theme.kind {
+        case .darkTacticalRadar:
+            root.addChild(makeRadarRings(in: arenaRect))
+            root.addChild(makeRadarTicks(in: arenaRect))
+        case .whitePrecisionBoard:
+            root.addChild(makePrecisionBoardLines(in: arenaRect))
+            root.addChild(makeCornerBrackets(in: arenaRect))
+        }
         root.addChild(makeBorder(in: arenaRect))
 
         return root
@@ -70,6 +77,82 @@ final class ArenaThemeRenderer {
         }
 
         return root
+    }
+
+    private func makeRadarTicks(in rect: CGRect) -> SKNode {
+        let path = CGMutablePath()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) * 0.46
+
+        for angle in stride(from: 0.0, to: Double.pi * 2, by: Double.pi / 8) {
+            let inner = radius - 10
+            let outer = radius + 4
+            path.move(to: CGPoint(x: center.x + cos(angle) * inner, y: center.y + sin(angle) * inner))
+            path.addLine(to: CGPoint(x: center.x + cos(angle) * outer, y: center.y + sin(angle) * outer))
+        }
+
+        let node = SKShapeNode(path: path)
+        node.strokeColor = theme.gridColor.withAlphaComponent(0.75)
+        node.lineWidth = 0.8
+        node.lineCap = .square
+        return node
+    }
+
+    private func makePrecisionBoardLines(in rect: CGRect) -> SKNode {
+        let path = CGMutablePath()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let tickLength: CGFloat = 18
+
+        path.move(to: CGPoint(x: center.x, y: rect.minY))
+        path.addLine(to: CGPoint(x: center.x, y: rect.maxY))
+        path.move(to: CGPoint(x: rect.minX, y: center.y))
+        path.addLine(to: CGPoint(x: rect.maxX, y: center.y))
+
+        for x in stride(from: rect.minX, through: rect.maxX, by: 96) {
+            path.move(to: CGPoint(x: x, y: rect.minY))
+            path.addLine(to: CGPoint(x: x, y: rect.minY + tickLength))
+            path.move(to: CGPoint(x: x, y: rect.maxY))
+            path.addLine(to: CGPoint(x: x, y: rect.maxY - tickLength))
+        }
+
+        for y in stride(from: rect.minY, through: rect.maxY, by: 96) {
+            path.move(to: CGPoint(x: rect.minX, y: y))
+            path.addLine(to: CGPoint(x: rect.minX + tickLength, y: y))
+            path.move(to: CGPoint(x: rect.maxX, y: y))
+            path.addLine(to: CGPoint(x: rect.maxX - tickLength, y: y))
+        }
+
+        let node = SKShapeNode(path: path)
+        node.strokeColor = theme.gridColor.withAlphaComponent(0.7)
+        node.lineWidth = 0.7
+        node.lineCap = .square
+        return node
+    }
+
+    private func makeCornerBrackets(in rect: CGRect) -> SKNode {
+        let path = CGMutablePath()
+        let length: CGFloat = min(42, min(rect.width, rect.height) * 0.12)
+        let corners = [
+            CGPoint(x: rect.minX, y: rect.minY),
+            CGPoint(x: rect.minX, y: rect.maxY),
+            CGPoint(x: rect.maxX, y: rect.minY),
+            CGPoint(x: rect.maxX, y: rect.maxY)
+        ]
+
+        for corner in corners {
+            let xDirection: CGFloat = corner.x == rect.minX ? 1 : -1
+            let yDirection: CGFloat = corner.y == rect.minY ? 1 : -1
+            path.move(to: corner)
+            path.addLine(to: CGPoint(x: corner.x + length * xDirection, y: corner.y))
+            path.move(to: corner)
+            path.addLine(to: CGPoint(x: corner.x, y: corner.y + length * yDirection))
+        }
+
+        let node = SKShapeNode(path: path)
+        node.strokeColor = theme.borderColor.withAlphaComponent(0.55)
+        node.lineWidth = 1
+        node.lineCap = .square
+        return node
     }
 
     private func makeBorder(in arenaRect: CGRect) -> SKNode {

--- a/TiltArena/Game/UI/ArenaLocalOptionsStore.swift
+++ b/TiltArena/Game/UI/ArenaLocalOptionsStore.swift
@@ -4,8 +4,36 @@ struct ArenaLocalOptions: Codable, Equatable {
     var audioEnabled = true
     var hapticsEnabled = true
     var reducedEffects = false
+    var themeKind: ArenaThemeKind = .darkTacticalRadar
 
     static let defaults = ArenaLocalOptions()
+
+    init(
+        audioEnabled: Bool = true,
+        hapticsEnabled: Bool = true,
+        reducedEffects: Bool = false,
+        themeKind: ArenaThemeKind = .darkTacticalRadar
+    ) {
+        self.audioEnabled = audioEnabled
+        self.hapticsEnabled = hapticsEnabled
+        self.reducedEffects = reducedEffects
+        self.themeKind = themeKind
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case audioEnabled
+        case hapticsEnabled
+        case reducedEffects
+        case themeKind
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        audioEnabled = try container.decodeIfPresent(Bool.self, forKey: .audioEnabled) ?? true
+        hapticsEnabled = try container.decodeIfPresent(Bool.self, forKey: .hapticsEnabled) ?? true
+        reducedEffects = try container.decodeIfPresent(Bool.self, forKey: .reducedEffects) ?? false
+        themeKind = (try? container.decode(ArenaThemeKind.self, forKey: .themeKind)) ?? .darkTacticalRadar
+    }
 }
 
 final class ArenaLocalOptionsStore {

--- a/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
+++ b/TiltArena/Game/Weapons/ArenaScene+WeaponEffects.swift
@@ -83,7 +83,7 @@ extension ArenaScene {
         ring.run(.sequence([expand, .removeFromParent()]))
     }
 
-    func playGravityWellEffect(at position: CGPoint) {
+    func playGravityWellEffect(at position: CGPoint, duration: TimeInterval? = nil) {
         gravityWellEffectNode?.removeFromParent()
         let container = SKNode()
         container.position = position
@@ -96,7 +96,7 @@ extension ArenaScene {
         ring.lineWidth = 1.8
         ring.glowWidth = 5
         container.addChild(ring)
-        let duration = max(0.12, weaponResolver.configuration.gravityWellPullDuration)
+        let duration = max(0.12, duration ?? weaponResolver.configuration.gravityWellPullDuration)
         let pulse = SKAction.group([
             .scale(to: 0.25, duration: duration),
             .fadeOut(withDuration: duration)

--- a/TiltArena/Game/Weapons/FlameTrailEffectNode.swift
+++ b/TiltArena/Game/Weapons/FlameTrailEffectNode.swift
@@ -2,7 +2,7 @@ import SpriteKit
 
 @MainActor
 final class FlameTrailEffectNode: SKNode {
-    private let theme: ArenaTheme
+    private var theme: ArenaTheme
     private var segmentNodes: [Int: SKShapeNode] = [:]
 
     init(theme: ArenaTheme) {
@@ -41,13 +41,23 @@ final class FlameTrailEffectNode: SKNode {
         removeAllChildren()
     }
 
+    func applyTheme(_ theme: ArenaTheme) {
+        self.theme = theme
+        for node in segmentNodes.values {
+            applyAppearance(to: node)
+        }
+    }
+
     private func makeSegmentNode(radius: CGFloat) -> SKShapeNode {
         let node = SKShapeNode(circleOfRadius: radius)
-        let orangeFill = SKColor(red: 1.0, green: 0.46, blue: 0.12, alpha: 0.24)
-        node.fillColor = orangeFill
+        applyAppearance(to: node)
+        return node
+    }
+
+    private func applyAppearance(to node: SKShapeNode) {
+        node.fillColor = theme.flameTrailFillColor
         node.strokeColor = theme.pickupAmber.withAlphaComponent(0.9)
         node.lineWidth = 1.4
         node.glowWidth = 2
-        return node
     }
 }

--- a/TiltArena/Game/Weapons/WeaponPickupNode.swift
+++ b/TiltArena/Game/Weapons/WeaponPickupNode.swift
@@ -4,27 +4,19 @@ import SpriteKit
 final class WeaponPickupNode: SKNode {
     private let bodyNode: SKShapeNode
     private let ringNode: SKShapeNode
+    private var theme: ArenaTheme
 
     init(pickup: WeaponPickup, theme: ArenaTheme) {
         bodyNode = SKShapeNode(path: Self.makeDiamondPath(radius: pickup.radius))
         ringNode = SKShapeNode(circleOfRadius: pickup.radius * 1.45)
+        self.theme = theme
         super.init()
 
         zPosition = 14
 
-        let color = Self.color(for: pickup.kind, theme: theme)
-        ringNode.strokeColor = color.withAlphaComponent(0.45)
-        ringNode.lineWidth = 1
-        ringNode.fillColor = .clear
-        ringNode.glowWidth = 1
+        applyAppearance(for: pickup.kind)
         addChild(ringNode)
-
-        bodyNode.fillColor = color.withAlphaComponent(0.9)
-        bodyNode.strokeColor = theme.playerColor.withAlphaComponent(0.8)
-        bodyNode.lineWidth = 1.1
-        bodyNode.glowWidth = 2
         addChild(bodyNode)
-
         apply(pickup)
     }
 
@@ -34,6 +26,24 @@ final class WeaponPickupNode: SKNode {
 
     func apply(_ pickup: WeaponPickup) {
         position = pickup.position
+    }
+
+    func applyTheme(_ theme: ArenaTheme, pickup: WeaponPickup) {
+        self.theme = theme
+        applyAppearance(for: pickup.kind)
+    }
+
+    private func applyAppearance(for kind: WeaponKind) {
+        let color = Self.color(for: kind, theme: theme)
+        ringNode.strokeColor = color.withAlphaComponent(0.45)
+        ringNode.lineWidth = 1
+        ringNode.fillColor = .clear
+        ringNode.glowWidth = 1
+
+        bodyNode.fillColor = color.withAlphaComponent(0.9)
+        bodyNode.strokeColor = theme.playerColor.withAlphaComponent(0.8)
+        bodyNode.lineWidth = 1.1
+        bodyNode.glowWidth = 2
     }
 
     private static func color(for kind: WeaponKind, theme: ArenaTheme) -> SKColor {

--- a/TiltArenaTests/ArenaLocalOptionsStoreTests.swift
+++ b/TiltArenaTests/ArenaLocalOptionsStoreTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import TiltArena
 
 final class ArenaLocalOptionsStoreTests: XCTestCase {
+    private static let optionsKey = "tiltArena.localOptions"
+
     private var defaults: UserDefaults!
     private var suiteName: String!
 
@@ -21,15 +23,68 @@ final class ArenaLocalOptionsStoreTests: XCTestCase {
 
     func testOptionsPersistAndReset() {
         let store = ArenaLocalOptionsStore(defaults: defaults)
-        store.options = ArenaLocalOptions(audioEnabled: false, hapticsEnabled: false, reducedEffects: true)
+        store.options = ArenaLocalOptions(
+            audioEnabled: false,
+            hapticsEnabled: false,
+            reducedEffects: true,
+            themeKind: .whitePrecisionBoard
+        )
 
         XCTAssertEqual(
             ArenaLocalOptionsStore(defaults: defaults).options,
-            ArenaLocalOptions(audioEnabled: false, hapticsEnabled: false, reducedEffects: true)
+            ArenaLocalOptions(
+                audioEnabled: false,
+                hapticsEnabled: false,
+                reducedEffects: true,
+                themeKind: .whitePrecisionBoard
+            )
         )
 
         store.reset()
 
         XCTAssertEqual(store.options, .defaults)
+    }
+
+    func testLegacyOptionsDecodeWithDefaultTheme() {
+        let legacyJSON = """
+        {
+          "audioEnabled": false,
+          "hapticsEnabled": true,
+          "reducedEffects": true
+        }
+        """
+        defaults.set(Data(legacyJSON.utf8), forKey: Self.optionsKey)
+
+        XCTAssertEqual(
+            ArenaLocalOptionsStore(defaults: defaults).options,
+            ArenaLocalOptions(
+                audioEnabled: false,
+                hapticsEnabled: true,
+                reducedEffects: true,
+                themeKind: .darkTacticalRadar
+            )
+        )
+    }
+
+    func testUnknownThemeDecodePreservesOtherOptionsWithDefaultTheme() {
+        let json = """
+        {
+          "audioEnabled": false,
+          "hapticsEnabled": false,
+          "reducedEffects": true,
+          "themeKind": "futureTheme"
+        }
+        """
+        defaults.set(Data(json.utf8), forKey: Self.optionsKey)
+
+        XCTAssertEqual(
+            ArenaLocalOptionsStore(defaults: defaults).options,
+            ArenaLocalOptions(
+                audioEnabled: false,
+                hapticsEnabled: false,
+                reducedEffects: true,
+                themeKind: .darkTacticalRadar
+            )
+        )
     }
 }

--- a/TiltArenaTests/ArenaThemeTests.swift
+++ b/TiltArenaTests/ArenaThemeTests.swift
@@ -1,0 +1,67 @@
+import SpriteKit
+import XCTest
+@testable import TiltArena
+
+final class ArenaThemeTests: XCTestCase {
+    func testThemeKindOrderAndTitlesAreStable() {
+        XCTAssertEqual(ArenaThemeKind.allCases, [.darkTacticalRadar, .whitePrecisionBoard])
+        XCTAssertEqual(ArenaThemeKind.darkTacticalRadar.shortTitle, "DARK")
+        XCTAssertEqual(ArenaThemeKind.whitePrecisionBoard.shortTitle, "WHITE")
+    }
+
+    func testThemeKindMapsToMatchingTheme() {
+        XCTAssertEqual(ArenaThemeKind.darkTacticalRadar.theme.kind, .darkTacticalRadar)
+        XCTAssertEqual(ArenaThemeKind.whitePrecisionBoard.theme.kind, .whitePrecisionBoard)
+    }
+
+    func testGameplayColorRolesStayDistinctAcrossThemes() {
+        for themeKind in ArenaThemeKind.allCases {
+            let theme = themeKind.theme
+            let enemy = components(of: theme.enemyColor)
+            XCTAssertGreaterThan(enemy.red - enemy.green, 0.6)
+            XCTAssertGreaterThan(enemy.red - enemy.blue, 0.6)
+
+            XCTAssertGreaterThan(colorDistance(theme.enemyColor, theme.pickupAmber), 0.4)
+            XCTAssertGreaterThan(colorDistance(theme.enemyColor, theme.pickupBlue), 0.4)
+            XCTAssertGreaterThan(colorDistance(theme.enemyColor, theme.pickupViolet), 0.4)
+            XCTAssertLessThan(components(of: theme.gridColor).alpha, components(of: theme.enemyColor).alpha)
+            XCTAssertLessThan(components(of: theme.panelStrokeColor).alpha, components(of: theme.enemyColor).alpha)
+        }
+    }
+
+    func testWhitePrecisionBoardAvoidsBeigeDominance() {
+        let background = components(of: ArenaTheme.whitePrecisionBoard.backgroundColor)
+
+        XCTAssertLessThan(abs(background.red - background.blue), 0.04)
+        XCTAssertGreaterThanOrEqual(background.green, background.red)
+        XCTAssertGreaterThan(background.blue, 0.92)
+    }
+
+    private func components(of color: SKColor) -> ColorComponents {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        XCTAssertTrue(color.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
+
+        return ColorComponents(red: red, green: green, blue: blue, alpha: alpha)
+    }
+
+    private func colorDistance(_ lhs: SKColor, _ rhs: SKColor) -> CGFloat {
+        let lhsComponents = components(of: lhs)
+        let rhsComponents = components(of: rhs)
+        let redDelta = lhsComponents.red - rhsComponents.red
+        let greenDelta = lhsComponents.green - rhsComponents.green
+        let blueDelta = lhsComponents.blue - rhsComponents.blue
+
+        return sqrt(redDelta * redDelta + greenDelta * greenDelta + blueDelta * blueDelta)
+    }
+}
+
+private struct ColorComponents {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}


### PR DESCRIPTION
## Summary

- Add persisted arena theme selection with Dark Tactical Radar as the default and White Precision Board as the alternate arena treatment.
- Restyle arena backgrounds, panels, player, enemies, pickups, telegraphs, trails, and weapon effects from the selected theme without changing gameplay state.
- Add regression coverage for theme defaults, local-options persistence, color-role readability, and unknown saved theme fallback.

## Validation

- `xcodegen generate`
- `swiftlint lint --no-cache` (passes with 3 existing unrelated warnings)
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -destination 'platform=iOS Simulator,id=F9038B9B-519B-49B6-9531-99DAA4F64D6C' -derivedDataPath /private/tmp/tilt-arena-derived build`
- `xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -destination 'platform=iOS Simulator,id=F9038B9B-519B-49B6-9531-99DAA4F64D6C' -derivedDataPath /private/tmp/tilt-arena-derived test` (171 tests, 0 failures)

Closes #14
