### PR TITLE
Add diagnostics logging export

### DIFF
--- a/TiltArena/App/AppDelegate.swift
+++ b/TiltArena/App/AppDelegate.swift
@@ -8,10 +8,31 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        AppDiagnostics.bootstrap()
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = GameViewController()
         window.makeKeyAndVisible()
         self.window = window
         return true
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        AppDiagnostics.logger(.app).info("app.active")
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        AppDiagnostics.logger(.app).info("app.inactive")
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        AppDiagnostics.logger(.app).notice("app.background")
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        AppDiagnostics.logger(.app).notice("app.foreground")
+    }
+
+    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+        AppDiagnostics.logger(.app).warning("app.memory_warning")
     }
 }

--- a/TiltArena/App/GameViewController.swift
+++ b/TiltArena/App/GameViewController.swift
@@ -65,6 +65,7 @@ final class GameViewController: UIViewController {
     private func presentArenaScene(in spriteView: SKView) {
         let scene = ArenaScene(size: spriteView.bounds.size)
         scene.orientationDelegate = self
+        scene.diagnosticsDelegate = self
         scene.scaleMode = .resizeFill
         spriteView.presentScene(scene)
         scene.refreshSafeAreaLayout()
@@ -144,5 +145,28 @@ extension GameViewController: ArenaSceneOrientationDelegate {
 
     func arenaSceneRequestsOrientationUnlock(_ scene: ArenaScene) {
         unlockRunOrientation()
+    }
+}
+
+extension GameViewController: ArenaSceneDiagnosticsDelegate {
+    func arenaSceneRequestsDiagnosticsExport(
+        _ scene: ArenaScene,
+        snapshot: DiagnosticGameplaySnapshot
+    ) {
+        do {
+            let bundleURL = try AppDiagnostics.makeExportBundle(gameplay: snapshot)
+            let activityController = UIActivityViewController(
+                activityItems: [bundleURL],
+                applicationActivities: nil
+            )
+            AppDiagnostics.logger(.app).notice("diagnostics.export.presented", metadata: [
+                "bundle": "\(bundleURL.lastPathComponent)"
+            ])
+            present(activityController, animated: true)
+        } catch {
+            AppDiagnostics.logger(.app).error("diagnostics.export.failed", metadata: [
+                "error": "\(error)"
+            ])
+        }
     }
 }

--- a/TiltArena/Diagnostics/AppDiagnostics.swift
+++ b/TiltArena/Diagnostics/AppDiagnostics.swift
@@ -25,9 +25,7 @@ enum AppDiagnostics {
         }
         isBootstrapped = true
 
-        logger(.app).notice("app.launch", metadata: [
-            "sessionID": "\(currentSessionID)"
-        ])
+        logger(.app).notice("app.launch")
     }
 
     static func logger(_ category: DiagnosticCategory) -> Logger {

--- a/TiltArena/Diagnostics/AppDiagnostics.swift
+++ b/TiltArena/Diagnostics/AppDiagnostics.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Logging
+
+@MainActor
+enum AppDiagnostics {
+    nonisolated static let subsystem = "com.xlc.TiltArena"
+    private static let sessionID = UUID().uuidString
+    private static var isBootstrapped = false
+
+    static func bootstrap(store: DiagnosticLogStore = .shared) {
+        guard !isBootstrapped else {
+            return
+        }
+
+        let currentSessionID = sessionID
+        LoggingSystem.bootstrap { label in
+            MultiplexLogHandler([
+                DiagnosticOSLogHandler(label: label),
+                DiagnosticJSONLLogHandler(
+                    label: label,
+                    store: store,
+                    sessionID: currentSessionID
+                )
+            ])
+        }
+        isBootstrapped = true
+
+        logger(.app).notice("app.launch", metadata: [
+            "sessionID": "\(currentSessionID)"
+        ])
+    }
+
+    static func logger(_ category: DiagnosticCategory) -> Logger {
+        Logger(label: "\(subsystem).\(category.rawValue)")
+    }
+
+    static func makeExportBundle(gameplay: DiagnosticGameplaySnapshot?) throws -> URL {
+        let generatedAt = Date()
+        let metadata = DiagnosticExportMetadataFactory.make(
+            generatedAt: generatedAt,
+            sessionID: sessionID,
+            gameplay: gameplay
+        )
+        let builder = DiagnosticBundleBuilder(
+            outputDirectoryURL: exportDirectoryURL()
+        )
+        return try builder.makeBundle(metadata: metadata)
+    }
+
+    private static func exportDirectoryURL() -> URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("DiagnosticsExports", isDirectory: true)
+    }
+}
+
+enum DiagnosticCategory: String {
+    case app
+    case scene
+    case input
+    case run
+    case spawn
+    case weapon
+    case profile
+    case performance
+}

--- a/TiltArena/Diagnostics/DiagnosticExport.swift
+++ b/TiltArena/Diagnostics/DiagnosticExport.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 
 struct DiagnosticGameplaySnapshot: Codable, Equatable {
@@ -48,7 +47,6 @@ struct DiagnosticAppMetadata: Codable, Equatable {
 struct DiagnosticDeviceMetadata: Codable, Equatable {
     let osName: String
     let osVersion: String
-    let modelIdentifier: String
     let localeIdentifier: String
 }
 
@@ -73,26 +71,10 @@ enum DiagnosticExportMetadataFactory {
             device: DiagnosticDeviceMetadata(
                 osName: "iOS",
                 osVersion: processInfo.operatingSystemVersionString,
-                modelIdentifier: modelIdentifier(),
                 localeIdentifier: locale.identifier
             ),
             gameplay: gameplay
         )
-    }
-
-    private static func modelIdentifier() -> String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-
-        let bytes = Mirror(reflecting: systemInfo.machine).children.compactMap { child -> UInt8? in
-            guard let value = child.value as? Int8, value != 0 else {
-                return nil
-            }
-
-            return UInt8(value)
-        }
-
-        return String(bytes: bytes, encoding: .ascii) ?? "unknown"
     }
 }
 

