### PR TITLE
Codify diagnostics logging practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,28 @@ Core loop:
   branch, switch back to `master`, and run `git pull`.
 - For GitHub issue and pull request workflow decisions, use the repo-local
   skill at `.agents/skills/github-issue-pr-workflow`.
+
+## Logging and Diagnostics
+
+- Use `AppDiagnostics.logger(_:)` and SwiftLog for app logging. Do not add
+  `print`, `debugPrint`, `NSLog`, ad hoc files, or another logging dependency.
+- Bootstrap logging once from app startup. Keep persistence behind SwiftLog
+  handlers so gameplay code only emits structured events.
+- Use stable dot-separated event names such as `run.started` or
+  `weapon.resolved`, not sentence text.
+- Choose levels deliberately: `debug` for high-volume local investigation,
+  `info` for routine state changes, `notice` for user-visible milestones,
+  `warning` for recoverable abnormal states, and `error` for failed operations.
+- Pass Swift errors through the SwiftLog `error:` parameter. Do not stringify
+  errors into a generic metadata key at call sites.
+- Keep metadata small, scalar, and bounded. Prefer modes, counts, durations,
+  coarse state names, and ephemeral run/session identifiers.
+- Never log secrets, tokens, email addresses, player names, vendor identifiers,
+  device names, precise device identifiers, or raw high-frequency movement data.
+- Throttle recurring diagnostics such as performance samples or spawn activity.
+  Per-frame JSONL logging is not acceptable.
+- JSONL logs must stay line-delimited, sorted-key, bounded by rotation, excluded
+  from backup, protected on device, and friendly to `rg`, `jq`, and
+  `scripts/tilt-logs`.
+- Logging and export failures must not affect gameplay. If logging persistence
+  fails, drop that diagnostic write rather than changing game behavior.

--- a/TiltArena/App/GameViewController.swift
+++ b/TiltArena/App/GameViewController.swift
@@ -164,9 +164,7 @@ extension GameViewController: ArenaSceneDiagnosticsDelegate {
             ])
             present(activityController, animated: true)
         } catch {
-            AppDiagnostics.logger(.app).error("diagnostics.export.failed", metadata: [
-                "error": "\(error)"
-            ])
+            AppDiagnostics.logger(.app).error("diagnostics.export.failed", error: error)
         }
     }
 }

--- a/TiltArena/Diagnostics/DiagnosticLogRecord.swift
+++ b/TiltArena/Diagnostics/DiagnosticLogRecord.swift
@@ -86,7 +86,8 @@ enum DiagnosticMetadataSanitizer {
     static func merged(
         base: Logger.Metadata,
         provider: Logger.MetadataProvider?,
-        explicit: Logger.Metadata?
+        explicit: Logger.Metadata?,
+        error: (any Error)? = nil
     ) -> Logger.Metadata {
         var merged = base
 
@@ -96,6 +97,11 @@ enum DiagnosticMetadataSanitizer {
 
         if let explicit {
             merged.merge(explicit, uniquingKeysWith: { _, explicit in explicit })
+        }
+
+        if let error {
+            merged["error.message"] = "\(error)"
+            merged["error.type"] = "\(String(reflecting: type(of: error)))"
         }
 
         return merged

--- a/TiltArena/Diagnostics/DiagnosticSwiftLogHandlers.swift
+++ b/TiltArena/Diagnostics/DiagnosticSwiftLogHandlers.swift
@@ -40,7 +40,8 @@ struct DiagnosticJSONLLogHandler: LogHandler {
             metadata: DiagnosticMetadataSanitizer.merged(
                 base: metadata,
                 provider: metadataProvider,
-                explicit: event.metadata
+                explicit: event.metadata,
+                error: event.error
             ),
             source: event.source,
             file: event.file,
@@ -73,7 +74,8 @@ struct DiagnosticOSLogHandler: LogHandler {
             DiagnosticMetadataSanitizer.merged(
                 base: metadata,
                 provider: metadataProvider,
-                explicit: event.metadata
+                explicit: event.metadata,
+                error: event.error
             )
         )
         let metadataText = metadata.isEmpty

--- a/TiltArenaTests/DiagnosticLogStoreTests.swift
+++ b/TiltArenaTests/DiagnosticLogStoreTests.swift
@@ -91,6 +91,37 @@ final class DiagnosticLogStoreTests: XCTestCase {
         XCTAssertEqual(metadata["mode"], "classic")
     }
 
+    func testJSONLHandlerIncludesSwiftLogErrorMetadata() throws {
+        let store = makeStore()
+        let handler = DiagnosticJSONLLogHandler(
+            label: "com.xlc.TiltArena.app",
+            store: store,
+            sessionID: "session-error",
+            dateProvider: { Date(timeIntervalSince1970: 1) }
+        )
+
+        handler.log(event: LogEvent(
+            level: .error,
+            message: "diagnostics.export.failed",
+            error: TestDiagnosticError(),
+            metadata: ["action": "export"],
+            source: "test",
+            file: "/tmp/GameViewController.swift",
+            function: "test()",
+            line: 7
+        ))
+
+        let contents = try String(contentsOf: store.currentLogFileURL, encoding: .utf8)
+        let line = try XCTUnwrap(contents.split(separator: "\n").first)
+        let record = try JSONDecoder().decode(DiagnosticLogRecord.self, from: Data(line.utf8))
+
+        XCTAssertEqual(record.level, "error")
+        XCTAssertEqual(record.message, "diagnostics.export.failed")
+        XCTAssertEqual(record.metadata["action"], "export")
+        XCTAssertEqual(record.metadata["error.message"], "test failure")
+        XCTAssertTrue(record.metadata["error.type"]?.contains("TestDiagnosticError") == true)
+    }
+
     func testExportBundleContainsMetadataReadmeAndCopiedLogs() throws {
         let store = makeStore()
         try store.append(record(message: "run.finished"))
@@ -167,5 +198,11 @@ final class DiagnosticLogStoreTests: XCTestCase {
             function: "record()",
             line: 1
         )
+    }
+}
+
+private struct TestDiagnosticError: Error, CustomStringConvertible {
+    var description: String {
+        "test failure"
     }
 }


### PR DESCRIPTION
## Summary
- Add AGENTS.md guidance for SwiftLog usage, metadata hygiene, privacy constraints, throttling, and JSONL export expectations.
- Route diagnostic export failures through SwiftLog’s `error:` parameter instead of ad hoc string metadata.
- Serialize `LogEvent.error` into structured bounded metadata for both JSONL and OSLog handlers, with regression coverage.

## Validation
- `git diff --check`
- `bash -n scripts/tilt-logs`
- `swiftlint lint --no-cache` (same 3 pre-existing warnings outside this slice)
- `xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- `xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id=AA706A81-B950-477D-8FAB-B8836EBD57E0' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test`

Closes #74