### PR TITLE
Fix safe-area refresh handling

### DIFF
--- a/TiltArena/App/GameViewController.swift
+++ b/TiltArena/App/GameViewController.swift
@@ -24,16 +24,15 @@ final class GameViewController: UIViewController {
         }
 
         if hasPresentedScene {
-            spriteView.scene?.size = spriteView.bounds.size
-            (spriteView.scene as? ArenaScene)?.refreshSafeAreaLayout()
+            updatePresentedSceneSize(in: spriteView)
         } else {
-            let scene = ArenaScene(size: spriteView.bounds.size)
-            scene.orientationDelegate = self
-            scene.scaleMode = .resizeFill
-            spriteView.presentScene(scene)
-            scene.refreshSafeAreaLayout()
-            hasPresentedScene = true
+            presentArenaScene(in: spriteView)
         }
+    }
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        refreshPresentedSceneSafeAreaLayout()
     }
 
     override var prefersStatusBarHidden: Bool {
@@ -61,6 +60,29 @@ final class GameViewController: UIViewController {
         spriteView.showsFPS = true
         spriteView.showsNodeCount = true
         #endif
+    }
+
+    private func presentArenaScene(in spriteView: SKView) {
+        let scene = ArenaScene(size: spriteView.bounds.size)
+        scene.orientationDelegate = self
+        scene.scaleMode = .resizeFill
+        spriteView.presentScene(scene)
+        scene.refreshSafeAreaLayout()
+        hasPresentedScene = true
+    }
+
+    private func updatePresentedSceneSize(in spriteView: SKView) {
+        let sceneSize = spriteView.bounds.size
+        guard spriteView.scene?.size != sceneSize else {
+            return
+        }
+
+        spriteView.scene?.size = sceneSize
+        refreshPresentedSceneSafeAreaLayout()
+    }
+
+    private func refreshPresentedSceneSafeAreaLayout() {
+        ((view as? SKView)?.scene as? ArenaScene)?.refreshSafeAreaLayout()
     }
 
     @discardableResult

--- a/TiltArenaTests/ArenaLandscapeUILayoutTests.swift
+++ b/TiltArenaTests/ArenaLandscapeUILayoutTests.swift
@@ -15,6 +15,18 @@ final class ArenaLandscapeUILayoutTests: XCTestCase {
         XCTAssertEqual(layout.bottomCenterPosition, CGPoint(x: 426, y: 45))
     }
 
+    func testSafeRectHonorsAsymmetricLandscapeInsets() {
+        let layout = ArenaLandscapeUILayout(
+            sceneSize: CGSize(width: 932, height: 430),
+            safeAreaInsets: UIEdgeInsets(top: 9, left: 59, bottom: 34, right: 21),
+            margin: 24
+        )
+
+        XCTAssertEqual(layout.safeRect, CGRect(x: 83, y: 58, width: 804, height: 339))
+        XCTAssertEqual(layout.titlePosition, CGPoint(x: 83, y: 397))
+        XCTAssertEqual(layout.bottomCenterPosition, CGPoint(x: 485, y: 58))
+    }
+
     func testBottomButtonsRemainCenteredInLandscapeSafeRect() {
         let layout = ArenaLandscapeUILayout(
             sceneSize: CGSize(width: 800, height: 360),

--- a/TiltArenaTests/GameViewControllerTests.swift
+++ b/TiltArenaTests/GameViewControllerTests.swift
@@ -1,3 +1,4 @@
+import SpriteKit
 import UIKit
 import XCTest
 @testable import TiltArena
@@ -58,5 +59,34 @@ final class GameViewControllerTests: XCTestCase {
 
         XCTAssertEqual(lockedOrientation, .landscapeRight)
         XCTAssertEqual(controller.supportedInterfaceOrientations, .landscapeRight)
+    }
+
+    @MainActor
+    func testSafeAreaInsetsChangeRefreshesPresentedSceneLayout() {
+        let spriteView = SafeAreaTestSKView(frame: CGRect(x: 0, y: 0, width: 852, height: 393))
+        let controller = GameViewController()
+        controller.view = spriteView
+        controller.viewDidLoad()
+        controller.viewDidLayoutSubviews()
+
+        guard let scene = spriteView.scene as? ArenaScene else {
+            XCTFail("Expected GameViewController to present ArenaScene.")
+            return
+        }
+
+        XCTAssertEqual(scene.movementController.state.position, CGPoint(x: 426, y: 196.5))
+
+        spriteView.testSafeAreaInsets = UIEdgeInsets(top: 0, left: 59, bottom: 21, right: 47)
+        controller.viewSafeAreaInsetsDidChange()
+
+        XCTAssertEqual(scene.movementController.state.position, CGPoint(x: 432, y: 207))
+    }
+}
+
+private final class SafeAreaTestSKView: SKView {
+    var testSafeAreaInsets: UIEdgeInsets = .zero
+
+    override var safeAreaInsets: UIEdgeInsets {
+        testSafeAreaInsets
     }
 }


### PR DESCRIPTION
## Summary
- refresh SpriteKit safe-area layout from UIViewController.viewSafeAreaInsetsDidChange()
- keep scene-size refreshes tied to SKView bounds changes in viewDidLayoutSubviews()
- add asymmetric landscape safe-area coverage and a controller regression for safe-area refreshes

## Validation
- git diff --check
- xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME= build-for-testing
- swiftlint lint --no-cache (exits 0; existing warnings remain)

Closes #66