### PR TITLE
Add hardware keyboard movement input

### DIFF
--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -33,6 +33,7 @@ final class ArenaScene: SKScene {
     private var arenaRoot = SKNode()
     private let uiRoot = SKNode()
     private lazy var tiltInputController = TiltInputController(settingsStore: tiltSettingsStore)
+    private let keyboardInputController = KeyboardInputController()
     var movementController = PlayerMovementController()
     private var runController = ClassicRunController()
     private var runProfile = RunProfile()
@@ -441,7 +442,7 @@ final class ArenaScene: SKScene {
     }
 
     private func updatePreRun(deltaTime: TimeInterval) {
-        let input = tiltInputController.update(deltaTime: deltaTime, orientation: currentTiltScreenOrientation)
+        let input = movementInput(deltaTime: deltaTime)
         let state = movementController.update(input: input, deltaTime: deltaTime, arenaBounds: currentGameplayBounds)
         applyPlayerState(state, resetTrail: false)
 
@@ -462,7 +463,7 @@ final class ArenaScene: SKScene {
             return
         }
 
-        let input = tiltInputController.update(deltaTime: deltaTime, orientation: currentTiltScreenOrientation)
+        let input = movementInput(deltaTime: deltaTime)
         warpDashState.record(input: input)
         let state = movementController.update(input: input, deltaTime: deltaTime, arenaBounds: currentGameplayBounds)
         applyPlayerState(state, resetTrail: false)
@@ -470,7 +471,7 @@ final class ArenaScene: SKScene {
     }
 
     private func updateCalibrationPreview(deltaTime: TimeInterval) {
-        let input = tiltInputController.update(deltaTime: deltaTime, orientation: currentTiltScreenOrientation)
+        let input = movementInput(deltaTime: deltaTime)
         let state = calibrationPreviewMovementController.update(
             input: input,
             deltaTime: deltaTime,
@@ -479,6 +480,16 @@ final class ArenaScene: SKScene {
 
         applyCalibrationPreviewState(state, resetTrail: false)
         updateTiltReadoutDisplay(deltaTime: deltaTime)
+    }
+
+    private func movementInput(deltaTime: TimeInterval) -> CGVector {
+        let tiltInput = tiltInputController.update(
+            deltaTime: deltaTime,
+            orientation: currentTiltScreenOrientation
+        )
+        let keyboardInput = keyboardInputController.movementInput()
+
+        return keyboardInput.isActive ? keyboardInput.vector : tiltInput
     }
 
     private func enterCalibrationPreview() {

--- a/TiltArena/Game/Input/KeyboardInputController.swift
+++ b/TiltArena/Game/Input/KeyboardInputController.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+import GameController
+
+struct KeyboardMovementInput: Equatable {
+    var left = false
+    var right = false
+    var upward = false
+    var downward = false
+
+    var isActive: Bool {
+        left || right || upward || downward
+    }
+
+    var vector: CGVector {
+        let horizontal = (right ? 1 : 0) - (left ? 1 : 0)
+        let vertical = (upward ? 1 : 0) - (downward ? 1 : 0)
+
+        return CGVector(
+            dx: CGFloat(horizontal),
+            dy: CGFloat(vertical)
+        ).clamped(toMaximumLength: 1)
+    }
+}
+
+@MainActor
+final class KeyboardInputController {
+    func movementInput() -> KeyboardMovementInput {
+        guard let keyboardInput = GCKeyboard.coalesced?.keyboardInput else {
+            return KeyboardMovementInput()
+        }
+
+        return KeyboardMovementInput(
+            left: isPressed([.leftArrow, .keyA], in: keyboardInput),
+            right: isPressed([.rightArrow, .keyD], in: keyboardInput),
+            upward: isPressed([.upArrow, .keyW], in: keyboardInput),
+            downward: isPressed([.downArrow, .keyS], in: keyboardInput)
+        )
+    }
+
+    private func isPressed(_ keyCodes: [GCKeyCode], in keyboardInput: GCKeyboardInput) -> Bool {
+        keyCodes.contains { keyCode in
+            keyboardInput.button(forKeyCode: keyCode)?.isPressed == true
+        }
+    }
+}

--- a/TiltArenaTests/KeyboardInputControllerTests.swift
+++ b/TiltArenaTests/KeyboardInputControllerTests.swift
@@ -1,0 +1,36 @@
+import CoreGraphics
+import XCTest
+@testable import TiltArena
+
+final class KeyboardInputControllerTests: XCTestCase {
+    func testNoPressedMovementKeysIsInactiveWithZeroVector() {
+        let input = KeyboardMovementInput()
+
+        XCTAssertFalse(input.isActive)
+        XCTAssertEqual(input.vector.dx, 0, accuracy: 0.0001)
+        XCTAssertEqual(input.vector.dy, 0, accuracy: 0.0001)
+    }
+
+    func testCardinalDirectionsMapToMovementVector() {
+        XCTAssertEqual(KeyboardMovementInput(left: true).vector, CGVector(dx: -1, dy: 0))
+        XCTAssertEqual(KeyboardMovementInput(right: true).vector, CGVector(dx: 1, dy: 0))
+        XCTAssertEqual(KeyboardMovementInput(upward: true).vector, CGVector(dx: 0, dy: 1))
+        XCTAssertEqual(KeyboardMovementInput(downward: true).vector, CGVector(dx: 0, dy: -1))
+    }
+
+    func testDiagonalMovementIsNormalized() {
+        let vector = KeyboardMovementInput(right: true, upward: true).vector
+
+        XCTAssertEqual(vector.length, 1, accuracy: 0.0001)
+        XCTAssertEqual(vector.dx, 0.7071, accuracy: 0.0001)
+        XCTAssertEqual(vector.dy, 0.7071, accuracy: 0.0001)
+    }
+
+    func testOpposingDirectionsCancelWhileInputRemainsActive() {
+        let input = KeyboardMovementInput(left: true, right: true)
+
+        XCTAssertTrue(input.isActive)
+        XCTAssertEqual(input.vector.dx, 0, accuracy: 0.0001)
+        XCTAssertEqual(input.vector.dy, 0, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a GameController-backed keyboard movement input path for arrows and WASD.
- Feed keyboard movement through the same normalized CGVector path as tilt in pre-run, active gameplay, and calibration preview.
- Add focused tests for inactive, cardinal, diagonal, and opposing keyboard movement vectors.

## Validation
- xcodegen generate
- plutil -lint TiltArena/Resources/Info.plist
- git diff --check
- swiftlint lint --no-cache (passes with 3 pre-existing warnings outside this change)
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id=7211F793-06FA-4695-B8CD-6E6A600CFCAE,arch=arm64' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test

Closes #80