### PR TITLE
Tune diagnostics log volume

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -140,7 +140,7 @@ final class ArenaScene: SKScene {
         layoutPauseControl()
         layoutDebugStats()
         rebuildUI()
-        AppDiagnostics.logger(.scene).info("scene.resized", metadata: [
+        AppDiagnostics.logger(.scene).debug("scene.resized", metadata: [
             "width": "\(Int(size.width.rounded()))",
             "height": "\(Int(size.height.rounded()))"
         ])

--- a/TiltArenaTests/DiagnosticLogStoreTests.swift
+++ b/TiltArenaTests/DiagnosticLogStoreTests.swift
@@ -122,6 +122,31 @@ final class DiagnosticLogStoreTests: XCTestCase {
         XCTAssertTrue(record.metadata["error.type"]?.contains("TestDiagnosticError") == true)
     }
 
+    func testJSONLHandlerSkipsDebugEventsFromMultiplexedLogger() throws {
+        let store = makeStore()
+        let logger = Logger(label: "com.xlc.TiltArena.spawn") { label in
+            MultiplexLogHandler([
+                DebugOnlyTestLogHandler(),
+                DiagnosticJSONLLogHandler(
+                    label: label,
+                    store: store,
+                    sessionID: "session-volume",
+                    dateProvider: { Date(timeIntervalSince1970: 1) }
+                )
+            ])
+        }
+
+        logger.debug("spawn.enemies", metadata: ["count": "4"])
+        logger.info("pickup.spawned", metadata: ["kind": "shockwave"])
+
+        let contents = try String(contentsOf: store.currentLogFileURL, encoding: .utf8)
+        let records = try contents.split(separator: "\n").map { line in
+            try JSONDecoder().decode(DiagnosticLogRecord.self, from: Data(line.utf8))
+        }
+
+        XCTAssertEqual(records.map(\.message), ["pickup.spawned"])
+    }
+
     func testExportBundleContainsMetadataReadmeAndCopiedLogs() throws {
         let store = makeStore()
         try store.append(record(message: "run.finished"))
@@ -205,4 +230,17 @@ private struct TestDiagnosticError: Error, CustomStringConvertible {
     var description: String {
         "test failure"
     }
+}
+
+private struct DebugOnlyTestLogHandler: LogHandler {
+    var metadata: Logger.Metadata = [:]
+    var metadataProvider: Logger.MetadataProvider?
+    var logLevel: Logger.Level = .debug
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: LogEvent) {}
 }


### PR DESCRIPTION
## Summary
- Move `scene.resized` from saved JSONL info logging to debug-only logging so layout churn stays out of exported diagnostics.
- Add coverage for the intended multiplexed logging volume boundary: debug events can flow through a debug backend while JSONL persists only info-and-above events.

## Validation
- `git diff --check master...HEAD`
- `bash -n scripts/tilt-logs`
- `swiftlint lint --no-cache` (same 3 pre-existing warnings outside this slice)
- `xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- `xcodebuild -quiet -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id=AA706A81-B950-477D-8FAB-B8836EBD57E0' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test`

Closes #76