### PR TITLE
Add gameplay haptics feedback

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -20,6 +20,7 @@ final class ArenaScene: SKScene {
     private let tiltSettingsStore = TiltSettingsStore()
     private let runProfileStore = RunProfileStore()
     private let localOptionsStore = ArenaLocalOptionsStore()
+    private let hapticsController = ArenaHapticsController()
     private var arenaRoot = SKNode()
     private let uiRoot = SKNode()
     private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
@@ -97,6 +98,7 @@ final class ArenaScene: SKScene {
     override func didMove(to view: SKView) {
         runProfile = runProfileStore.profile
         localOptions = localOptionsStore.options
+        syncHapticsOption()
         backgroundColor = theme.backgroundColor
         rebuildArena()
         if flameTrailEffectNode.parent == nil { addChild(flameTrailEffectNode) }
@@ -493,6 +495,7 @@ final class ArenaScene: SKScene {
         runController.start()
         readyHoldController.reset()
         resetActiveRun()
+        hapticsController.prepare()
         show(.activeGameplay)
     }
 
@@ -511,9 +514,14 @@ final class ArenaScene: SKScene {
     private func finishRun(playFeedback: Bool = true) {
         previousBestScore = runProfile.bestScore
         runController.endRun(mode: selectedMode)
+        let isNewBest = (runController.finalizedSummary?.score ?? runController.score) > previousBestScore
         persistFinalRunIfNeeded()
         if playFeedback {
             playDeathFeedback()
+            playHaptic(.death)
+        }
+        if isNewBest {
+            playHaptic(.newBest)
         }
         show(.postRun)
     }
@@ -767,9 +775,13 @@ final class ArenaScene: SKScene {
         }
 
         for pickup in collectedPickups {
+            let creditedDangerGrab: Bool
             if isDangerGrab(pickup) {
-                runController.recordDangerGrab(pickupID: pickup.id)
+                creditedDangerGrab = runController.recordDangerGrab(pickupID: pickup.id)
+            } else {
+                creditedDangerGrab = false
             }
+            playHaptic(creditedDangerGrab ? .dangerPickup : .pickup)
 
             removePickup(id: pickup.id)
             applyWeapon(pickup.kind, playerPosition: currentPlayerPosition)
@@ -847,7 +859,9 @@ final class ArenaScene: SKScene {
             return
         }
 
+        let previousComboMultiplier = runController.comboMultiplier
         runController.recordEnemyKills(count: enemyIDs.count, weaponKind: weaponKind)
+        playEnemyClearHaptics(killCount: enemyIDs.count, previousComboMultiplier: previousComboMultiplier)
         removeEnemies(ids: enemyIDs)
     }
 
@@ -927,14 +941,19 @@ final class ArenaScene: SKScene {
         razorShieldTimeRemaining = max(0, razorShieldTimeRemaining - max(0, deltaTime))
 
         if razorShieldTimeRemaining == 0 {
-            deactivateRazorShield()
+            deactivateRazorShield(emitHaptic: true)
         }
     }
 
-    private func deactivateRazorShield() {
+    private func deactivateRazorShield(emitHaptic: Bool = false) {
+        let hadActiveShield = razorShieldNode != nil || razorShieldTimeRemaining > 0
         razorShieldTimeRemaining = 0
         razorShieldNode?.removeFromParent()
         razorShieldNode = nil
+
+        if emitHaptic, hadActiveShield, runController.phase == .active {
+            playHaptic(.shieldExpired)
+        }
     }
 
     private func updateFlameTrail(deltaTime: TimeInterval, playerPosition: CGPoint) {
@@ -999,6 +1018,23 @@ final class ArenaScene: SKScene {
         let settle = SKAction.scale(to: 1.0, duration: 0.08)
 
         playerNode?.run(.sequence([pulse, settle]))
+    }
+
+    private func syncHapticsOption() {
+        hapticsController.isEnabled = localOptions.hapticsEnabled
+    }
+
+    private func playHaptic(_ event: ArenaHapticEvent) {
+        hapticsController.play(event)
+    }
+
+    private func playEnemyClearHaptics(killCount: Int, previousComboMultiplier: Int) {
+        playHaptic(.enemyClear(count: killCount))
+
+        let currentComboMultiplier = runController.comboMultiplier
+        if currentComboMultiplier > previousComboMultiplier {
+            playHaptic(.comboMilestone(multiplier: currentComboMultiplier))
+        }
     }
 
     private func updateRunDisplay() {
@@ -1083,12 +1119,18 @@ final class ArenaScene: SKScene {
             radius: runController.configuration.playerHitRadius + runController.configuration.nearMissEdgeGap
         )
 
+        var didRecordNearMiss = false
+
         for enemy in enemies where nearMissCircle.intersects(enemy.collisionCircle) {
             guard !hitCircle.intersects(enemy.collisionCircle) else {
                 continue
             }
 
-            runController.recordNearMiss(enemyID: enemy.id)
+            didRecordNearMiss = runController.recordNearMiss(enemyID: enemy.id) || didRecordNearMiss
+        }
+
+        if didRecordNearMiss {
+            playHaptic(.nearMiss)
         }
     }
 
@@ -1844,6 +1886,7 @@ private extension ArenaScene {
         case .toggleHaptics:
             localOptions.hapticsEnabled.toggle()
             localOptionsStore.options = localOptions
+            syncHapticsOption()
             rebuildUI()
         case .toggleEffects:
             localOptions.reducedEffects.toggle()
@@ -1904,6 +1947,7 @@ private extension ArenaScene {
         localOptionsStore.reset()
         runProfile = RunProfile()
         localOptions = .defaults
+        syncHapticsOption()
         lastProgressionResult = nil
         selectedMode = .classic
         resetDataArmed = false
@@ -2351,7 +2395,9 @@ private extension ArenaScene {
             return
         }
         playFrozenShatterEffect(at: positions(forEnemyIDs: shatterIDs), color: theme.playerColor)
+        let previousComboMultiplier = runController.comboMultiplier
         runController.recordFrozenShatters(count: shatterIDs.count, weaponKind: .freezeBurst)
+        playEnemyClearHaptics(killCount: shatterIDs.count, previousComboMultiplier: previousComboMultiplier)
         removeEnemies(ids: shatterIDs)
     }
 }

--- a/TiltArena/Game/Feedback/ArenaHapticsController.swift
+++ b/TiltArena/Game/Feedback/ArenaHapticsController.swift
@@ -1,0 +1,144 @@
+import CoreGraphics
+import UIKit
+
+enum ArenaHapticImpactStyle: Equatable {
+    case light
+    case medium
+    case heavy
+}
+
+enum ArenaHapticNotificationStyle: Equatable {
+    case success
+    case warning
+    case error
+}
+
+struct ArenaHapticPattern: Equatable {
+    enum Kind: Equatable {
+        case impact(ArenaHapticImpactStyle)
+        case notification(ArenaHapticNotificationStyle)
+    }
+
+    let kind: Kind
+    let intensity: CGFloat?
+
+    static func impact(_ style: ArenaHapticImpactStyle, intensity: CGFloat) -> ArenaHapticPattern {
+        ArenaHapticPattern(kind: .impact(style), intensity: intensity)
+    }
+
+    static func notification(_ style: ArenaHapticNotificationStyle) -> ArenaHapticPattern {
+        ArenaHapticPattern(kind: .notification(style), intensity: nil)
+    }
+}
+
+enum ArenaHapticEvent: Equatable {
+    case pickup
+    case dangerPickup
+    case nearMiss
+    case enemyClear(count: Int)
+    case comboMilestone(multiplier: Int)
+    case shieldExpired
+    case death
+    case newBest
+
+    var pattern: ArenaHapticPattern {
+        switch self {
+        case .pickup:
+            return .impact(.light, intensity: 0.45)
+        case .dangerPickup:
+            return .impact(.heavy, intensity: 0.82)
+        case .nearMiss:
+            return .impact(.light, intensity: 0.35)
+        case let .enemyClear(count) where count >= 8:
+            return .impact(.heavy, intensity: 0.9)
+        case let .enemyClear(count) where count >= 3:
+            return .impact(.medium, intensity: 0.68)
+        case .enemyClear:
+            return .impact(.light, intensity: 0.42)
+        case let .comboMilestone(multiplier) where multiplier >= 4:
+            return .impact(.heavy, intensity: 1.0)
+        case .comboMilestone:
+            return .impact(.medium, intensity: 0.78)
+        case .shieldExpired:
+            return .notification(.warning)
+        case .death:
+            return .notification(.error)
+        case .newBest:
+            return .notification(.success)
+        }
+    }
+}
+
+@MainActor
+final class ArenaHapticsController {
+    var isEnabled = true {
+        didSet {
+            if isEnabled {
+                prepare()
+            }
+        }
+    }
+
+    private let lightImpactGenerator = UIImpactFeedbackGenerator(style: .light)
+    private let mediumImpactGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private let heavyImpactGenerator = UIImpactFeedbackGenerator(style: .heavy)
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+
+    func prepare() {
+        guard isEnabled else {
+            return
+        }
+
+        lightImpactGenerator.prepare()
+        mediumImpactGenerator.prepare()
+        heavyImpactGenerator.prepare()
+        notificationGenerator.prepare()
+    }
+
+    func play(_ event: ArenaHapticEvent) {
+        guard isEnabled else {
+            return
+        }
+
+        play(event.pattern)
+    }
+
+    private func play(_ pattern: ArenaHapticPattern) {
+        switch pattern.kind {
+        case let .impact(style):
+            impactGenerator(for: style).impactOccurred(intensity: pattern.clampedIntensity)
+        case let .notification(style):
+            notificationGenerator.notificationOccurred(style.feedbackType)
+        }
+    }
+
+    private func impactGenerator(for style: ArenaHapticImpactStyle) -> UIImpactFeedbackGenerator {
+        switch style {
+        case .light:
+            return lightImpactGenerator
+        case .medium:
+            return mediumImpactGenerator
+        case .heavy:
+            return heavyImpactGenerator
+        }
+    }
+}
+
+private extension ArenaHapticPattern {
+    var clampedIntensity: CGFloat {
+        min(1, max(0, intensity ?? 1))
+    }
+}
+
+private extension ArenaHapticNotificationStyle {
+    var feedbackType: UINotificationFeedbackGenerator.FeedbackType {
+        switch self {
+        case .success:
+            return .success
+        case .warning:
+            return .warning
+        case .error:
+            return .error
+        }
+    }
+}

--- a/TiltArenaTests/ArenaHapticsControllerTests.swift
+++ b/TiltArenaTests/ArenaHapticsControllerTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import TiltArena
+
+final class ArenaHapticsControllerTests: XCTestCase {
+    func testPickupAndDangerPickupUseDistinctImpactPatterns() {
+        XCTAssertEqual(
+            ArenaHapticEvent.pickup.pattern,
+            .impact(.light, intensity: 0.45)
+        )
+        XCTAssertEqual(
+            ArenaHapticEvent.dangerPickup.pattern,
+            .impact(.heavy, intensity: 0.82)
+        )
+    }
+
+    func testNearMissUsesLightImpactPattern() {
+        XCTAssertEqual(
+            ArenaHapticEvent.nearMiss.pattern,
+            .impact(.light, intensity: 0.35)
+        )
+    }
+
+    func testEnemyClearScalesWithClearSize() {
+        XCTAssertEqual(
+            ArenaHapticEvent.enemyClear(count: 1).pattern,
+            .impact(.light, intensity: 0.42)
+        )
+        XCTAssertEqual(
+            ArenaHapticEvent.enemyClear(count: 3).pattern,
+            .impact(.medium, intensity: 0.68)
+        )
+        XCTAssertEqual(
+            ArenaHapticEvent.enemyClear(count: 8).pattern,
+            .impact(.heavy, intensity: 0.9)
+        )
+    }
+
+    func testComboMilestoneScalesWithMultiplier() {
+        XCTAssertEqual(
+            ArenaHapticEvent.comboMilestone(multiplier: 2).pattern,
+            .impact(.medium, intensity: 0.78)
+        )
+        XCTAssertEqual(
+            ArenaHapticEvent.comboMilestone(multiplier: 4).pattern,
+            .impact(.heavy, intensity: 1.0)
+        )
+    }
+
+    func testShieldDeathAndNewBestUseDistinctNotificationPatterns() {
+        XCTAssertEqual(
+            ArenaHapticEvent.shieldExpired.pattern,
+            .notification(.warning)
+        )
+        XCTAssertEqual(
+            ArenaHapticEvent.death.pattern,
+            .notification(.error)
+        )
+        XCTAssertEqual(
+            ArenaHapticEvent.newBest.pattern,
+            .notification(.success)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a UIKit-backed gameplay haptics controller with testable event-to-pattern mapping.
- Wires haptics into pickup, danger pickup, near miss, enemy clear, combo milestone, shield expiry, death, and new-best events.
- Reuses the existing HAPTICS option without adding settings schema, audio assets, music, Core Haptics, or visual changes.

## Validation
- xcodegen generate
- plutil -lint TiltArena/Resources/Info.plist
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'id=7211F793-06FA-4695-B8CD-6E6A600CFCAE' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test

Closes #70
Advances #15