### PR TITLE
Fix review issues in diagnostics and options

### DIFF
--- a/TiltArena/Diagnostics/DiagnosticExport.swift
+++ b/TiltArena/Diagnostics/DiagnosticExport.swift
@@ -13,9 +13,7 @@ struct DiagnosticGameplaySnapshot: Codable, Equatable {
 }
 
 struct DiagnosticLocalOptionsSnapshot: Codable, Equatable {
-    let audioEnabled: Bool
     let hapticsEnabled: Bool
-    let reducedEffects: Bool
     let theme: String
 }
 

--- a/TiltArena/Diagnostics/DiagnosticLogStore.swift
+++ b/TiltArena/Diagnostics/DiagnosticLogStore.swift
@@ -43,9 +43,8 @@ final class DiagnosticLogStore: @unchecked Sendable {
     }
 
     func append(_ record: DiagnosticLogRecord) throws {
-        let data = try encodedLine(for: record)
-
         try lock.withLock {
+            let data = try encodedLine(for: record)
             try prepareDirectoryLocked()
             if try shouldRotateCurrentLogLocked(appendingByteCount: data.count) {
                 try rotateCurrentLogLocked()

--- a/TiltArena/Game/ArenaScene.swift
+++ b/TiltArena/Game/ArenaScene.swift
@@ -1688,26 +1688,14 @@ private extension ArenaScene {
 
     func renderLocalOptions(in frame: CGRect) {
         addToggle(
-            title: "AUDIO",
-            isOn: localOptions.audioEnabled,
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 54, width: 132, height: 34),
-            action: .toggleAudio
-        )
-        addToggle(
             title: "HAPTICS",
             isOn: localOptions.hapticsEnabled,
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 96, width: 132, height: 34),
+            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 54, width: 132, height: 34),
             action: .toggleHaptics
-        )
-        addToggle(
-            title: "EFFECTS",
-            isOn: !localOptions.reducedEffects,
-            frame: CGRect(x: frame.minX + 14, y: frame.maxY - 138, width: 132, height: 34),
-            action: .toggleEffects
         )
         addButton(
             "LOGS",
-            frame: CGRect(x: frame.maxX - 104, y: frame.maxY - 138, width: 90, height: 34),
+            frame: CGRect(x: frame.maxX - 104, y: frame.maxY - 54, width: 90, height: 34),
             action: .exportDiagnostics,
             style: .secondary
         )
@@ -1895,8 +1883,7 @@ private extension ArenaScene {
             performRunControlAction(action)
         case .exportDiagnostics:
             exportDiagnostics()
-        case .sensitivityDown, .sensitivityUp, .preset, .toggleAudio, .toggleHaptics, .toggleEffects, .selectTheme,
-                .resetData:
+        case .sensitivityDown, .sensitivityUp, .preset, .toggleHaptics, .selectTheme, .resetData:
             performOptionsAction(action)
         }
     }
@@ -1963,7 +1950,7 @@ private extension ArenaScene {
                 resetCalibrationPreviewPosition()
             }
             rebuildUI()
-        case .toggleAudio, .toggleHaptics, .toggleEffects:
+        case .toggleHaptics:
             performLocalOptionToggle(action)
         case .selectTheme, .resetData:
             performLocalDataAction(action)
@@ -1974,18 +1961,10 @@ private extension ArenaScene {
 
     func performLocalOptionToggle(_ action: ArenaControlAction) {
         switch action {
-        case .toggleAudio:
-            localOptions.audioEnabled.toggle()
-            localOptionsStore.options = localOptions
-            rebuildUI()
         case .toggleHaptics:
             localOptions.hapticsEnabled.toggle()
             localOptionsStore.options = localOptions
             syncHapticsOption()
-            rebuildUI()
-        case .toggleEffects:
-            localOptions.reducedEffects.toggle()
-            localOptionsStore.options = localOptions
             rebuildUI()
         default:
             break
@@ -2097,9 +2076,7 @@ private extension ArenaScene {
             enemyCount: enemies.count,
             pickupCount: pickups.count,
             localOptions: DiagnosticLocalOptionsSnapshot(
-                audioEnabled: localOptions.audioEnabled,
                 hapticsEnabled: localOptions.hapticsEnabled,
-                reducedEffects: localOptions.reducedEffects,
                 theme: localOptions.themeKind.rawValue
             ),
             profile: DiagnosticProfileSnapshot(
@@ -2583,9 +2560,7 @@ private enum ArenaControlAction: Equatable {
     case sensitivityDown
     case sensitivityUp
     case preset(TiltCalibrationPreset)
-    case toggleAudio
     case toggleHaptics
-    case toggleEffects
     case selectTheme(ArenaThemeKind)
     case resetData
     case exportDiagnostics

--- a/TiltArena/Game/UI/ArenaLocalOptionsStore.swift
+++ b/TiltArena/Game/UI/ArenaLocalOptionsStore.swift
@@ -1,37 +1,27 @@
 import Foundation
 
 struct ArenaLocalOptions: Codable, Equatable {
-    var audioEnabled = true
     var hapticsEnabled = true
-    var reducedEffects = false
     var themeKind: ArenaThemeKind = .darkTacticalRadar
 
     static let defaults = ArenaLocalOptions()
 
     init(
-        audioEnabled: Bool = true,
         hapticsEnabled: Bool = true,
-        reducedEffects: Bool = false,
         themeKind: ArenaThemeKind = .darkTacticalRadar
     ) {
-        self.audioEnabled = audioEnabled
         self.hapticsEnabled = hapticsEnabled
-        self.reducedEffects = reducedEffects
         self.themeKind = themeKind
     }
 
     private enum CodingKeys: String, CodingKey {
-        case audioEnabled
         case hapticsEnabled
-        case reducedEffects
         case themeKind
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        audioEnabled = try container.decodeIfPresent(Bool.self, forKey: .audioEnabled) ?? true
         hapticsEnabled = try container.decodeIfPresent(Bool.self, forKey: .hapticsEnabled) ?? true
-        reducedEffects = try container.decodeIfPresent(Bool.self, forKey: .reducedEffects) ?? false
         themeKind = (try? container.decode(ArenaThemeKind.self, forKey: .themeKind)) ?? .darkTacticalRadar
     }
 }

--- a/TiltArenaTests/ArenaLocalOptionsStoreTests.swift
+++ b/TiltArenaTests/ArenaLocalOptionsStoreTests.swift
@@ -24,18 +24,14 @@ final class ArenaLocalOptionsStoreTests: XCTestCase {
     func testOptionsPersistAndReset() {
         let store = ArenaLocalOptionsStore(defaults: defaults)
         store.options = ArenaLocalOptions(
-            audioEnabled: false,
             hapticsEnabled: false,
-            reducedEffects: true,
             themeKind: .whitePrecisionBoard
         )
 
         XCTAssertEqual(
             ArenaLocalOptionsStore(defaults: defaults).options,
             ArenaLocalOptions(
-                audioEnabled: false,
                 hapticsEnabled: false,
-                reducedEffects: true,
                 themeKind: .whitePrecisionBoard
             )
         )
@@ -58,9 +54,7 @@ final class ArenaLocalOptionsStoreTests: XCTestCase {
         XCTAssertEqual(
             ArenaLocalOptionsStore(defaults: defaults).options,
             ArenaLocalOptions(
-                audioEnabled: false,
                 hapticsEnabled: true,
-                reducedEffects: true,
                 themeKind: .darkTacticalRadar
             )
         )
@@ -80,9 +74,7 @@ final class ArenaLocalOptionsStoreTests: XCTestCase {
         XCTAssertEqual(
             ArenaLocalOptionsStore(defaults: defaults).options,
             ArenaLocalOptions(
-                audioEnabled: false,
                 hapticsEnabled: false,
-                reducedEffects: true,
                 themeKind: .darkTacticalRadar
             )
         )

--- a/TiltArenaTests/DiagnosticLogStoreTests.swift
+++ b/TiltArenaTests/DiagnosticLogStoreTests.swift
@@ -79,6 +79,43 @@ final class DiagnosticLogStoreTests: XCTestCase {
         XCTAssertTrue(logFiles.contains(store.currentLogFileURL))
     }
 
+    func testConcurrentAppendsProduceCompleteLineDelimitedRecords() throws {
+        let store = makeStore(configuration: DiagnosticLogStore.Configuration(
+            maxCurrentFileBytes: 128 * 1_024,
+            maxArchivedFileCount: 0,
+            maxTotalBytes: 256 * 1_024
+        ))
+        let records = (0..<80).map { index in
+            record(message: "event.\(index)")
+        }
+        let queue = DispatchQueue(label: "DiagnosticLogStoreTests.concurrent", attributes: .concurrent)
+        let group = DispatchGroup()
+        let errors = ConcurrentErrorRecorder()
+
+        for record in records {
+            group.enter()
+            queue.async {
+                defer { group.leave() }
+                do {
+                    try store.append(record)
+                } catch {
+                    errors.record(error)
+                }
+            }
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 5), .success)
+        XCTAssertTrue(errors.isEmpty)
+
+        let contents = try String(contentsOf: store.currentLogFileURL, encoding: .utf8)
+        let lines = contents.split(separator: "\n")
+        XCTAssertEqual(lines.count, records.count)
+
+        for line in lines {
+            XCTAssertNoThrow(try JSONDecoder().decode(DiagnosticLogRecord.self, from: Data(line.utf8)))
+        }
+    }
+
     func testMetadataSanitizerRedactsSensitiveKeys() {
         let metadata = DiagnosticMetadataSanitizer.sanitized([
             "token": "secret-token",
@@ -167,5 +204,30 @@ final class DiagnosticLogStoreTests: XCTestCase {
             function: "record()",
             line: 1
         )
+    }
+}
+
+private extension NSLock {
+    func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}
+
+private final class ConcurrentErrorRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [any Error] = []
+
+    var isEmpty: Bool {
+        lock.withLock {
+            errors.isEmpty
+        }
+    }
+
+    func record(_ error: any Error) {
+        lock.withLock {
+            errors.append(error)
+        }
     }
 }


### PR DESCRIPTION
Closes #82

Summary:
- Serialize diagnostic JSONL encoding under the DiagnosticLogStore lock.
- Remove no-op local AUDIO/EFFECTS options from UI, persistence, and diagnostic exports.
- Add focused regression coverage for concurrent log appends and local options decoding.

Validation:
- xcodegen generate
- plutil -lint TiltArena/Resources/Info.plist
- git diff --check
- swiftlint lint --no-cache (passes with 3 existing warnings)
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -destination generic/platform=iOS Simulator -derivedDataPath build/DerivedData build-for-testing
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -destination platform=iOS Simulator,id=AA706A81-B950-477D-8FAB-B8836EBD57E0 -derivedDataPath build/DerivedData -only-testing:TiltArenaTests/DiagnosticLogStoreTests test
- xcodebuild -project TiltArena.xcodeproj -scheme TiltArena -destination platform=iOS Simulator,id=AA706A81-B950-477D-8FAB-B8836EBD57E0 -derivedDataPath build/DerivedData -only-testing:TiltArenaTests/ArenaLocalOptionsStoreTests test