--- a/TiltArena/Diagnostics/DiagnosticExport.swift
+++ b/TiltArena/Diagnostics/DiagnosticExport.swift
@@ -1,0 +1,163 @@
+import Darwin
+import Foundation
+
+struct DiagnosticGameplaySnapshot: Codable, Equatable {
+    let uiState: String
+    let selectedMode: String
+    let runPhase: String
+    let score: Int
+    let survivalTime: TimeInterval
+    let enemyCount: Int
+    let pickupCount: Int
+    let localOptions: DiagnosticLocalOptionsSnapshot
+    let profile: DiagnosticProfileSnapshot
+}
+
+struct DiagnosticLocalOptionsSnapshot: Codable, Equatable {
+    let audioEnabled: Bool
+    let hapticsEnabled: Bool
+    let reducedEffects: Bool
+    let theme: String
+}
+
+struct DiagnosticProfileSnapshot: Codable, Equatable {
+    let bestScore: Int
+    let highestCombo: Int
+    let longestSurvivalTime: TimeInterval
+    let totalRuns: Int
+    let totalEnemiesDestroyed: Int
+    let unlockedWeaponCount: Int
+    let earnedAwardCount: Int
+}
+
+struct DiagnosticExportMetadata: Codable, Equatable {
+    let schemaVersion: Int
+    let generatedAt: String
+    let sessionID: String
+    let app: DiagnosticAppMetadata
+    let device: DiagnosticDeviceMetadata
+    let gameplay: DiagnosticGameplaySnapshot?
+}
+
+struct DiagnosticAppMetadata: Codable, Equatable {
+    let bundleID: String
+    let version: String
+    let build: String
+}
+
+struct DiagnosticDeviceMetadata: Codable, Equatable {
+    let osName: String
+    let osVersion: String
+    let modelIdentifier: String
+    let localeIdentifier: String
+}
+
+enum DiagnosticExportMetadataFactory {
+    static func make(
+        generatedAt: Date,
+        sessionID: String,
+        gameplay: DiagnosticGameplaySnapshot?,
+        bundle: Bundle = .main,
+        processInfo: ProcessInfo = .processInfo,
+        locale: Locale = .autoupdatingCurrent
+    ) -> DiagnosticExportMetadata {
+        DiagnosticExportMetadata(
+            schemaVersion: 1,
+            generatedAt: DiagnosticDateFormatter.string(from: generatedAt),
+            sessionID: sessionID,
+            app: DiagnosticAppMetadata(
+                bundleID: bundle.bundleIdentifier ?? "unknown",
+                version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+                build: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+            ),
+            device: DiagnosticDeviceMetadata(
+                osName: "iOS",
+                osVersion: processInfo.operatingSystemVersionString,
+                modelIdentifier: modelIdentifier(),
+                localeIdentifier: locale.identifier
+            ),
+            gameplay: gameplay
+        )
+    }
+
+    private static func modelIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+
+        let bytes = Mirror(reflecting: systemInfo.machine).children.compactMap { child -> UInt8? in
+            guard let value = child.value as? Int8, value != 0 else {
+                return nil
+            }
+
+            return UInt8(value)
+        }
+
+        return String(bytes: bytes, encoding: .ascii) ?? "unknown"
+    }
+}
+
+struct DiagnosticBundleBuilder {
+    let store: DiagnosticLogStore
+    let outputDirectoryURL: URL
+    let fileManager: FileManager
+    let dateProvider: @Sendable () -> Date
+    let uuidProvider: @Sendable () -> UUID
+
+    init(
+        store: DiagnosticLogStore = .shared,
+        outputDirectoryURL: URL,
+        fileManager: FileManager = .default,
+        dateProvider: @escaping @Sendable () -> Date = Date.init,
+        uuidProvider: @escaping @Sendable () -> UUID = UUID.init
+    ) {
+        self.store = store
+        self.outputDirectoryURL = outputDirectoryURL
+        self.fileManager = fileManager
+        self.dateProvider = dateProvider
+        self.uuidProvider = uuidProvider
+    }
+
+    func makeBundle(metadata: DiagnosticExportMetadata) throws -> URL {
+        try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
+
+        let bundleURL = outputDirectoryURL.appendingPathComponent(
+            "TiltArenaDiagnostics-\(DiagnosticDateFormatter.fileSafeString(from: dateProvider()))-\(uuidProvider().uuidString)",
+            isDirectory: true
+        )
+        if fileManager.fileExists(atPath: bundleURL.path) {
+            try fileManager.removeItem(at: bundleURL)
+        }
+
+        try fileManager.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        try markExcludedFromBackup(bundleURL)
+
+        let metadataURL = bundleURL.appendingPathComponent("metadata.json", isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(metadata).write(to: metadataURL, options: [.atomic])
+
+        let logsDirectoryURL = bundleURL.appendingPathComponent("logs", isDirectory: true)
+        try store.copyLogFiles(to: logsDirectoryURL)
+
+        let readmeURL = bundleURL.appendingPathComponent("README.txt", isDirectory: false)
+        try readmeText.write(to: readmeURL, atomically: true, encoding: .utf8)
+
+        return bundleURL
+    }
+
+    private var readmeText: String {
+        """
+        Tilt Arena diagnostics export
+
+        metadata.json contains app, OS, session, and gameplay snapshot fields.
+        logs/*.jsonl contains line-delimited diagnostic records suitable for tail, rg, and jq.
+        """
+    }
+
+    private func markExcludedFromBackup(_ url: URL) throws {
+        var mutableURL = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try mutableURL.setResourceValues(values)
+    }
+}

--- a/TiltArena/Diagnostics/DiagnosticLogRecord.swift
+++ b/TiltArena/Diagnostics/DiagnosticLogRecord.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Logging
+
+struct DiagnosticLogRecord: Codable, Equatable {
+    let schemaVersion: Int
+    let timestamp: String
+    let sessionID: String
+    let level: String
+    let label: String
+    let category: String
+    let message: String
+    let metadata: [String: String]
+    let source: String
+    let file: String
+    let function: String
+    let line: UInt
+
+    init(
+        timestamp: Date,
+        sessionID: String,
+        level: Logger.Level,
+        label: String,
+        message: Logger.Message,
+        metadata: Logger.Metadata,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        schemaVersion = 1
+        self.timestamp = DiagnosticDateFormatter.string(from: timestamp)
+        self.sessionID = sessionID
+        self.level = level.rawValue
+        self.label = label
+        category = DiagnosticLogRecord.category(from: label)
+        self.message = message.description
+        self.metadata = DiagnosticMetadataSanitizer.sanitized(metadata)
+        self.source = source
+        self.file = URL(fileURLWithPath: file).lastPathComponent
+        self.function = function
+        self.line = line
+    }
+
+    static func category(from label: String) -> String {
+        let prefix = "\(AppDiagnostics.subsystem)."
+        guard label.hasPrefix(prefix) else {
+            return label
+        }
+
+        return String(label.dropFirst(prefix.count))
+    }
+}
+
+enum DiagnosticDateFormatter {
+    static func string(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    static func fileSafeString(from date: Date) -> String {
+        let milliseconds = Int((date.timeIntervalSince1970 * 1_000).rounded())
+        return "\(milliseconds)"
+    }
+}
+
+enum DiagnosticMetadataSanitizer {
+    private static let redactedKeyFragments = [
+        "email",
+        "password",
+        "secret",
+        "token",
+        "userid",
+        "user_id",
+        "vendor",
+        "identifier"
+    ]
+
+    static func sanitized(_ metadata: Logger.Metadata) -> [String: String] {
+        metadata.reduce(into: [String: String]()) { result, pair in
+            let key = sanitizedKey(pair.key)
+            result[key] = shouldRedact(key: key) ? "<redacted>" : sanitizedValue(pair.value)
+        }
+    }
+
+    static func merged(
+        base: Logger.Metadata,
+        provider: Logger.MetadataProvider?,
+        explicit: Logger.Metadata?
+    ) -> Logger.Metadata {
+        var merged = base
+
+        if let provided = provider?.get() {
+            merged.merge(provided, uniquingKeysWith: { _, provided in provided })
+        }
+
+        if let explicit {
+            merged.merge(explicit, uniquingKeysWith: { _, explicit in explicit })
+        }
+
+        return merged
+    }
+
+    private static func sanitizedKey(_ key: String) -> String {
+        String(key.prefix(80))
+    }
+
+    private static func sanitizedValue(_ value: Logger.Metadata.Value) -> String {
+        let rendered: String
+
+        switch value {
+        case let .string(string):
+            rendered = string
+        case let .stringConvertible(value):
+            rendered = value.description
+        case let .array(values):
+            rendered = values.map(sanitizedValue).joined(separator: ",")
+        case let .dictionary(dictionary):
+            rendered = dictionary
+                .map { "\($0.key)=\(sanitizedValue($0.value))" }
+                .sorted()
+                .joined(separator: ",")
+        }
+
+        return String(rendered.prefix(240))
+    }
+
+    private static func shouldRedact(key: String) -> Bool {
+        let lowercasedKey = key.lowercased()
+        return redactedKeyFragments.contains { lowercasedKey.contains($0) }
+    }
+}

--- a/TiltArena/Diagnostics/DiagnosticLogStore.swift
+++ b/TiltArena/Diagnostics/DiagnosticLogStore.swift
@@ -86,16 +86,6 @@ final class DiagnosticLogStore: @unchecked Sendable {
         }
     }
 
-    func removeAllLogs() throws {
-        try lock.withLock {
-            guard fileManager.fileExists(atPath: directoryURL.path) else {
-                return
-            }
-
-            try fileManager.removeItem(at: directoryURL)
-        }
-    }
-
     private static func defaultDirectoryURL() -> URL {
         let baseURL = FileManager.default.urls(
             for: .applicationSupportDirectory,

--- a/TiltArena/Diagnostics/DiagnosticLogStore.swift
+++ b/TiltArena/Diagnostics/DiagnosticLogStore.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+final class DiagnosticLogStore: @unchecked Sendable {
+    struct Configuration: Equatable {
+        var maxCurrentFileBytes = 512 * 1_024
+        var maxArchivedFileCount = 5
+        var maxTotalBytes = 3 * 1_024 * 1_024
+
+        static let production = Configuration()
+    }
+
+    static let shared = DiagnosticLogStore(
+        directoryURL: DiagnosticLogStore.defaultDirectoryURL(),
+        configuration: .production
+    )
+
+    let directoryURL: URL
+    let configuration: Configuration
+    private let fileManager: FileManager
+    private let lock = NSLock()
+    private let dateProvider: @Sendable () -> Date
+    private let uuidProvider: @Sendable () -> UUID
+    private let encoder: JSONEncoder
+
+    init(
+        directoryURL: URL,
+        configuration: Configuration,
+        fileManager: FileManager = .default,
+        dateProvider: @escaping @Sendable () -> Date = Date.init,
+        uuidProvider: @escaping @Sendable () -> UUID = UUID.init
+    ) {
+        self.directoryURL = directoryURL
+        self.configuration = configuration
+        self.fileManager = fileManager
+        self.dateProvider = dateProvider
+        self.uuidProvider = uuidProvider
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    var currentLogFileURL: URL {
+        directoryURL.appendingPathComponent("current.jsonl", isDirectory: false)
+    }
+
+    func append(_ record: DiagnosticLogRecord) throws {
+        let data = try encodedLine(for: record)
+
+        try lock.withLock {
+            try prepareDirectoryLocked()
+            if try shouldRotateCurrentLogLocked(appendingByteCount: data.count) {
+                try rotateCurrentLogLocked()
+            }
+
+            try appendLocked(data, to: currentLogFileURL)
+            try pruneArchivesLocked()
+        }
+    }
+
+    func logFileURLs() throws -> [URL] {
+        try lock.withLock {
+            try prepareDirectoryLocked()
+            let archiveURLs = try archiveLogFileURLsLocked()
+            guard fileManager.fileExists(atPath: currentLogFileURL.path) else {
+                return archiveURLs
+            }
+
+            return archiveURLs + [currentLogFileURL]
+        }
+    }
+
+    func copyLogFiles(to destinationDirectoryURL: URL) throws {
+        try lock.withLock {
+            try prepareDirectoryLocked()
+            try fileManager.createDirectory(
+                at: destinationDirectoryURL,
+                withIntermediateDirectories: true
+            )
+
+            for sourceURL in try logFileURLsLocked() {
+                let destinationURL = destinationDirectoryURL.appendingPathComponent(sourceURL.lastPathComponent)
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: destinationURL)
+                }
+                try fileManager.copyItem(at: sourceURL, to: destinationURL)
+            }
+        }
+    }
+
+    func removeAllLogs() throws {
+        try lock.withLock {
+            guard fileManager.fileExists(atPath: directoryURL.path) else {
+                return
+            }
+
+            try fileManager.removeItem(at: directoryURL)
+        }
+    }
+
+    private static func defaultDirectoryURL() -> URL {
+        let baseURL = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+
+        return baseURL
+            .appendingPathComponent("Diagnostics", isDirectory: true)
+            .appendingPathComponent("Logs", isDirectory: true)
+    }
+
+    private func encodedLine(for record: DiagnosticLogRecord) throws -> Data {
+        var data = try encoder.encode(record)
+        data.append(0x0A)
+        return data
+    }
+
+    private func prepareDirectoryLocked() throws {
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try markExcludedFromBackup(directoryURL)
+        try applyFileProtection(to: directoryURL)
+    }
+
+    private func shouldRotateCurrentLogLocked(appendingByteCount: Int) throws -> Bool {
+        guard fileManager.fileExists(atPath: currentLogFileURL.path) else {
+            return false
+        }
+
+        let currentSize = try fileSizeLocked(currentLogFileURL)
+        return currentSize > 0 && currentSize + appendingByteCount > configuration.maxCurrentFileBytes
+    }
+
+    private func rotateCurrentLogLocked() throws {
+        guard fileManager.fileExists(atPath: currentLogFileURL.path) else {
+            return
+        }
+
+        let archiveName = [
+            "diagnostics",
+            DiagnosticDateFormatter.fileSafeString(from: dateProvider()),
+            uuidProvider().uuidString
+        ].joined(separator: "-") + ".jsonl"
+        let archiveURL = directoryURL.appendingPathComponent(archiveName, isDirectory: false)
+        try fileManager.moveItem(at: currentLogFileURL, to: archiveURL)
+    }
+
+    private func appendLocked(_ data: Data, to url: URL) throws {
+        if !fileManager.fileExists(atPath: url.path) {
+            fileManager.createFile(atPath: url.path, contents: nil)
+            try applyFileProtection(to: url)
+        }
+
+        let handle = try FileHandle(forWritingTo: url)
+        defer {
+            try? handle.close()
+        }
+
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+    }
+
+    private func logFileURLsLocked() throws -> [URL] {
+        let archiveURLs = try archiveLogFileURLsLocked()
+        guard fileManager.fileExists(atPath: currentLogFileURL.path) else {
+            return archiveURLs
+        }
+
+        return archiveURLs + [currentLogFileURL]
+    }
+
+    private func archiveLogFileURLsLocked() throws -> [URL] {
+        guard fileManager.fileExists(atPath: directoryURL.path) else {
+            return []
+        }
+
+        return try fileManager
+            .contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: [.fileSizeKey],
+                options: [.skipsHiddenFiles]
+            )
+            .filter {
+                $0.lastPathComponent.hasPrefix("diagnostics-")
+                    && $0.pathExtension == "jsonl"
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private func pruneArchivesLocked() throws {
+        var archives = try archiveLogFileURLsLocked()
+        while archives.count > configuration.maxArchivedFileCount {
+            try fileManager.removeItem(at: archives.removeFirst())
+        }
+
+        var totalBytes = try logFileURLsLocked().reduce(0) { total, url in
+            try total + fileSizeLocked(url)
+        }
+
+        archives = try archiveLogFileURLsLocked()
+        while totalBytes > configuration.maxTotalBytes, let oldestArchive = archives.first {
+            let removedSize = try fileSizeLocked(oldestArchive)
+            try fileManager.removeItem(at: oldestArchive)
+            totalBytes -= removedSize
+            archives.removeFirst()
+        }
+    }
+
+    private func fileSizeLocked(_ url: URL) throws -> Int {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        return (attributes[.size] as? NSNumber)?.intValue ?? 0
+    }
+
+    private func markExcludedFromBackup(_ url: URL) throws {
+        var mutableURL = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try mutableURL.setResourceValues(values)
+    }
+
+    private func applyFileProtection(to url: URL) throws {
+        #if os(iOS)
+        try fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: url.path
+        )
+        #else
+        _ = url
+        #endif
+    }
+}
+
+private extension NSLock {
+    func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/TiltArena/Diagnostics/DiagnosticSwiftLogHandlers.swift
+++ b/TiltArena/Diagnostics/DiagnosticSwiftLogHandlers.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Logging
+import OSLog
+
+struct DiagnosticJSONLLogHandler: LogHandler {
+    private let label: String
+    private let store: DiagnosticLogStore
+    private let sessionID: String
+    private let dateProvider: @Sendable () -> Date
+    var metadata: Logging.Logger.Metadata = [:]
+    var metadataProvider: Logging.Logger.MetadataProvider?
+    var logLevel: Logging.Logger.Level
+
+    init(
+        label: String,
+        store: DiagnosticLogStore = .shared,
+        sessionID: String,
+        logLevel: Logging.Logger.Level = .info,
+        dateProvider: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.label = label
+        self.store = store
+        self.sessionID = sessionID
+        self.logLevel = logLevel
+        self.dateProvider = dateProvider
+    }
+
+    subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: LogEvent) {
+        let record = DiagnosticLogRecord(
+            timestamp: dateProvider(),
+            sessionID: sessionID,
+            level: event.level,
+            label: label,
+            message: event.message,
+            metadata: DiagnosticMetadataSanitizer.merged(
+                base: metadata,
+                provider: metadataProvider,
+                explicit: event.metadata
+            ),
+            source: event.source,
+            file: event.file,
+            function: event.function,
+            line: event.line
+        )
+
+        try? store.append(record)
+    }
+}
+
+struct DiagnosticOSLogHandler: LogHandler {
+    private let label: String
+    var metadata: Logging.Logger.Metadata = [:]
+    var metadataProvider: Logging.Logger.MetadataProvider?
+    var logLevel: Logging.Logger.Level
+
+    init(label: String, logLevel: Logging.Logger.Level = .debug) {
+        self.label = label
+        self.logLevel = logLevel
+    }
+
+    subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: LogEvent) {
+        let metadata = DiagnosticMetadataSanitizer.sanitized(
+            DiagnosticMetadataSanitizer.merged(
+                base: metadata,
+                provider: metadataProvider,
+                explicit: event.metadata
+            )
+        )
+        let metadataText = metadata.isEmpty
+            ? ""
+            : " " + metadata.map { "\($0.key)=\($0.value)" }.sorted().joined(separator: " ")
+        let fileName = URL(fileURLWithPath: event.file).lastPathComponent
+        let rendered = "\(event.message.description)\(metadataText) \(fileName):\(event.line)"
+        let logger = DiagnosticOSLogCache.shared.log(for: label)
+
+        os_log("%{public}@", log: logger, type: osLogType(for: event.level), rendered)
+    }
+
+    private func osLogType(for level: Logging.Logger.Level) -> OSLogType {
+        switch level {
+        case .trace, .debug:
+            return .debug
+        case .info, .notice:
+            return .default
+        case .warning, .error:
+            return .error
+        case .critical:
+            return .fault
+        }
+    }
+}
+
+private final class DiagnosticOSLogCache: @unchecked Sendable {
+    static let shared = DiagnosticOSLogCache()
+
+    private let lock = NSLock()
+    private var logs: [String: OSLog] = [:]
+
+    func log(for label: String) -> OSLog {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let log = logs[label] {
+            return log
+        }
+
+        let log = OSLog(
+            subsystem: AppDiagnostics.subsystem,
+            category: DiagnosticLogRecord.category(from: label)
+        )
+        logs[label] = log
+        return log
+    }
+}

--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -11,9 +11,18 @@ protocol ArenaSceneOrientationDelegate: AnyObject {
     func arenaSceneRequestsOrientationUnlock(_ scene: ArenaScene)
 }
 
+@MainActor
+protocol ArenaSceneDiagnosticsDelegate: AnyObject {
+    func arenaSceneRequestsDiagnosticsExport(
+        _ scene: ArenaScene,
+        snapshot: DiagnosticGameplaySnapshot
+    )
+}
+
 // swiftlint:disable:next type_body_length
 final class ArenaScene: SKScene {
     weak var orientationDelegate: ArenaSceneOrientationDelegate?
+    weak var diagnosticsDelegate: ArenaSceneDiagnosticsDelegate?
     var theme: ArenaTheme {
         localOptions.themeKind.theme
     }
@@ -71,6 +80,7 @@ final class ArenaScene: SKScene {
 #if DEBUG
     private let debugStatsLabel = SKLabelNode(fontNamed: "Menlo")
     private var debugStatsElapsed: TimeInterval = 0
+    private var debugStatsLogElapsed: TimeInterval = 0
     private var debugStatsFrameCount = 0
 #endif
     private let hudMargin: CGFloat = 24
@@ -110,6 +120,10 @@ final class ArenaScene: SKScene {
         updateRunDisplay()
         rebuildUI()
         tiltInputController.start()
+        AppDiagnostics.logger(.scene).notice("scene.presented", metadata: [
+            "width": "\(Int(size.width.rounded()))",
+            "height": "\(Int(size.height.rounded()))"
+        ])
     }
 
     override func didChangeSize(_ oldSize: CGSize) {
@@ -126,12 +140,17 @@ final class ArenaScene: SKScene {
         layoutPauseControl()
         layoutDebugStats()
         rebuildUI()
+        AppDiagnostics.logger(.scene).info("scene.resized", metadata: [
+            "width": "\(Int(size.width.rounded()))",
+            "height": "\(Int(size.height.rounded()))"
+        ])
     }
 
     override func willMove(from view: SKView) {
         orientationDelegate?.arenaSceneRequestsOrientationUnlock(self)
         tiltInputController.stop()
         lastUpdateTime = nil
+        AppDiagnostics.logger(.scene).notice("scene.removed")
     }
 
     override func update(_ currentTime: TimeInterval) {
@@ -166,6 +185,9 @@ final class ArenaScene: SKScene {
 
     func recalibrateTiltControls() {
         tiltInputController.recalibrateToCurrentAttitude(orientation: currentTiltScreenOrientation)
+        AppDiagnostics.logger(.input).notice("input.calibrated", metadata: [
+            "orientation": "\(currentTiltScreenOrientation.rawValue)"
+        ])
         if uiState == .calibrationPreview {
             resetCalibrationPreviewPosition()
         }
@@ -346,6 +368,7 @@ final class ArenaScene: SKScene {
     private func updateDebugStats(deltaTime: TimeInterval) {
         #if DEBUG
         debugStatsElapsed += deltaTime
+        debugStatsLogElapsed += deltaTime
         debugStatsFrameCount += 1
 
         guard debugStatsElapsed >= 0.25 else {
@@ -353,7 +376,15 @@ final class ArenaScene: SKScene {
         }
 
         let framesPerSecond = Double(debugStatsFrameCount) / debugStatsElapsed
-        debugStatsLabel.text = "nodes:\(debugNodeCount(in: self))  \(Int(framesPerSecond.rounded())) fps"
+        let nodeCount = debugNodeCount(in: self)
+        debugStatsLabel.text = "nodes:\(nodeCount)  \(Int(framesPerSecond.rounded())) fps"
+        if debugStatsLogElapsed >= 5 {
+            AppDiagnostics.logger(.performance).info("performance.sample", metadata: [
+                "fps": "\(Int(framesPerSecond.rounded()))",
+                "nodes": "\(nodeCount)"
+            ])
+            debugStatsLogElapsed = 0
+        }
         debugStatsElapsed = 0
         debugStatsFrameCount = 0
         #endif
@@ -489,6 +520,9 @@ final class ArenaScene: SKScene {
         readyStartPoint = movementController.state.position
         resetPlayerFeedback()
         show(.preRun)
+        AppDiagnostics.logger(.run).notice("run.prepared", metadata: [
+            "mode": "\(selectedMode.rawValue)"
+        ])
     }
 
     private func startRun() {
@@ -497,18 +531,29 @@ final class ArenaScene: SKScene {
         resetActiveRun()
         hapticsController.prepare()
         show(.activeGameplay)
+        AppDiagnostics.logger(.run).notice("run.started", metadata: [
+            "mode": "\(selectedMode.rawValue)"
+        ])
     }
 
     private func pauseRun() {
         runController.pause()
         tiltInputController.resetSmoothedInput()
         show(.pause)
+        AppDiagnostics.logger(.run).info("run.paused", metadata: [
+            "score": "\(runController.score)",
+            "survivalTime": "\(runController.survivalTime)"
+        ])
     }
 
     private func resumeRun() {
         tiltInputController.resetSmoothedInput()
         runController.resume()
         show(.activeGameplay)
+        AppDiagnostics.logger(.run).info("run.resumed", metadata: [
+            "score": "\(runController.score)",
+            "survivalTime": "\(runController.survivalTime)"
+        ])
     }
 
     private func finishRun(playFeedback: Bool = true) {
@@ -524,6 +569,7 @@ final class ArenaScene: SKScene {
             playHaptic(.newBest)
         }
         show(.postRun)
+        logFinishedRun(isNewBest: isNewBest)
     }
 
     private func resetActiveRun() {
@@ -664,6 +710,13 @@ final class ArenaScene: SKScene {
     }
 
     private func addSpawnedEnemies(_ spawnedEnemies: [ArenaEnemy]) {
+        if !spawnedEnemies.isEmpty {
+            AppDiagnostics.logger(.spawn).debug("spawn.enemies", metadata: [
+                "count": "\(spawnedEnemies.count)",
+                "survivalTime": "\(runController.survivalTime)"
+            ])
+        }
+
         for enemy in spawnedEnemies {
             enemies.append(enemy)
 
@@ -708,6 +761,10 @@ final class ArenaScene: SKScene {
         }
 
         pickups.append(pickup)
+        AppDiagnostics.logger(.weapon).info("pickup.spawned", metadata: [
+            "id": "\(pickup.id)",
+            "kind": "\(pickup.kind.rawValue)"
+        ])
 
         let node = WeaponPickupNode(pickup: pickup, theme: theme)
         pickupNodes[pickup.id] = node
@@ -782,6 +839,11 @@ final class ArenaScene: SKScene {
                 creditedDangerGrab = false
             }
             playHaptic(creditedDangerGrab ? .dangerPickup : .pickup)
+            AppDiagnostics.logger(.weapon).notice("pickup.collected", metadata: [
+                "id": "\(pickup.id)",
+                "kind": "\(pickup.kind.rawValue)",
+                "dangerGrab": "\(creditedDangerGrab)"
+            ])
 
             removePickup(id: pickup.id)
             applyWeapon(pickup.kind, playerPosition: currentPlayerPosition)
@@ -843,6 +905,12 @@ final class ArenaScene: SKScene {
         }
 
         destroyEnemies(ids: resolution.destroyedEnemyIDs, weaponKind: kind)
+        AppDiagnostics.logger(.weapon).notice("weapon.resolved", metadata: [
+            "kind": "\(kind.rawValue)",
+            "destroyed": "\(resolution.destroyedEnemyIDs.count)",
+            "frozen": "\(resolution.frozenEnemyIDs.count)",
+            "gravityTargets": "\(resolution.gravityWellEnemyIDs.count)"
+        ])
     }
 
     private func positions(forEnemyIDs enemyIDs: Set<Int>) -> [CGPoint] {
@@ -1626,6 +1694,12 @@ private extension ArenaScene {
             frame: CGRect(x: frame.minX + 14, y: frame.maxY - 138, width: 132, height: 34),
             action: .toggleEffects
         )
+        addButton(
+            "LOGS",
+            frame: CGRect(x: frame.maxX - 104, y: frame.maxY - 138, width: 90, height: 34),
+            action: .exportDiagnostics,
+            style: .secondary
+        )
         addSmallLabel(
             "THEME",
             at: CGPoint(x: frame.minX + 14, y: frame.minY + 70),
@@ -1808,7 +1882,10 @@ private extension ArenaScene {
             performNavigationAction(action)
         case .selectMode, .resume, .calibrate, .endRun:
             performRunControlAction(action)
-        case .sensitivityDown, .sensitivityUp, .preset, .toggleAudio, .toggleHaptics, .toggleEffects, .selectTheme, .resetData:
+        case .exportDiagnostics:
+            exportDiagnostics()
+        case .sensitivityDown, .sensitivityUp, .preset, .toggleAudio, .toggleHaptics, .toggleEffects, .selectTheme,
+                .resetData:
             performOptionsAction(action)
         }
     }
@@ -1865,13 +1942,9 @@ private extension ArenaScene {
     func performOptionsAction(_ action: ArenaControlAction) {
         switch action {
         case .sensitivityDown:
-            tiltSettingsStore.updateSensitivity(tiltSettingsStore.settings.clampedSensitivity - 0.1)
-            tiltInputController.resetSmoothedInput()
-            rebuildUI()
+            updateSensitivity(by: -0.1)
         case .sensitivityUp:
-            tiltSettingsStore.updateSensitivity(tiltSettingsStore.settings.clampedSensitivity + 0.1)
-            tiltInputController.resetSmoothedInput()
-            rebuildUI()
+            updateSensitivity(by: 0.1)
         case let .preset(preset):
             tiltSettingsStore.selectPreset(preset)
             tiltInputController.resetSmoothedInput()
@@ -1879,6 +1952,17 @@ private extension ArenaScene {
                 resetCalibrationPreviewPosition()
             }
             rebuildUI()
+        case .toggleAudio, .toggleHaptics, .toggleEffects:
+            performLocalOptionToggle(action)
+        case .selectTheme, .resetData:
+            performLocalDataAction(action)
+        default:
+            break
+        }
+    }
+
+    func performLocalOptionToggle(_ action: ArenaControlAction) {
+        switch action {
         case .toggleAudio:
             localOptions.audioEnabled.toggle()
             localOptionsStore.options = localOptions
@@ -1892,6 +1976,13 @@ private extension ArenaScene {
             localOptions.reducedEffects.toggle()
             localOptionsStore.options = localOptions
             rebuildUI()
+        default:
+            break
+        }
+    }
+
+    func performLocalDataAction(_ action: ArenaControlAction) {
+        switch action {
         case let .selectTheme(themeKind):
             guard localOptions.themeKind != themeKind else {
                 return
@@ -1899,12 +1990,25 @@ private extension ArenaScene {
 
             localOptions.themeKind = themeKind
             localOptionsStore.options = localOptions
+            AppDiagnostics.logger(.app).notice("options.theme_changed", metadata: [
+                "theme": "\(themeKind.rawValue)"
+            ])
             applyThemeChange()
         case .resetData:
             resetLocalDataOrArmConfirmation()
         default:
             break
         }
+    }
+
+    func updateSensitivity(by delta: Double) {
+        tiltSettingsStore.updateSensitivity(tiltSettingsStore.settings.clampedSensitivity + delta)
+        tiltInputController.resetSmoothedInput()
+        rebuildUI()
+    }
+
+    func exportDiagnostics() {
+        diagnosticsDelegate?.arenaSceneRequestsDiagnosticsExport(self, snapshot: diagnosticSnapshot())
     }
 
     func resetMenuPreviewIfNeeded() {
@@ -1951,7 +2055,52 @@ private extension ArenaScene {
         lastProgressionResult = nil
         selectedMode = .classic
         resetDataArmed = false
+        AppDiagnostics.logger(.profile).warning("profile.reset")
         applyThemeChange()
+    }
+
+    func logFinishedRun(isNewBest: Bool) {
+        guard let summary = runController.finalizedSummary else {
+            AppDiagnostics.logger(.run).error("run.finished_missing_summary")
+            return
+        }
+
+        AppDiagnostics.logger(.run).notice("run.finished", metadata: [
+            "mode": "\(summary.mode.rawValue)",
+            "score": "\(summary.score)",
+            "survivalTime": "\(summary.survivalTime)",
+            "maxCombo": "\(summary.maxCombo)",
+            "enemiesDestroyed": "\(summary.enemiesDestroyed)",
+            "bestWeapon": "\(summary.bestWeapon?.rawValue ?? "none")",
+            "newBest": "\(isNewBest)"
+        ])
+    }
+
+    func diagnosticSnapshot() -> DiagnosticGameplaySnapshot {
+        DiagnosticGameplaySnapshot(
+            uiState: uiState.diagnosticName,
+            selectedMode: selectedMode.rawValue,
+            runPhase: runController.phase.diagnosticName,
+            score: runController.score,
+            survivalTime: runController.survivalTime,
+            enemyCount: enemies.count,
+            pickupCount: pickups.count,
+            localOptions: DiagnosticLocalOptionsSnapshot(
+                audioEnabled: localOptions.audioEnabled,
+                hapticsEnabled: localOptions.hapticsEnabled,
+                reducedEffects: localOptions.reducedEffects,
+                theme: localOptions.themeKind.rawValue
+            ),
+            profile: DiagnosticProfileSnapshot(
+                bestScore: runProfile.bestScore,
+                highestCombo: runProfile.highestCombo,
+                longestSurvivalTime: runProfile.longestSurvivalTime,
+                totalRuns: runProfile.totalRuns,
+                totalEnemiesDestroyed: runProfile.totalEnemiesDestroyed,
+                unlockedWeaponCount: runProfile.unlockedWeapons.count,
+                earnedAwardCount: runProfile.earnedAwardIDs.count
+            )
+        )
     }
 
     func addReadyStartCircle(at point: CGPoint) {
@@ -2428,6 +2577,7 @@ private enum ArenaControlAction: Equatable {
     case toggleEffects
     case selectTheme(ArenaThemeKind)
     case resetData
+    case exportDiagnostics
 }
 
 private enum ArenaButtonStyle {
@@ -2445,4 +2595,44 @@ private enum ArenaUIZPosition {
     static let control: CGFloat = 24
     static let controlFill: CGFloat = 25
     static let label: CGFloat = 32
+}
+
+private extension ArenaUISceneState {
+    var diagnosticName: String {
+        switch self {
+        case .home:
+            return "home"
+        case .modeSelect:
+            return "modeSelect"
+        case .awards:
+            return "awards"
+        case .options:
+            return "options"
+        case .calibrationPreview:
+            return "calibrationPreview"
+        case .preRun:
+            return "preRun"
+        case .activeGameplay:
+            return "activeGameplay"
+        case .pause:
+            return "pause"
+        case .postRun:
+            return "postRun"
+        }
+    }
+}
+
+private extension ClassicRunPhase {
+    var diagnosticName: String {
+        switch self {
+        case .preRun:
+            return "preRun"
+        case .active:
+            return "active"
+        case .paused:
+            return "paused"
+        case .gameOver:
+            return "gameOver"
+        }
+    }
 }

--- a/TiltArenaTests/DiagnosticLogStoreTests.swift
+++ b/TiltArenaTests/DiagnosticLogStoreTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Logging
+import XCTest
+@testable import TiltArena
+
+final class DiagnosticLogStoreTests: XCTestCase {
+    private var rootURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiagnosticLogStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let rootURL, FileManager.default.fileExists(atPath: rootURL.path) {
+            try FileManager.default.removeItem(at: rootURL)
+        }
+        rootURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testJSONLHandlerWritesStableLineDelimitedRecord() throws {
+        let store = makeStore()
+        var handler = DiagnosticJSONLLogHandler(
+            label: "com.xlc.TiltArena.run",
+            store: store,
+            sessionID: "session-1",
+            dateProvider: { Date(timeIntervalSince1970: 1) }
+        )
+        handler[metadataKey: "mode"] = "classic"
+
+        handler.log(event: LogEvent(
+            level: .notice,
+            message: "run.started",
+            metadata: ["score": "10"],
+            source: "test",
+            file: "/tmp/ArenaScene.swift",
+            function: "test()",
+            line: 42
+        ))
+
+        let contents = try String(contentsOf: store.currentLogFileURL, encoding: .utf8)
+        let lines = contents.split(separator: "\n")
+        XCTAssertEqual(lines.count, 1)
+
+        let record = try JSONDecoder().decode(
+            DiagnosticLogRecord.self,
+            from: Data(lines[0].utf8)
+        )
+        XCTAssertEqual(record.schemaVersion, 1)
+        XCTAssertEqual(record.timestamp, "1970-01-01T00:00:01.000Z")
+        XCTAssertEqual(record.sessionID, "session-1")
+        XCTAssertEqual(record.level, "notice")
+        XCTAssertEqual(record.category, "run")
+        XCTAssertEqual(record.message, "run.started")
+        XCTAssertEqual(record.metadata["mode"], "classic")
+        XCTAssertEqual(record.metadata["score"], "10")
+        XCTAssertEqual(record.file, "ArenaScene.swift")
+        XCTAssertEqual(record.line, 42)
+    }
+
+    func testRotationCapsArchivedFileCount() throws {
+        let store = makeStore(configuration: DiagnosticLogStore.Configuration(
+            maxCurrentFileBytes: 260,
+            maxArchivedFileCount: 2,
+            maxTotalBytes: 20_000
+        ))
+        let longMessage = String(repeating: "x", count: 180)
+
+        for index in 0..<12 {
+            try store.append(record(message: "event.\(index).\(longMessage)"))
+        }
+
+        let logFiles = try store.logFileURLs()
+        let archivedFiles = logFiles.filter { $0.lastPathComponent.hasPrefix("diagnostics-") }
+        XCTAssertLessThanOrEqual(archivedFiles.count, 2)
+        XCTAssertTrue(logFiles.contains(store.currentLogFileURL))
+    }
+
+    func testMetadataSanitizerRedactsSensitiveKeys() {
+        let metadata = DiagnosticMetadataSanitizer.sanitized([
+            "token": "secret-token",
+            "userID": "abc",
+            "mode": "classic"
+        ])
+
+        XCTAssertEqual(metadata["token"], "<redacted>")
+        XCTAssertEqual(metadata["userID"], "<redacted>")
+        XCTAssertEqual(metadata["mode"], "classic")
+    }
+
+    func testExportBundleContainsMetadataReadmeAndCopiedLogs() throws {
+        let store = makeStore()
+        try store.append(record(message: "run.finished"))
+        let builder = DiagnosticBundleBuilder(
+            store: store,
+            outputDirectoryURL: rootURL.appendingPathComponent("exports", isDirectory: true),
+            dateProvider: { Date(timeIntervalSince1970: 2) },
+            uuidProvider: { UUID(uuidString: "00000000-0000-0000-0000-000000000001")! }
+        )
+        let metadata = DiagnosticExportMetadataFactory.make(
+            generatedAt: Date(timeIntervalSince1970: 3),
+            sessionID: "session-2",
+            gameplay: nil
+        )
+
+        let bundleURL = try builder.makeBundle(metadata: metadata)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bundleURL.appendingPathComponent("README.txt").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bundleURL.appendingPathComponent("metadata.json").path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: bundleURL
+                .appendingPathComponent("logs", isDirectory: true)
+                .appendingPathComponent("current.jsonl")
+                .path
+        ))
+
+        let decodedMetadata = try JSONDecoder().decode(
+            DiagnosticExportMetadata.self,
+            from: Data(contentsOf: bundleURL.appendingPathComponent("metadata.json"))
+        )
+        XCTAssertEqual(decodedMetadata.schemaVersion, 1)
+        XCTAssertEqual(decodedMetadata.sessionID, "session-2")
+    }
+
+    func testExportMetadataOmitsDeviceNameAndVendorIdentifier() throws {
+        let metadata = DiagnosticExportMetadataFactory.make(
+            generatedAt: Date(timeIntervalSince1970: 4),
+            sessionID: "session-3",
+            gameplay: nil
+        )
+        let data = try JSONEncoder().encode(metadata)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let device = try XCTUnwrap(object["device"] as? [String: Any])
+
+        XCTAssertNotNil(device["modelIdentifier"])
+        XCTAssertNil(device["name"])
+        XCTAssertNil(device["identifierForVendor"])
+    }
+
+    private func makeStore(
+        configuration: DiagnosticLogStore.Configuration = DiagnosticLogStore.Configuration(
+            maxCurrentFileBytes: 512 * 1_024,
+            maxArchivedFileCount: 5,
+            maxTotalBytes: 3 * 1_024 * 1_024
+        )
+    ) -> DiagnosticLogStore {
+        DiagnosticLogStore(
+            directoryURL: rootURL.appendingPathComponent("logs", isDirectory: true),
+            configuration: configuration,
+            dateProvider: { Date(timeIntervalSince1970: 1) }
+        )
+    }
+
+    private func record(message: Logger.Message) -> DiagnosticLogRecord {
+        DiagnosticLogRecord(
+            timestamp: Date(timeIntervalSince1970: 1),
+            sessionID: "session",
+            level: .notice,
+            label: "com.xlc.TiltArena.run",
+            message: message,
+            metadata: ["mode": "classic"],
+            source: "test",
+            file: "/tmp/Test.swift",
+            function: "record()",
+            line: 1
+        )
+    }
+}

--- a/TiltArenaTests/DiagnosticLogStoreTests.swift
+++ b/TiltArenaTests/DiagnosticLogStoreTests.swift
@@ -125,7 +125,7 @@ final class DiagnosticLogStoreTests: XCTestCase {
         XCTAssertEqual(decodedMetadata.sessionID, "session-2")
     }
 
-    func testExportMetadataOmitsDeviceNameAndVendorIdentifier() throws {
+    func testExportMetadataOmitsDeviceNameVendorIdentifierAndModelIdentifier() throws {
         let metadata = DiagnosticExportMetadataFactory.make(
             generatedAt: Date(timeIntervalSince1970: 4),
             sessionID: "session-3",
@@ -135,7 +135,7 @@ final class DiagnosticLogStoreTests: XCTestCase {
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         let device = try XCTUnwrap(object["device"] as? [String: Any])
 
-        XCTAssertNotNil(device["modelIdentifier"])
+        XCTAssertNil(device["modelIdentifier"])
         XCTAssertNil(device["name"])
         XCTAssertNil(device["identifierForVendor"])
     }

--- a/docs/diagnostics-logging.md
+++ b/docs/diagnostics-logging.md
@@ -1,0 +1,39 @@
+# Diagnostics Logging
+
+Tilt Arena uses `apple/swift-log` as the app logging API and writes exportable
+diagnostics to bounded JSONL files in the app container.
+
+## Backend Choice
+
+`apple/swift-log` provides the logging API and `MultiplexLogHandler`, but it does
+not include JSONL file persistence or rotation.
+
+`crspybits/swift-log-file` was evaluated as a lightweight existing file backend.
+It is iOS-compatible, but it only covers simple file logging and does not provide
+the JSONL schema, bounded rotation policy, export metadata, or CLI-oriented
+diagnostics bundle required for this app.
+
+`CocoaLumberjack` provides mature rolling file logs, but it is a much larger
+dependency than the current need. The first-party JSONL handler keeps the
+surface area small and makes the on-disk format stable for support tooling.
+
+## Local Inspection
+
+For the booted simulator:
+
+```sh
+scripts/tilt-logs tail
+scripts/tilt-logs list
+scripts/tilt-logs copy /tmp/tilt-logs
+```
+
+The underlying log files are plain line-delimited JSON:
+
+```sh
+scripts/tilt-logs cat | jq 'select(.category == "run")'
+scripts/tilt-logs cat | rg '"message":"run.finished"'
+```
+
+Physical device retrieval should use Apple `devicectl` or an open-source tool
+such as `idb` to pull `Library/Application Support/Diagnostics/Logs` from the
+app container.

--- a/project.yml
+++ b/project.yml
@@ -13,6 +13,11 @@ settings:
     IPHONEOS_DEPLOYMENT_TARGET: "18.0"
     TARGETED_DEVICE_FAMILY: "1"
 
+packages:
+  SwiftLog:
+    url: https://github.com/apple/swift-log
+    from: "1.6.0"
+
 targets:
   TiltArena:
     type: application
@@ -20,6 +25,9 @@ targets:
     deploymentTarget: "18.0"
     sources:
       - path: TiltArena
+    dependencies:
+      - package: SwiftLog
+        product: Logging
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -39,6 +47,8 @@ targets:
       - path: TiltArenaTests
     dependencies:
       - target: TiltArena
+      - package: SwiftLog
+        product: Logging
     settings:
       base:
         CODE_SIGN_STYLE: Automatic

--- a/scripts/tilt-logs
+++ b/scripts/tilt-logs
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUNDLE_ID="${BUNDLE_ID:-com.xlc.TiltArena}"
+SIMULATOR="${SIMULATOR:-booted}"
+
+usage() {
+  cat <<USAGE
+Usage: scripts/tilt-logs <command> [destination]
+
+Commands:
+  path             Print the simulator diagnostics log directory
+  list             List simulator JSONL log files
+  cat              Print all simulator JSONL log files
+  tail             Follow current.jsonl from the booted simulator
+  copy <dest-dir>  Copy simulator JSONL log files to dest-dir
+
+Environment:
+  BUNDLE_ID        Defaults to com.xlc.TiltArena
+  SIMULATOR        Defaults to booted
+USAGE
+}
+
+container_path() {
+  xcrun simctl get_app_container "$SIMULATOR" "$BUNDLE_ID" data
+}
+
+log_dir() {
+  printf '%s/Library/Application Support/Diagnostics/Logs\n' "$(container_path)"
+}
+
+jsonl_files() {
+  local directory
+  directory="$(log_dir)"
+  if [[ ! -d "$directory" ]]; then
+    return
+  fi
+  find "$directory" -maxdepth 1 -name '*.jsonl' -print | sort
+}
+
+command="${1:-}"
+case "$command" in
+  path)
+    log_dir
+    ;;
+  list)
+    jsonl_files
+    ;;
+  cat)
+    while IFS= read -r file; do
+      cat "$file"
+    done < <(jsonl_files)
+    ;;
+  tail)
+    tail -f "$(log_dir)/current.jsonl"
+    ;;
+  copy)
+    destination="${2:-}"
+    if [[ -z "$destination" ]]; then
+      usage >&2
+      exit 2
+    fi
+    mkdir -p "$destination"
+    while IFS= read -r file; do
+      cp "$file" "$destination/"
+    done < <(jsonl_files)
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `apple/swift-log` as the app logging API with multiplexed OSLog and app-owned JSONL sinks.
- Adds bounded JSONL log rotation, metadata sanitization, diagnostics bundle creation, and an Options > LOGS export flow.
- Adds sparse lifecycle, scene, input, run, pickup/weapon, profile reset, spawn debug, and debug performance sample events.
- Documents the backend evaluation and adds `scripts/tilt-logs` for CLI inspection of simulator logs.

Closes #72

## Validation

- `plutil -lint TiltArena/Resources/Info.plist`
- `git diff --check`
- `bash -n scripts/tilt-logs`
- `swiftlint lint --no-cache` (passes with existing warnings only)
- `xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- `xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id=AA706A81-B950-477D-8FAB-B8836EBD57E0' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test`
